### PR TITLE
fix(levels): reject min > max with a clear error & default min level to 0

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
@@ -127,8 +127,8 @@ private class WakfuAutobuild :
         "--min-niveau",
         help = "The min level of the character (no items selected will be under this level)"
     ).int()
-        .default(1)
-        .check("Level should be between 1 and 245") { it in 1..245 }
+        .default(0)
+        .check("Min level should be between 0 and 245") { it in 0..245 }
 
     private val characterClass: CharacterClass? by option(
         "--class",
@@ -424,6 +424,18 @@ HUPPERMAGE"""
     ).flag(default = false, defaultForHelp = "disabled")
 
     override fun run() {
+        // Contradictory level bounds (min above max) match no normal item — the engine's level
+        // filter keeps items with min <= itemLevel <= max — so the solver would silently fall back
+        // to the only level-agnostic slots (pets/mounts) and return a near-empty nonsense build.
+        // Fail fast with a clear message instead of running the solver on impossible constraints.
+        if (minLevelWanted > maxLevelWanted) {
+            throw PrintMessage(
+                message =
+                    "The min level ($minLevelWanted) cannot be greater than the max level ($maxLevelWanted). " +
+                        "Lower --min-level or raise --max-level.",
+                printError = true
+            )
+        }
         val character = Character(characterClass ?: CharacterClass.UNKNOWN, maxLevelWanted, minLevelWanted)
         val targetStats =
             TargetStats(

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -30,6 +30,10 @@ enum class Tr(
     CLASS("Class", "Classe"),
     LEVEL_SHORT("Lvl", "Niv"),
     MIN_SHORT("Min", "Min"),
+    LEVEL_RANGE_INVALID(
+        "Min level can't be higher than the character level. Lower the min, or raise the level.",
+        "Le niveau min ne peut pas dépasser le niveau du personnage. Baisse le min, ou augmente le niveau."
+    ),
     PROGRESS("Progress", "Progression"),
     PRELOAD_ICONS("Preloading item icons…", "Préchargement des icônes d'objets…"),
     PRELOAD_WARMUP("Starting the engine…", "Démarrage du moteur…"),

--- a/gui-compose/src/main/kotlin/me/chosante/ui/shell/TopBar.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/shell/TopBar.kt
@@ -96,7 +96,14 @@ fun TopBar(
                 Spacer(modifier = Modifier.width(10.dp))
                 NumberControl(label = tr(Tr.LEVEL_SHORT), value = ui.level.toString(), onValueChange = onLevelChange)
                 Spacer(modifier = Modifier.width(10.dp))
-                NumberControl(label = tr(Tr.MIN_SHORT), value = ui.minLevel.toString(), onValueChange = onMinLevelChange)
+                // Flag the field red the moment min exceeds the character level — an impossible
+                // range the search will refuse (see BuildSearchModel.search).
+                NumberControl(
+                    label = tr(Tr.MIN_SHORT),
+                    value = ui.minLevel.toString(),
+                    onValueChange = onMinLevelChange,
+                    isError = ui.minLevel > ui.level
+                )
                 Spacer(modifier = Modifier.width(22.dp))
                 TopMeter(label = tr(Tr.PROGRESS), value = "${ui.progress}%", fill = ui.progress / 100f, color = WColor.accent2)
                 Spacer(modifier = Modifier.width(16.dp))
@@ -333,6 +340,7 @@ private fun NumberControl(
     label: String,
     value: String,
     onValueChange: (String) -> Unit,
+    isError: Boolean = false,
 ) {
     var draft by remember { mutableStateOf(value) }
     // Keep the box in lockstep with the model's canonical (already-coerced) value. When the user types
@@ -351,7 +359,7 @@ private fun NumberControl(
                 .height(38.dp)
                 .clip(RoundedCornerShape(9.dp))
                 .background(WColor.raised)
-                .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                .border(1.dp, if (isError) WColor.danger else WColor.border, RoundedCornerShape(9.dp))
                 .padding(horizontal = 9.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -494,8 +494,15 @@ class BuildSearchModel(
     fun search() {
         job?.cancel()
         val snapshot = ui
-        val effectiveMinLevel = snapshot.minLevel.coerceAtMost(snapshot.level)
-        val character = Character(snapshot.clazz, snapshot.level, effectiveMinLevel)
+        // Contradictory level bounds (min above the character level) match no normal item — the
+        // engine keeps items with minLevel <= itemLevel <= level — so the solver would fall back to
+        // the only level-agnostic slots (pets/mounts) and surface a near-empty nonsense build. Fail
+        // fast with a clear, visible error instead of silently coercing the bounds and searching.
+        if (snapshot.minLevel > snapshot.level) {
+            ui = snapshot.copy(error = Tr.LEVEL_RANGE_INVALID.value(snapshot.lang))
+            return
+        }
+        val character = Character(snapshot.clazz, snapshot.level, snapshot.minLevel)
         val targetStats = snapshot.toTargetStats()
         val params =
             WakfuBestBuildParams(

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -83,7 +83,8 @@ data class UiState(
     val lang: Lang = Lang.EN,
     val clazz: CharacterClass = CharacterClass.CRA,
     val level: Int = 110,
-    val minLevel: Int = 80,
+    /** Lower item-level bound for the search; 0 = no minimum (consider every item up to [level]). */
+    val minLevel: Int = 0,
     val mode: ScoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
     val targets: List<TargetRow> = defaultTargets(),
     val maxRarity: Rarity = Rarity.EPIC,

--- a/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
@@ -81,6 +81,9 @@ fun StatsPanel(
         ) {
             MatchHero(ui)
             if (ui.phase == Phase.Idle && ui.build == null) {
+                // No build yet: the ActionsCard (which normally carries the error banner) isn't shown,
+                // so surface a pre-search error — e.g. an invalid min/max level range — here instead.
+                ui.error?.let { ErrorBanner(error = it) }
                 EmptyHint()
             } else {
                 ActionsCard(

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
@@ -31,6 +31,7 @@ import me.chosante.common.Equipment
 import me.chosante.common.skills.CharacterSkills
 import me.chosante.ui.history.HistoryRepository
 import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.Tr
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -320,6 +321,37 @@ class BuildSearchModelE2ETest {
             assertTrue(model.ui.forcedItems.isEmpty())
             assertEquals(listOf("Solomonk"), model.ui.excludedItems.map { it.matchName })
             assertNull(model.ui.modal)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a min level above the character level is rejected before the solver runs`() {
+        var solverInvocations = 0
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model =
+            newModel(
+                scope = scope,
+                buildFinder = {
+                    solverInvocations++
+                    emptyFlow()
+                }
+            )
+
+        try {
+            // Default character level is 110; push the min above it to make the range impossible.
+            model.setMinLevel("120")
+            assertTrue(model.ui.minLevel > model.ui.level)
+
+            model.search()
+
+            // The solver is never invoked, and a clear localized error is surfaced instead of the
+            // engine silently returning a near-empty pets/mounts-only build.
+            assertEquals(0, solverInvocations)
+            assertEquals(Tr.LEVEL_RANGE_INVALID.value(Lang.EN), model.ui.error)
+            assertEquals(Phase.Idle, model.ui.phase)
+            assertNull(model.ui.build)
         } finally {
             scope.cancel()
         }


### PR DESCRIPTION
## Problem

Setting a **minimum item level higher than the character level** made the solver return a nonsense build. The engine's level filter keeps items where `minLevel <= itemLevel <= level`, **except** pets/mounts which ignore level. So when `min > level`, no normal item qualifies and the solver falls back to a near-empty build with only a pet/mount.

- **CLI**: no validation at all.
- **GUI**: silently coerced the min down to the level (changed the user's input without telling them).

## Changes

**Validation — both front-ends now refuse the impossible range and never run the solver:**
- CLI (`Main.kt`): fails fast in `run()` with a clear message.
- GUI (`BuildSearchModel.search`): sets a localized error (`Tr.LEVEL_RANGE_INVALID`) and returns.
- GUI surfaces that error in the idle / no-build state (`StatsPanel`) — otherwise the message wouldn't show before a first build.
- GUI flags the **Min** field red live the moment `min > level` (`TopBar`).

**Default minimum level → 0:**
- GUI default `minLevel` 80 → 0; CLI `--min-level` default 1 → 0, and accepted range widened to `0..245` (the GUI already allowed 0). The default search now considers every item up to the character level.

## Tests / verification
- New `BuildSearchModelE2ETest`: when `min > level`, the solver is never invoked and a clear error is set.
- `:gui-compose:test` green, `:autobuilder:compileKotlin` + `ktlintCheck` green.
- CLI checked manually: `--min-level 100 --max-level 50` prints the clear error and does not run the solver; omitting `--min-level` (default 0) validates and produces a build.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
