### PR TITLE
test(autobuilder): make the level-245 CP-SAT solver test deterministic

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -232,9 +232,31 @@ object WakfuBuildSolver {
         return result
     }
 
+    /**
+     * Test-only knobs to make a solve bit-for-bit reproducible. Production never passes this — the
+     * default `null` keeps the real search (wall-clock budget, a worker per core, no fixed seed),
+     * which is fast but intentionally non-deterministic. A test that drives that real search can stop
+     * at a *sub-optimal feasible* build on a slow/loaded CI runner (the AP/MP/range/crit targets are
+     * objective penalties, not hard constraints, so a poor feasible solution can violate them). With
+     * a tuning, CP-SAT instead runs a fixed worker count + fixed seed + a **deterministic-time**
+     * budget — work-unit based, not wall-clock — so it returns the *same proven optimum* on any
+     * machine, however slow or loaded.
+     */
+    internal data class SolverTuning(
+        val numSearchWorkers: Int = 8,
+        val randomSeed: Int = 1,
+        val maxDeterministicTime: Double = 60.0,
+    )
+
     fun optimize(
         params: WakfuBestBuildParams,
         equipmentsByItemType: Map<ItemType, List<Equipment>>,
+    ): Flow<GeneticAlgorithmResult<BuildCombination>> = optimize(params, equipmentsByItemType, tuning = null)
+
+    internal fun optimize(
+        params: WakfuBestBuildParams,
+        equipmentsByItemType: Map<ItemType, List<Equipment>>,
+        tuning: SolverTuning?,
     ): Flow<GeneticAlgorithmResult<BuildCombination>> =
         callbackFlow {
             withContext(Dispatchers.IO) {
@@ -265,7 +287,7 @@ object WakfuBuildSolver {
                     }
                 model.maximize(objective)
 
-                executeSolverAndEmitResults(model, params, allEquips, equipVars, skillVars, this@callbackFlow)
+                executeSolverAndEmitResults(model, params, allEquips, equipVars, skillVars, this@callbackFlow, tuning)
             }
             close()
             awaitClose { }
@@ -468,15 +490,28 @@ object WakfuBuildSolver {
         equipVars: Map<Equipment, IntVar>,
         skillVars: Map<SkillCharacteristic, IntVar>,
         scope: ProducerScope<GeneticAlgorithmResult<BuildCombination>>,
+        tuning: SolverTuning?,
     ) {
         val solver = CpSolver()
-        solver.parameters.maxTimeInSeconds = params.searchDuration.inWholeSeconds.toDouble()
         solver.parameters.logSearchProgress = false
-        // Run a parallel portfolio across all cores (CP-SAT's equivalent of the GA's parallel
-        // scoring). Presolve is capped because full presolve on this objective never terminates in
-        // the time budget; the prefiltered (small) model keeps even a light presolve effective.
-        solver.parameters.numSearchWorkers = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
-        solver.parameters.maxPresolveIterations = 1
+        if (tuning == null) {
+            // Production: a parallel portfolio across all cores (CP-SAT's equivalent of the GA's
+            // parallel scoring), bounded by the user's wall-clock search duration. Presolve is capped
+            // because full presolve on this objective never terminates within that budget; the
+            // prefiltered (small) model keeps even a light presolve effective.
+            solver.parameters.maxPresolveIterations = 1
+            solver.parameters.maxTimeInSeconds = params.searchDuration.inWholeSeconds.toDouble()
+            solver.parameters.numSearchWorkers = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+        } else {
+            // Deterministic, machine-independent solve for tests — see [SolverTuning]. A fixed worker
+            // count + seed + a deterministic-time budget (not wall-clock) make CP-SAT reach the same
+            // proven optimum on every machine, removing the flakiness of a wall-clock-bounded search.
+            // Presolve runs in full here (tests only ever solve the small, prefiltered model) so the
+            // optimality proof finishes quickly.
+            solver.parameters.numSearchWorkers = tuning.numSearchWorkers
+            solver.parameters.randomSeed = tuning.randomSeed
+            solver.parameters.maxDeterministicTime = tuning.maxDeterministicTime
+        }
 
         val startTime = System.currentTimeMillis()
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -288,10 +288,26 @@ class WakfuBuildSolverTest {
                             it.itemType == ItemType.MOUNTS
                     }.groupBy { it.itemType }
 
-            val lpBest = WakfuBuildSolver.optimize(params, equipmentsByItemType).toList().maxByOrNull { it.matchPercentage }!!
+            // Deterministic, machine-independent solve (fixed worker + seed + deterministic-time
+            // budget): the search reaches the *same proven optimum* on every machine. This is what
+            // de-flakes the test — under the real wall-clock search a slow/loaded CI runner could stop
+            // early on a sub-optimal feasible build that violated the assertions below.
+            val results =
+                WakfuBuildSolver
+                    .optimize(params, equipmentsByItemType, WakfuBuildSolver.SolverTuning())
+                    .toList()
+
+            // Optimality must actually be *proven* within the deterministic-time budget — that proof
+            // is what keeps every assertion below stable. A failure here is a loud, reproducible
+            // "budget too small" signal, never a flake.
+            val lpBest =
+                results.lastOrNull { it.isOptimal }
+            assertThat(lpBest)
+                .describedAs("solver must prove optimality within the deterministic-time budget")
+                .isNotNull
 
             // A real, valid, non-trivial build — not an empty no-op that could pass a bare ">= GA".
-            assertThat(lpBest.individual.isValid()).isTrue()
+            assertThat(lpBest!!.individual.isValid()).isTrue()
             assertThat(lpBest.individual.equipments.size).isGreaterThanOrEqualTo(10)
 
             // Correctness on real data: every required hard constraint (AP/MP/range/crit) is actually met.


### PR DESCRIPTION
## Problem

The `lp solver finds a valid feasible build on the level 245 dataset` test fails **randomly on CI**, which blocks the build job (and anything gated on it, e.g. deploy).

## Root cause

The test drives the **production** solver path `WakfuBuildSolver.optimize()`, which is intentionally non-deterministic:

- `maxTimeInSeconds` → **wall-clock** stop
- `numSearchWorkers = availableProcessors()` → parallel portfolio (worker count depends on the machine)
- no fixed `randomSeed`

On a fast machine 15s is far more than enough to **prove the optimum**, so it always passes locally. On a slow/loaded CI runner (shared cores + the one-time OR-Tools native cold start eating into the budget) the search can stop on a **sub-optimal feasible** build. In most-masteries mode the AP/MP/range/crit targets are **objective penalties, not hard constraints**, so that poorer build can violate the test's assertions (`>= 10` items, required constraints met, `>= GA` baseline) — random red.

## Fix

Make **this test** deterministic and machine-independent, **without changing production behaviour**:

- Add an `internal` `SolverTuning` seam to `WakfuBuildSolver.optimize`. The public 2-arg overload delegates with `tuning = null`, so production keeps the exact same wall-clock / all-cores / unseeded search.
- With a tuning, CP-SAT runs a **fixed worker count + fixed seed + a deterministic-time budget** (`maxDeterministicTime`, work-unit based, not wall-clock) → it returns the **same proven optimum on every machine**, however slow or loaded.
- The test passes that tuning and asserts the result `isOptimal`. A failure there is now a loud, reproducible "budget too small" signal, never a flake.

The cold start no longer affects correctness either: deterministic time counts work, not seconds.

## Verification

- `score` / `size` / `isOptimal` **identical across repeated runs** (`5770` / `14` / `true`).
- `:autobuilder:test` green — solver suite 14/14, module 20/20.
- `ktlintCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
