### PR TITLE
fix(startup): eliminate the macOS startup freeze via an extract-once OR-Tools native cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,9 +99,14 @@ solver.
 - `genetic/wakfu/WakfuBuildSolver.kt`: models the build as a constraint-optimization problem and
   solves it with CP-SAT for a **deterministic, provably optimal** result. Streams improving
   solutions via `callbackFlow`.
-- **Native**: OR-Tools ships a native library loaded at runtime via `Loader.loadNativeLibraries()`
-  (`WakfuBuildSolver`'s `init` / `warmUp()`). The **first** solve pays a one-time cold start
-  (library extraction + load); the GUI hides this behind a loading screen (see §6).
+- **Native**: OR-Tools ships ~100 native dylibs loaded at runtime via `OrToolsNativeLoader.load()`
+  (`WakfuBuildSolver`'s `init` / `warmUp()`). On macOS that loader extracts them **once** into
+  `~/Library/Caches/WakfuAutobuilder/ortools-native/<fingerprint>/` and reuses them: the stock
+  `Loader.loadNativeLibraries()` re-extracts to a fresh temp dir every launch, and macOS's
+  code-sign validation of freshly written dylibs (~10–25 s) stalls the whole UI thread — the
+  startup-freeze root cause. Only the **first** launch (or first after an OR-Tools bump) pays the
+  validation; later launches load in ~0.1 s. Other OSes keep the stock loader. The GUI hides the
+  cold start behind a loading screen (see §6).
 - Running/testing the solver needs extra JVM args — see §9.
 
 ### Two scoring modes (`ScoreComputationMode`)
@@ -155,14 +160,20 @@ then run `./gradlew :gui-compose:generateAssets`.
 is no FXML/XML.** Package root `me.chosante.ui`, organized by feature: `shell`, `request`,
 `paperdoll`, `stats`, `state`, `components`, `i18n`, `theme`, `testing`.
 
-- **`Main.kt`** — `application { Window(...) }`. `App()` gates on `BuildSearchModel.isReady`: it
-  shows a **`LoadingScreen`** (`shell/`) — app wordmark + a self-calibrating warm-up `%`/ETA — while
-  OR-Tools' native cold start is paid off the UI thread, then **`Crossfade`s** into the main UI. It
-  also sets the window / macOS dock icon from `assets/branding/app-icon.png`.
+- **`Main.kt`** — `application { Window(...) }`. The window opens **floating** (centered, clamped to
+  the usable screen) so the loading screen paints instantly, is pulled to the foreground (useful for
+  un-bundled `gradle run` launches), and is **maximised only once warm-up completes** — maximising at
+  launch ran the macOS zoom transition during the native load and froze startup. `App()` gates on
+  `BuildSearchModel.isReady`: it shows a **`LoadingScreen`** (`shell/`) — app wordmark + a
+  self-calibrating warm-up `%`/ETA — while OR-Tools' native cold start is paid off the UI thread,
+  then **`Crossfade`s** into the main UI. It also sets the window / macOS dock icon from
+  `assets/branding/app-icon.png`.
 - **`BuildSearchModel`** (`state/`) — the **single shared view-model** (Compose `mutableStateOf`
   `UiState`). It runs the search off-thread (`Dispatchers.Default`), collects the engine `Flow`,
-  and owns warm-up state (`WarmupTiming`), background icon preloading, the equipment catalog, and
-  Zenith build creation. (Unlike the old JavaFX GUI, state is centralized here — not in the widgets.)
+  and owns warm-up state (`WarmupTiming`), background icon preloading (started **after** warm-up so
+  the two never compete during startup), the equipment catalog, and Zenith build creation. The
+  warm-up itself waits for the window's first frame (`windowShown`) before touching the native
+  engine. (Unlike the old JavaFX GUI, state is centralized here — not in the widgets.)
 - **`AppShell`** (`shell/`) — `TopBar` (brand logo, language toggle, class, level/min-level, the
   progress + match/mastery meters, Search button) above a 3-column body:
   - **`RequestPanel`** (`request/`) — search mode, target-stats editor, constraints (per-rarity

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/OrToolsNativeLoader.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/OrToolsNativeLoader.kt
@@ -1,0 +1,199 @@
+package me.chosante.autobuilder.genetic.wakfu
+
+import com.google.ortools.Loader
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.net.JarURLConnection
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.jar.JarFile
+
+/**
+ * Loads the OR-Tools native libraries, replacing [Loader.loadNativeLibraries] on macOS with an
+ * extract-once cache.
+ *
+ * The stock loader unpacks the ~100 bundled dylibs (~50 MB) into a **fresh temp directory on every
+ * launch**, and macOS validates the code signature of freshly written dylibs on their first
+ * `dlopen` — measured at 10–25 s on an M-series Mac, during which the OS dynamic loader stalls the
+ * whole UI (AWT event thread / AppKit), freezing the app at every startup. That validation is
+ * cached per on-disk file, so loading the *same* files again costs ~50 ms (measured: 25.4 s fresh
+ * vs 0.055 s cached). Extracting once into a stable per-version directory and reusing it makes
+ * every launch after the first fast and freeze-free; only the very first launch (or the first one
+ * after an OR-Tools upgrade) still pays the validation.
+ *
+ * Any unexpected condition (non-jar classpath, unwritable cache, partial extraction, exotic OS…)
+ * falls back to the stock loader — slow but battle-tested. Non-mac OSes always use the stock
+ * loader: they don't re-validate fresh files the way macOS does, so the cache would only save a
+ * little extraction IO.
+ */
+object OrToolsNativeLoader {
+    private val logger = KotlinLogging.logger {}
+    private var loaded = false
+
+    private const val JNI_LIB = "libjniortools.dylib"
+
+    /**
+     * Idempotent. Like the stock loader (`synchronized` there too), concurrent callers block until
+     * the first one finishes, so no caller can ever observe a half-loaded state; a failed attempt
+     * (stock-loader throw) stays un-latched and is retried by the next call.
+     */
+    @Synchronized
+    fun load() {
+        if (loaded) return
+        val isMac =
+            System
+                .getProperty("os.name")
+                .orEmpty()
+                .lowercase()
+                .contains("mac")
+        val cached =
+            isMac &&
+                runCatching { loadFromStableCache() }
+                    .onFailure { logger.warn(it) { "OR-Tools stable-cache load failed; falling back to the stock loader." } }
+                    .getOrDefault(false)
+        if (!cached) {
+            Loader.loadNativeLibraries()
+        }
+        loaded = true
+    }
+
+    /** @return true when the natives were loaded from (or freshly installed into) the stable cache. */
+    private fun loadFromStableCache(): Boolean {
+        val arch = System.getProperty("os.arch").orEmpty().lowercase()
+        val resourceDir = "ortools-darwin-" + if (arch == "aarch64" || arch == "arm64") "aarch64" else "x86-64"
+
+        val jniResource =
+            Loader::class.java.classLoader.getResource("$resourceDir/$JNI_LIB")
+                ?: return false
+        val connection = jniResource.openConnection() as? JarURLConnection ?: return false
+        connection.useCaches = false
+        val jarPath = Path.of(connection.jarFileURL.toURI())
+
+        // One cache directory per *content fingerprint* of the bundled natives, so any OR-Tools
+        // change lands in a new directory and re-validates exactly once. The jar's file name is NOT
+        // a safe key: the natives can be resolved from the CLI fat jar, whose name never changes
+        // across upgrades. CRCs come from the zip central directory, so fingerprinting reads no
+        // entry content — and stays identical across fat-jar rebuilds that keep the same natives.
+        val cacheRoot =
+            Path
+                .of(System.getProperty("user.home"))
+                .resolve("Library")
+                .resolve("Caches")
+                .resolve("WakfuAutobuilder")
+                .resolve("ortools-native")
+        val cacheDir = cacheRoot.resolve(nativesFingerprint(jarPath, resourceDir))
+        val jniPath = cacheDir.resolve(JNI_LIB)
+
+        if (!Files.isRegularFile(jniPath)) {
+            extractInto(jarPath, resourceDir, cacheDir)
+        }
+        try {
+            // The JNI dylib finds its ~100 dependencies next to itself (@loader_path), exactly like
+            // the stock loader's temp directory.
+            System.load(jniPath.toAbsolutePath().toString())
+        } catch (firstAttempt: Throwable) {
+            // Self-heal: ~/Library/Caches is purgeable, so macOS (or a cleaner) can delete *some* of
+            // the ~100 sibling dylibs while the JNI gate file survives — without this retry such a
+            // half-purged directory would be trusted (and fail) on every launch forever, silently
+            // reinstating the per-launch slow path this cache exists to eliminate.
+            logger.warn(firstAttempt) { "Cached OR-Tools natives failed to load; re-extracting once: $cacheDir" }
+            cacheDir.toFile().deleteRecursively()
+            extractInto(jarPath, resourceDir, cacheDir)
+            System.load(jniPath.toAbsolutePath().toString())
+        }
+        // Recency marker for cleanStaleVersions: a directory's own mtime only changes when entries
+        // are added/removed, never on load, so an actively-used cache would otherwise look stale.
+        runCatching {
+            Files.setLastModifiedTime(
+                cacheDir,
+                java.nio.file.attribute.FileTime
+                    .fromMillis(System.currentTimeMillis())
+            )
+        }
+        cleanStaleVersions(cacheRoot, keep = cacheDir)
+        logger.debug { "OR-Tools natives loaded from stable cache: $cacheDir" }
+        return true
+    }
+
+    /** Stable hex digest of the `resourceDir/` entries' names + CRC32s (zip central directory only). */
+    private fun nativesFingerprint(
+        jarPath: Path,
+        resourceDir: String,
+    ): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+        JarFile(jarPath.toFile()).use { jar ->
+            jar
+                .entries()
+                .asSequence()
+                .filter { !it.isDirectory && it.name.startsWith("$resourceDir/") }
+                .sortedBy { it.name }
+                .forEach { entry ->
+                    digest.update(entry.name.toByteArray())
+                    digest.update(entry.crc.toString().toByteArray())
+                }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }.take(16)
+    }
+
+    /**
+     * Extracts every `resourceDir/` entry of [jarPath] into [target]. Writes to a temp sibling and
+     * atomically renames so [target] is only ever absent or complete — a crash mid-extraction can
+     * never leave a half-populated directory that later loads would trust.
+     */
+    private fun extractInto(
+        jarPath: Path,
+        resourceDir: String,
+        target: Path,
+    ) {
+        Files.createDirectories(target.parent)
+        val tmp = Files.createTempDirectory(target.parent, ".extract-")
+        try {
+            JarFile(jarPath.toFile()).use { jar ->
+                for (entry in jar.entries()) {
+                    if (entry.isDirectory || !entry.name.startsWith("$resourceDir/")) continue
+                    val out = tmp.resolve(entry.name.substringAfterLast('/'))
+                    jar.getInputStream(entry).use { Files.copy(it, out, StandardCopyOption.REPLACE_EXISTING) }
+                }
+            }
+            try {
+                Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE)
+            } catch (moveFailed: Exception) {
+                if (Files.isRegularFile(target.resolve(JNI_LIB))) {
+                    // Another process finished first; its copy is equivalent.
+                    tmp.toFile().deleteRecursively()
+                } else {
+                    // A half-purged leftover directory (e.g. macOS reaped the JNI dylib but not its
+                    // siblings) blocks the rename; replace it wholesale or fail for real.
+                    target.toFile().deleteRecursively()
+                    Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE)
+                }
+            }
+        } catch (failure: Throwable) {
+            tmp.toFile().deleteRecursively()
+            throw failure
+        }
+    }
+
+    /**
+     * Best-effort removal of cache entries (each ~50 MB) unused for 30+ days — covering both old
+     * OR-Tools versions and `.extract-` directories orphaned by a crash mid-extraction. Age-based
+     * on purpose: a delete-all-siblings policy would make two coexisting versions (an installed
+     * release alongside a dev tree after a dependency bump) evict each other on every alternating
+     * launch, re-paying the validation the cache exists to avoid. Recency comes from the marker
+     * touch in [loadFromStableCache].
+     */
+    private fun cleanStaleVersions(
+        root: Path,
+        keep: Path,
+    ) {
+        val cutoffMs = System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000
+        runCatching {
+            Files.list(root).use { siblings ->
+                siblings
+                    .filter { it != keep }
+                    .filter { runCatching { Files.getLastModifiedTime(it).toMillis() < cutoffMs }.getOrDefault(false) }
+                    .forEach { stale -> runCatching { stale.toFile().deleteRecursively() } }
+            }
+        }
+    }
+}

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
@@ -24,19 +24,26 @@ object WakfuBestBuildFinderAlgorithm {
      */
     val dataVersion: String = VERSION
 
-    val equipments =
+    // Both data sets are `lazy` on purpose: touching ANY member of this object (e.g. [dataVersion]
+    // from the GUI view-model's constructor, which runs on the AWT event thread) used to trigger
+    // these multi-MB JSON parses eagerly — blocking the UI thread before the first frame could even
+    // paint. Lazy init moves the parse to the first real use (icon preloading / the first search),
+    // which always happens on a background thread in the GUI and on the main thread in the CLI.
+    val equipments: List<Equipment> by lazy {
         this.javaClass.classLoader.getResourceAsStream("equipments-v$VERSION.json")?.readAllBytes()!!.let {
             Json.decodeFromString<List<Equipment>>(String(it))
         }
+    }
 
     /**
      * The embedded runes ([RuneType]) for the current data version, or empty if the resource is
      * absent. The OR-Tools solver socket-fills equipped items with these when [WakfuBestBuildParams.useRunes].
      */
-    val runes: List<RuneType> =
+    val runes: List<RuneType> by lazy {
         this.javaClass.classLoader.getResourceAsStream("runes-v$VERSION.json")?.readAllBytes()?.let {
             Json.decodeFromString<List<RuneType>>(String(it))
         } ?: emptyList()
+    }
 
     fun run(params: WakfuBestBuildParams): Flow<GeneticAlgorithmResult<BuildCombination>> {
         val equipmentsByItemType =

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -1,6 +1,5 @@
 package me.chosante.autobuilder.genetic.wakfu
 
-import com.google.ortools.Loader
 import com.google.ortools.sat.CpModel
 import com.google.ortools.sat.CpSolver
 import com.google.ortools.sat.CpSolverSolutionCallback
@@ -85,7 +84,7 @@ object WakfuBuildSolver {
         )
 
     init {
-        Loader.loadNativeLibraries()
+        OrToolsNativeLoader.load()
     }
 
     private val warmedUp =
@@ -103,7 +102,7 @@ object WakfuBuildSolver {
      */
     fun warmUp() {
         if (!warmedUp.compareAndSet(false, true)) return
-        // Referencing this object already ran `init { Loader.loadNativeLibraries() }`.
+        // Referencing this object already ran `init { OrToolsNativeLoader.load() }`.
         val model = CpModel()
         val a = model.newBoolVar("warmup_a")
         val b = model.newBoolVar("warmup_b")
@@ -118,10 +117,14 @@ object WakfuBuildSolver {
         val solver = CpSolver()
         solver.parameters.maxTimeInSeconds = 1.0
         solver.parameters.logSearchProgress = false
-        // Use the full core count, exactly like the real search, so the multi-worker portfolio is
-        // spun up here too. The CPU spike is safe because warm-up runs behind the lightweight
-        // loading screen — the heavy main UI only mounts once this has finished.
-        solver.parameters.numSearchWorkers = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+        // Deliberately NOT the full core count. What warm-up actually pays off is the native-library
+        // load, JNI/class initialization and the first solve's code paths — none of which need many
+        // workers (CpSolver spins its worker pool up per solve, so nothing about a big pool persists
+        // anyway). Saturating every core here starved the GUI's AWT event thread during startup: on
+        // macOS any window operation (zoom, raise, resize) then stalled until warm-up finished and
+        // the whole app appeared frozen. Two workers still exercise the multi-worker portfolio path
+        // while leaving the UI thread (and the OS) breathing room.
+        solver.parameters.numSearchWorkers = 2
         solver.solve(model)
     }
 

--- a/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
@@ -34,6 +34,7 @@ import java.awt.Desktop
 import java.awt.GraphicsEnvironment
 import java.awt.Taskbar
 import javax.imageio.ImageIO
+import kotlin.time.Duration.Companion.milliseconds
 
 const val SCREENSHOT_PATH_PROPERTY = "wakfu.compose.screenshot"
 
@@ -49,33 +50,29 @@ fun main() {
         // state and capture once a build has landed.
         val scope = rememberCoroutineScope()
         val model = remember { BuildSearchModel(scope) }
+        // The window opens *floating* (small, centered) and is only maximised once warm-up is done —
+        // see the LaunchedEffect below. Opening maximised looked attractive but reintroduced the
+        // startup freeze it was meant to fix: applying Maximized runs the macOS zoom transition the
+        // moment the window appears, i.e. exactly while OR-Tools' native cold start is competing for
+        // CPU — the same starvation the user hit by double-clicking the title bar during warm-up.
+        // A small floating loader, by contrast, paints its first frame instantly.
+        val windowState =
+            remember {
+                WindowState(
+                    position = WindowPosition.Aligned(Alignment.Center),
+                    size = fittedWindowSize(DpSize(1440.dp, 900.dp))
+                )
+            }
         Window(
             onCloseRequest = { exitApplication() },
             title = "Wakfu Autobuilder",
             icon = appIcon,
-            state =
-                WindowState(
-                    // Open maximised so the app fills the screen from the first frame. This also avoids
-                    // the macOS freeze that hit when the window was zoomed/full-screened *during* OR-Tools'
-                    // native cold start: that resize transition has to keep rendering while every core is
-                    // busy paying the one-time startup cost behind the loading screen, so it stalls and the
-                    // app appears frozen. Opening already maximised means there is no zoom to trigger while
-                    // warm-up runs. (Must pair with a resizable window — AWT can refuse to maximise a
-                    // non-resizable frame on macOS, and Compose applies the placement only once.)
-                    placement = WindowPlacement.Maximized,
-                    // Un-maximised (restore) size/position, clamped so the title bar stays reachable.
-                    position = WindowPosition.Aligned(Alignment.Center),
-                    size = fittedWindowSize(DpSize(1440.dp, 900.dp))
-                )
+            state = windowState
         ) {
-            // Pull the window to the front as soon as it is shown. Two reasons:
-            //  • Launched via `gradle run` (an un-bundled JVM) the window can open *behind* the
-            //    launching app, hiding the loading screen so the warm-up progress isn't visible.
-            //  • macOS pauses rendering for an occluded window, so raising a *maximised* window later
-            //    forces the first full-surface render of the big window at that moment — which stalled
-            //    when it coincided with the native warm-up. Rendering it in the foreground now, while
-            //    the cheap loading screen is up, avoids that deferred heavy first paint entirely.
-            // Best-effort: a window-ordering hint must never break startup, so failures are swallowed.
+            // Pull the window to the front as soon as it is shown: launched via `gradle run` (an
+            // un-bundled JVM) the window can open *behind* the launching app, hiding the loading
+            // screen so the warm-up progress isn't visible. Best-effort: a window-ordering hint must
+            // never break startup, so failures are swallowed.
             LaunchedEffect(Unit) {
                 runCatching {
                     window.toFront()
@@ -84,6 +81,27 @@ fun main() {
                     if (desktop.isSupported(Desktop.Action.APP_REQUEST_FOREGROUND)) {
                         desktop.requestForeground(true)
                     }
+                }
+            }
+            // Tell the model once the window is actually on screen — this releases the native
+            // warm-up, whose macOS first-launch code-sign validation stalls the UI thread (see
+            // BuildSearchModel.windowShown). Polling is fine: it resolves within a frame or two.
+            LaunchedEffect(Unit) {
+                while (!window.isShowing) {
+                    kotlinx.coroutines.delay(16.milliseconds)
+                }
+                model.windowShown.complete(Unit)
+            }
+            // Maximise only once the engine is warm: the user wants the app full-screen without
+            // doing anything, and by now the cores are free so the zoom transition renders smoothly
+            // (doing this at launch is what froze startup — see windowState above). Skipped in
+            // screenshot mode (captures need the deterministic fitted size) and when the user
+            // resized the loader themselves — on a long first launch their explicit choice must not
+            // be yanked to full screen.
+            val initialSize = remember { windowState.size }
+            LaunchedEffect(model.isReady) {
+                if (model.isReady && screenshotPath == null && windowState.size == initialSize) {
+                    windowState.placement = WindowPlacement.Maximized
                 }
             }
             ScreenshotCapture(

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -121,6 +121,15 @@ class BuildSearchModel(
     var isReady by androidx.compose.runtime.mutableStateOf(false)
         private set
 
+    /**
+     * Completed by the UI once the window is actually on screen. Gates the native warm-up: on its
+     * very first launch macOS spends seconds validating the freshly extracted OR-Tools dylibs and
+     * stalls the UI thread for the whole load (see `OrToolsNativeLoader`), so the load must never
+     * start before the loading screen has had its first frame. Awaited with a timeout so headless
+     * usage (tests) can never hang on it.
+     */
+    val windowShown: kotlinx.coroutines.CompletableDeferred<Unit> = kotlinx.coroutines.CompletableDeferred()
+
     /** Estimated warm-up progress (0..1) for the loading screen. See [WarmupTiming]. */
     var warmupProgress by androidx.compose.runtime.mutableStateOf(0f)
         private set
@@ -152,14 +161,6 @@ class BuildSearchModel(
             System.getenv("WAKFU_COMPOSE_SCREENSHOT_VARY_PRIORITY") != null
 
     init {
-        // Decode item icons into the cache off the UI thread so they're ready (and decoded once)
-        // by the time a build is shown. Purely background work: it never gates startup — items
-        // simply appear as they decode, so we don't make the user wait on ~thousands of PNGs.
-        scope.launch(Dispatchers.Default) {
-            val paths = warmUpPaths(WakfuBestBuildFinderAlgorithm.equipments)
-            IconPreloader.warmUp(scope, paths) { _, _ -> }
-        }
-
         // Load the saved-build library off the UI thread. A read failure must never block startup —
         // it just yields an empty library that fills in as the user saves builds.
         scope.launch(Dispatchers.IO) {
@@ -172,6 +173,7 @@ class BuildSearchModel(
             // with the default request so the captured frame shows a populated build (paperdoll,
             // stats, skill tree) instead of an empty shell. The first solve pays OR-Tools' cold
             // start inline; ScreenshotCapture waits for the build before grabbing pixels.
+            startIconPreload()
             isReady = true
             if (screenshotPrecisionMode) setMode(ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT)
             if (screenshotVaryPriority) {
@@ -202,13 +204,29 @@ class BuildSearchModel(
                             delay(80.milliseconds)
                         }
                     }
-                delay(200.milliseconds)
+                // Wait for the loading screen's first frame before touching the native engine: the
+                // load can stall the UI thread (macOS first-launch code-sign validation), and a
+                // stall behind a painted window is invisible while one before it looks like the app
+                // failed to start. Generous bound: on a cold first packaged launch the window itself
+                // can take seconds to appear (Skiko's freshly extracted dylib pays the same macOS
+                // validation), and guessing low here would start the native load before the first
+                // frame — the exact failure this gate prevents. Nothing user-visible ever waits on
+                // the timeout (tests cancel their scope; the GUI completes the gate within ~200ms),
+                // it only exists so a headless run can never hang.
+                kotlinx.coroutines.withTimeoutOrNull(15.seconds) { windowShown.await() }
+                delay(100.milliseconds)
                 try {
                     WakfuBuildSolver.warmUp()
                     WarmupTiming.record(System.currentTimeMillis() - start)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (throwable: Throwable) {
+                    // Swallow (Throwable: native loading raises Errors, not Exceptions): a warm-up
+                    // failure should degrade to a cold first search, never crash the app.
+                    throwable.printStackTrace()
                 } finally {
-                    // Always reveal the UI: a warm-up failure should degrade to a cold first search,
-                    // never leave the app stuck on the loading screen.
+                    // Always reveal the UI: a warm-up failure must never leave the app stuck on the
+                    // loading screen.
                     ticker.cancel()
                     withContext(mainDispatcher) {
                         warmupProgress = 1f
@@ -216,7 +234,27 @@ class BuildSearchModel(
                         isReady = true
                     }
                 }
+                // Only start decoding item icons once the engine is warm. During warm-up every core
+                // counts: running the preloader (thousands of PNG decodes + the equipments JSON parse
+                // it triggers) concurrently with the native cold start starved the AWT event thread,
+                // which on macOS froze any window operation until warm-up finished. Icons are not
+                // needed before the first build is shown, so starting late costs nothing visible.
+                startIconPreload()
             }
+        }
+    }
+
+    /**
+     * Decodes item icons into the cache off the UI thread so they're ready (and decoded once) by the
+     * time a build is shown. Purely background work: it never gates startup — items simply appear as
+     * they decode, so we don't make the user wait on ~thousands of PNGs. First touch of
+     * [WakfuBestBuildFinderAlgorithm.equipments] also pays its (lazy) JSON parse, here on a
+     * background thread — never on the UI thread.
+     */
+    private fun startIconPreload() {
+        scope.launch(Dispatchers.Default) {
+            val paths = warmUpPaths(WakfuBestBuildFinderAlgorithm.equipments)
+            IconPreloader.warmUp(scope, paths) { _, _ -> }
         }
     }
 


### PR DESCRIPTION
## Problem

Every launch on macOS froze the UI for **10–25 s**, and any window gesture during startup (double-click-to-zoom, raising the window) appeared to hang the app until loading finished.

## Root cause (measured)

The stock OR-Tools `Loader.loadNativeLibraries()` extracts ~100 dylibs (~52 MB) into a **fresh temp directory on every launch**, and macOS code-sign-validates freshly written dylibs on their first `dlopen` — stalling the whole AWT/AppKit thread for the entire load. The validation is cached **per on-disk file**:

| Scenario | dlopen time |
|---|---|
| Freshly extracted dir #1 | **25.4 s** (0% CPU — pure kernel wait) |
| Same dir, new process | **0.055 s** |
| Freshly extracted dir #2 | **11.0 s** |

Two secondary contributors compounded it: the GUI view-model constructor triggered the eager multi-MB equipments+runes JSON parses **on the AWT thread** before the first frame, and the warm-up solve + icon preloader competed for every core during startup.

## Fix

- **`OrToolsNativeLoader`** (new): extracts once into `~/Library/Caches/WakfuAutobuilder/ortools-native/<crc-fingerprint>/` and reuses it. Content-fingerprinted (an OR-Tools bump re-validates exactly once), self-healing (a half-purged cache dir is deleted, re-extracted and retried once), age-based 30-day cleanup, and falls back to the stock loader on any failure and on non-mac OSes.
- **Lazy `equipments`/`runes`**: the parses now happen on first real use, always off the UI thread in the GUI.
- **Window sequencing**: open floating so the loading screen paints instantly (~160 ms), gate the native warm-up on the window's first frame (`windowShown`, 15 s bound so headless runs can't hang), then maximize automatically once warm-up completes (skipped in screenshot mode or if the user resized the loader).
- **Warm-up solve** uses 2 workers instead of every core; **icon preloading** starts after warm-up.

## Measured result

- First-ever launch (or first after an OR-Tools bump): one-time ~10–25 s validation, now behind a visible loading screen.
- Every subsequent launch: natives load in **66–150 ms**, app ready **and maximized at ~0.5 s**. CLI benefits equally.
- Self-heal verified end-to-end: deleting a sibling dylib from the cache → next launch re-extracts and recovers automatically.

## Validation

- Full test suite + ktlint green.
- 5 instrumented real launches (cold, warm ×2, corrupted-cache recovery, final clean run) + a full CLI search.
- Adversarial multi-agent review confirmed and led to 4 robustness fixes (self-heal, generous first-frame timeout, age-based cache eviction instead of delete-all-siblings, orphaned temp-dir handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)