### PR TITLE
feat(engine): overshoot tie-breaker spends idle skill points (re #126)

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -43,6 +43,13 @@ object WakfuBuildSolver {
     private const val MAX_POWER_TABLE_INDEX = 2_000
     private const val MAX_PENALTY_MULTIPLIER = 1_000_000L
 
+    // Lexicographic scale for the "most masteries" overshoot tie-breaker. The primary objective tops
+    // out at MASTERY_SCORE_ABS_MAX * MAX_PENALTY_MULTIPLIER = 1e14; multiplying it by this scale and
+    // adding a bonus in [0, OVERSHOOT_SCALE) keeps the combined objective (~1e18) well under
+    // Long.MAX/2 (~4.6e18) while guaranteeing one unit of primary always beats any overshoot bonus.
+    // See [withOvershootTieBreaker].
+    private const val OVERSHOOT_SCALE = 10_000L
+
     // The GA scorers weight each target by a Double = (100 / target) * userDefinedWeight, which is
     // almost always < 1 for high targets (e.g. HP target 2000 -> 0.05). Truncating that to Long with
     // .toLong() collapsed those weights to 0, silently dropping HP and any target > 100 from the
@@ -444,10 +451,52 @@ object WakfuBuildSolver {
 
         val maxObjective = safeMultiply(MASTERY_SCORE_ABS_MAX, powerTable.maxValue)
         val objectiveBound = maxObjective.coerceAtMost(Long.MAX_VALUE / 2)
-        val objective = newIntVar(-objectiveBound, objectiveBound, "objectiveScore")
-        addMultiplicationEquality(objective, masteryScore, multiplier)
+        val primaryObjective = newIntVar(-objectiveBound, objectiveBound, "objectiveScore")
+        addMultiplicationEquality(primaryObjective, masteryScore, multiplier)
 
-        return objective
+        // Lexicographic tie-breaker: among builds the primary objective ranks equally, prefer the one
+        // that exceeds the required targets the most (weighted by the same per-constraint priorities).
+        // This is what makes the solver spend otherwise objective-neutral skill points into HP/CC%
+        // (and, among ties, pick gear that overshoots) instead of leaving them unused — free in-game
+        // value the player would always take. It can never trade a maximized-mastery point for
+        // overshoot; see [withOvershootTieBreaker].
+        val overshoot = statBuilder.overshootScore(requiredTargets, totalExpectedScore, targetStats)
+        return withOvershootTieBreaker(primaryObjective, objectiveBound, overshoot, totalExpectedScore)
+    }
+
+    /**
+     * Folds a lexicographic overshoot tie-breaker under [primaryObjective], returning
+     * `primaryObjective * OVERSHOOT_SCALE + bonus` where `bonus ∈ [0, OVERSHOOT_SCALE)` is the
+     * weighted overshoot normalised into that range. Because `bonus < OVERSHOOT_SCALE`, even a
+     * one-unit improvement in the (integer) primary objective — worth `OVERSHOOT_SCALE` after scaling
+     * — always dominates any overshoot gain. So this never sacrifices a maximized-mastery point for
+     * overshoot; it only ranks builds the primary objective already considers tied. [totalExpectedScore]
+     * (≥ 1) is the same denominator the penalty uses, so the bonus is proportional to how far the
+     * build exceeds its targets relative to what was asked.
+     */
+    private fun CpModel.withOvershootTieBreaker(
+        primaryObjective: IntVar,
+        primaryBound: Long,
+        rawOvershoot: IntVar,
+        totalExpectedScore: Long,
+    ): IntVar {
+        val scaledRaw = newIntVar(0, safeMultiply(totalExpectedScore, OVERSHOOT_SCALE - 1), "overshootScaled")
+        addEquality(scaledRaw, LinearExpr.term(rawOvershoot, OVERSHOOT_SCALE - 1))
+
+        val bonus = newIntVar(0, OVERSHOOT_SCALE - 1, "overshootBonus")
+        addDivisionEquality(bonus, scaledRaw, newConstant(totalExpectedScore))
+
+        val combinedBound = safeMultiply(primaryBound, OVERSHOOT_SCALE) + OVERSHOOT_SCALE
+        val combined = newIntVar(-combinedBound, combinedBound, "objectiveWithOvershoot")
+        addEquality(
+            combined,
+            LinearExpr
+                .newBuilder()
+                .addTerm(primaryObjective, OVERSHOOT_SCALE)
+                .addTerm(bonus, 1)
+                .build()
+        )
+        return combined
     }
 
     private fun CpModel.buildPrecisionObjective(
@@ -629,6 +678,49 @@ object WakfuBuildSolver {
                 }
 
             return model.sumVar("totalActualScore", contributions, -totalExpectedScore, totalExpectedScore)
+        }
+
+        /**
+         * Weighted amount by which a build *exceeds* its required targets — the raw input to the
+         * lexicographic overshoot tie-breaker (see [WakfuBuildSolver.withOvershootTieBreaker]). Mirrors
+         * [totalActualScore] (same `requiredActualStat` values, same per-constraint weights), but scores
+         * `weight * clamp(actual - target, 0, target)`: only the part above the target, and capped at
+         * one extra target's worth so the whole sum stays ≤ [totalExpectedScore] and no single stat can
+         * dominate. The shared weights mean leftover skill points flow to the highest-priority stat
+         * exactly like the constraints themselves decide, with no separate distribution policy to encode.
+         */
+        fun overshootScore(
+            requiredTargets: List<TargetStat>,
+            totalExpectedScore: Long,
+            targetStats: TargetStats,
+        ): IntVar {
+            val contributions =
+                requiredTargets.map { targetStat ->
+                    val actual = requiredActualStat(targetStat.characteristic)
+                    val weight = targetStats.scaledWeight(targetStat)
+                    val target = targetStat.target.toLong().coerceAtLeast(0)
+                    val name = targetStat.characteristic.name
+
+                    val excess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, STAT_WITH_PERCENT_ABS_MAX, "excess_$name")
+                    model.addEquality(
+                        excess,
+                        LinearExpr
+                            .newBuilder()
+                            .addTerm(actual, 1)
+                            .add(-target)
+                            .build()
+                    )
+                    val cappedExcess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, target, "excessCap_$name")
+                    model.addMinEquality(cappedExcess, arrayOf(excess, model.newConstant(target)))
+                    val positiveExcess = model.newIntVar(0, target, "excessPos_$name")
+                    model.addMaxEquality(positiveExcess, arrayOf(cappedExcess, model.newConstant(0L)))
+
+                    val contribution = model.newIntVar(0, target * weight, "overshoot_$name")
+                    model.addEquality(contribution, LinearExpr.term(positiveExcess, weight))
+                    contribution
+                }
+
+            return model.sumVar("overshootScore", contributions, 0, totalExpectedScore)
         }
 
         /**

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -356,6 +356,56 @@ class WakfuBuildSolverTest {
     }
 
     @Test
+    fun `most-masteries spends an objective-neutral skill point to overshoot a required target`(): Unit =
+        runBlocking {
+            // Issue #126: once HP is fully covered by gear, extra HP from skills is worth 0 to the
+            // maximized masteries, so the solver used to leave those points unassigned. The lexicographic
+            // overshoot tie-breaker now spends them — free in-game value — WITHOUT changing the (mastery)
+            // score. A level-1 CRA has a single Intelligence point whose only scored lever is % HP, and
+            // the HP target is met by gear alone, so assigning it is a pure overshoot gain.
+            val level = 1
+            val characterSkills = CharacterSkills(level)
+            val character = Character(clazz = CharacterClass.CRA, level = level, minLevel = level, characterSkills)
+            val equipments =
+                listOf(
+                    equipment(1, ItemType.AMULET, "HpAmulet", mapOf(Characteristic.HP to 200, Characteristic.MASTERY_MELEE to 10)),
+                    equipment(2, ItemType.AMULET, "DmgAmulet", mapOf(Characteristic.MASTERY_MELEE to 100)),
+                    equipment(3, ItemType.BELT, "Belt", mapOf(Characteristic.MASTERY_MELEE to 40))
+                )
+            val targetStats = TargetStats(listOf(TargetStat(Characteristic.HP, 200), TargetStat(Characteristic.MASTERY_MELEE, 1)))
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = targetStats,
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+
+            // Deterministic solve so the *proven* optimum (carrying the tie-breaker's allocation) is emitted.
+            val optimal =
+                WakfuBuildSolver
+                    .optimize(params, equipments.groupBy { it.itemType }, WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .last { it.isOptimal }
+
+            // The mastery score is still exactly the exhaustive (unskilled) optimum — overshoot never inflates it.
+            val exhaustiveScore =
+                allValidCombinations(equipments, characterSkills)
+                    .maxOf { FindMostMasteriesFromInputScoring.computeScore(targetStats, it, character.baseCharacteristicValues) }
+            assertThat(optimal.matchPercentage).isEqualByComparingTo(exhaustiveScore)
+            assertThat(optimal.individual.equipments.map { it.name.fr }).containsExactlyInAnyOrder("HpAmulet", "Belt")
+
+            // ...but the otherwise-idle Intelligence point is now spent overshooting HP (was 0 before #126).
+            assertThat(optimal.individual.characterSkills.intelligence.hpPercentage.pointsAssigned)
+                .describedAs("objective-neutral Intelligence point should be spent overshooting HP")
+                .isGreaterThan(0)
+        }
+
+    @Test
     fun `precision solver hits exact AP and mastery targets`() {
         val equipments =
             listOf(


### PR DESCRIPTION
## What

In **most-masteries** mode, once a required target (HP, CC%, AP, …) is met by gear, extra points toward it are worth **0** to the maximized masteries — so the solver left otherwise-neutral skill points **unassigned** (the symptom reported in #126).

This adds a **lexicographic overshoot tie-breaker**: among builds the primary objective ranks equally, prefer the one that exceeds the required targets the most, weighted by the **same per-constraint priorities as #123**.

## How

- `StatBuilder.overshootScore` = `Σ scaledWeight · clamp(actual − target, 0, target)` — reuses the existing weights, so leftover points flow to the highest-priority stat with **no separate distribution policy to encode**.
- `withOvershootTieBreaker`: `objective = primary · OVERSHOOT_SCALE + bonus`, `bonus ∈ [0, OVERSHOOT_SCALE)`. One unit of primary (≥ `OVERSHOOT_SCALE` after scaling) always dominates → **never trades a maximized-mastery point for overshoot**. Combined objective ~1e18 < `Long.MAX/2`. Mirrors `precisionScore`'s `fullyMet`/`bonus`.

## Scope (honest)

This fixes the **"idle skill points"** symptom, not the deeper ask in #126 (preferring **CC% over a maximized mastery** like Back) — a tie-breaker is mathematically below the primary, so it cannot change the mastery outcome. That case needs a **max-damage objective mode** (the damage function trades CC% vs mastery directly), tracked separately.

## Tests

- New guard test `most-masteries spends an objective-neutral skill point to overshoot a required target` — proves the idle point is now spent, **score unchanged**.
- Full suite green (all modules), incl. the deterministic level-245 proven-optimum test and the #123 priority test. ktlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)