### PR TITLE
feat(gui): organize the build library (cards · sort · filter · group · tags · folders)

### DIFF
--- a/common-lib/src/main/kotlin/me/chosante/common/history/HistoryEntry.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/history/HistoryEntry.kt
@@ -40,6 +40,10 @@ data class HistoryEntry(
     val result: ResultSnapshot,
     /** Cached Zenith share URL, if one was ever generated for this build. */
     val zenithUrl: String? = null,
+    /** Free-form user tags (trimmed, case-insensitively unique). Empty for pre-feature saves. */
+    val tags: List<String> = emptyList(),
+    /** User folder name, or null = unfiled. Folders are implicit (they exist via membership). */
+    val folder: String? = null,
 ) {
     companion object {
         const val CURRENT_SCHEMA_VERSION = 1

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
@@ -23,9 +23,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -41,6 +45,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.chosante.common.Characteristic
 import me.chosante.common.Equipment
+import me.chosante.common.history.HistoryEntry
+import me.chosante.ui.history.normalizeTags
 import me.chosante.ui.i18n.Lang
 import me.chosante.ui.i18n.LocalLang
 import me.chosante.ui.i18n.Tr
@@ -50,6 +56,7 @@ import me.chosante.ui.state.Modal
 import me.chosante.ui.state.PickerMode
 import me.chosante.ui.state.color
 import me.chosante.ui.state.statCatalog
+import me.chosante.ui.state.tagInputSuggestions
 import me.chosante.ui.theme.WColor
 import me.chosante.ui.theme.WDimens
 import me.chosante.ui.theme.WType
@@ -66,9 +73,17 @@ fun ModalHost(
     suggestedSaveName: String = "",
     isEditingExisting: Boolean = false,
     takenNames: Set<String> = emptySet(),
+    editingEntry: HistoryEntry? = null,
+    existingFolders: List<String> = emptyList(),
+    existingTags: List<String> = emptyList(),
     onSaveBuild: (name: String, note: String?, asNew: Boolean) -> Unit = { _, _, _ -> },
-    onRenameBuild: (id: String, newName: String) -> Unit = { _, _ -> },
+    onEditBuild: (id: String, name: String, note: String?, tags: List<String>, folder: String?) -> Unit = { _, _, _, _, _ -> },
     onDeleteBuild: (id: String) -> Unit = {},
+    onRenameFolder: (oldName: String, newName: String) -> Unit = { _, _ -> },
+    onDeleteFolder: (name: String) -> Unit = {},
+    onCreateTag: (name: String) -> Unit = {},
+    onRenameTag: (oldName: String, newName: String) -> Unit = { _, _ -> },
+    onDeleteTag: (name: String) -> Unit = {},
     onConfirmReSearch: () -> Unit = {},
 ) {
     if (modal == null) return
@@ -96,10 +111,74 @@ fun ModalHost(
                     onCancel = onDismiss
                 )
 
-            is Modal.RenameBuild ->
-                RenameModal(
-                    initialName = modal.currentName,
-                    onRename = { newName -> onRenameBuild(modal.id, newName) },
+            is Modal.EditBuild -> {
+                // Resolve at render time so the dialog never edits a stale snapshot. If the entry
+                // vanished (e.g. deleted elsewhere), close from a side-effect (never write state
+                // during composition).
+                if (editingEntry == null || editingEntry.id != modal.id) {
+                    LaunchedEffect(modal.id) { onDismiss() }
+                } else {
+                    // key on the entry id so the form's internal state resets if the dialog is ever
+                    // re-pointed at a different build without closing in between.
+                    key(editingEntry.id) {
+                        EditBuildModal(
+                            entry = editingEntry,
+                            takenNames = takenNames,
+                            existingFolders = existingFolders,
+                            existingTags = existingTags,
+                            onSave = onEditBuild,
+                            onCancel = onDismiss
+                        )
+                    }
+                }
+            }
+
+            is Modal.RenameFolder ->
+                RenameValueModal(
+                    title = tr(Tr.RENAME_FOLDER_TITLE),
+                    label = tr(Tr.FOLDER_LABEL),
+                    initialName = modal.name,
+                    onRename = { newName -> onRenameFolder(modal.name, newName) },
+                    onCancel = onDismiss
+                )
+
+            is Modal.ConfirmDeleteFolder ->
+                ConfirmModal(
+                    title = tr(Tr.DELETE_FOLDER_TITLE),
+                    emphasis = modal.name,
+                    message = tr(Tr.DELETE_FOLDER_HINT),
+                    confirmLabel = tr(Tr.ACTION_DELETE),
+                    confirmColor = WColor.danger,
+                    onConfirm = { onDeleteFolder(modal.name) },
+                    onCancel = onDismiss
+                )
+
+            Modal.CreateTag ->
+                RenameValueModal(
+                    title = tr(Tr.CREATE_TAG_TITLE),
+                    label = tr(Tr.TAGS_LABEL),
+                    initialName = "",
+                    onRename = onCreateTag,
+                    onCancel = onDismiss
+                )
+
+            is Modal.RenameTag ->
+                RenameValueModal(
+                    title = tr(Tr.RENAME_TAG_TITLE),
+                    label = tr(Tr.TAGS_LABEL),
+                    initialName = modal.name,
+                    onRename = { newName -> onRenameTag(modal.name, newName) },
+                    onCancel = onDismiss
+                )
+
+            is Modal.ConfirmDeleteTag ->
+                ConfirmModal(
+                    title = tr(Tr.DELETE_TAG_TITLE),
+                    emphasis = modal.name,
+                    message = tr(Tr.DELETE_TAG_HINT),
+                    confirmLabel = tr(Tr.ACTION_DELETE),
+                    confirmColor = WColor.danger,
+                    onConfirm = { onDeleteTag(modal.name) },
                     onCancel = onDismiss
                 )
 
@@ -553,19 +632,158 @@ private fun SaveBuildModal(
 }
 
 @Composable
-private fun RenameModal(
+private fun EditBuildModal(
+    entry: HistoryEntry,
+    takenNames: Set<String>,
+    existingFolders: List<String>,
+    existingTags: List<String>,
+    onSave: (id: String, name: String, note: String?, tags: List<String>, folder: String?) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var name by remember { mutableStateOf(entry.name) }
+    var note by remember { mutableStateOf(entry.note.orEmpty()) }
+    var tags by remember { mutableStateOf(entry.tags) }
+    var folder by remember { mutableStateOf(entry.folder) }
+    // The build's own name must not count as "taken" (editing it isn't a collision with itself).
+    val ownName = entry.name.trim().lowercase()
+    val nameTaken = name.trim().lowercase().let { it != ownName && it in takenNames }
+
+    ModalCard(title = tr(Tr.EDIT_BUILD_TITLE)) {
+        LabeledField(label = tr(Tr.SAVE_NAME_LABEL), value = name, onValueChange = { name = it }, placeholder = "")
+        if (nameTaken) {
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(text = tr(Tr.SAVE_NAME_TAKEN), style = WTypography.labelSmall.copy(color = WColor.danger))
+        }
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        LabeledField(label = tr(Tr.SAVE_NOTE_LABEL), value = note, onValueChange = { note = it }, placeholder = "")
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        Text(text = tr(Tr.TAGS_LABEL), style = WTypography.labelMedium.copy(color = WColor.muted))
+        Spacer(modifier = Modifier.height(6.dp))
+        TagInput(
+            selected = tags,
+            known = existingTags,
+            onAdd = { tags = normalizeTags(tags + it) },
+            onRemove = { removed -> tags = tags.filterNot { it.equals(removed, ignoreCase = true) } }
+        )
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        Text(text = tr(Tr.FOLDER_LABEL), style = WTypography.labelMedium.copy(color = WColor.muted))
+        Spacer(modifier = Modifier.height(6.dp))
+        FolderPicker(
+            current = folder,
+            existingFolders = existingFolders,
+            onSelect = { folder = it }
+        )
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        Row(horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+            DialogButton(text = tr(Tr.CANCEL), filled = false, color = WColor.border, onClick = onCancel, modifier = Modifier.weight(1f))
+            DialogButton(
+                text = tr(Tr.SAVE),
+                filled = true,
+                color = WColor.accent,
+                enabled = name.isNotBlank() && !nameTaken,
+                onClick = { onSave(entry.id, name, note.ifBlank { null }, tags, folder) },
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun FolderPicker(
+    current: String?,
+    existingFolders: List<String>,
+    onSelect: (String?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var creating by remember { mutableStateOf(false) }
+    var draft by remember { mutableStateOf("") }
+    Column {
+        Box {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(40.dp)
+                        .clip(RoundedCornerShape(9.dp))
+                        .background(WColor.bg)
+                        .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                        .clickable { expanded = true }
+                        .padding(horizontal = 11.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = current ?: tr(Tr.FOLDER_NONE),
+                    style = WTypography.bodyMedium.copy(color = if (current == null) WColor.faint else WColor.text),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(text = "▾", style = WTypography.labelSmall.copy(lineHeight = 10.sp))
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                containerColor = WColor.surface,
+                border = androidx.compose.foundation.BorderStroke(1.dp, WColor.border)
+            ) {
+                DropdownMenuItem(
+                    text = { Text(text = tr(Tr.FOLDER_NONE), style = WTypography.bodyMedium.copy(color = if (current == null) WColor.accent else WColor.text)) },
+                    onClick = {
+                        onSelect(null)
+                        expanded = false
+                    }
+                )
+                existingFolders.forEach { name ->
+                    DropdownMenuItem(
+                        text = { Text(text = name, style = WTypography.bodyMedium.copy(color = if (name == current) WColor.accent else WColor.text)) },
+                        onClick = {
+                            onSelect(name)
+                            expanded = false
+                        }
+                    )
+                }
+                DropdownMenuItem(
+                    text = { Text(text = tr(Tr.FOLDER_NEW), style = WTypography.bodyMedium.copy(color = WColor.accent2)) },
+                    onClick = {
+                        creating = true
+                        draft = ""
+                        expanded = false
+                    }
+                )
+            }
+        }
+        if (creating) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Box(modifier = Modifier.weight(1f)) {
+                    SearchField(query = draft, onQueryChange = { draft = it }, placeholder = tr(Tr.FOLDER_NEW))
+                }
+                DialogButton(
+                    text = tr(Tr.TAG_ADD),
+                    filled = false,
+                    color = WColor.accent2,
+                    enabled = draft.isNotBlank(),
+                    onClick = {
+                        onSelect(draft.trim())
+                        creating = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RenameValueModal(
+    title: String,
+    label: String,
     initialName: String,
     onRename: (String) -> Unit,
     onCancel: () -> Unit,
 ) {
     var name by remember { mutableStateOf(initialName) }
-    ModalCard(title = tr(Tr.RENAME_TITLE)) {
-        LabeledField(
-            label = tr(Tr.SAVE_NAME_LABEL),
-            value = name,
-            onValueChange = { name = it },
-            placeholder = ""
-        )
+    ModalCard(title = title) {
+        LabeledField(label = label, value = name, onValueChange = { name = it }, placeholder = "")
         Spacer(modifier = Modifier.height(WDimens.gap))
         Row(horizontalArrangement = Arrangement.spacedBy(9.dp)) {
             DialogButton(text = tr(Tr.CANCEL), filled = false, color = WColor.border, onClick = onCancel, modifier = Modifier.weight(1f))
@@ -577,6 +795,144 @@ private fun RenameModal(
                 onClick = { onRename(name) },
                 modifier = Modifier.weight(1f)
             )
+        }
+    }
+}
+
+/**
+ * Type-or-select tag input. The currently-assigned tags show as removable chips; the field below
+ * filters the known tags as you type (▾ browses them all), and offers to create the typed name when
+ * it's new. Tags are first-class entities — removing one here only unassigns it from this build; it
+ * lives on until deleted from the library sidebar.
+ */
+@Composable
+internal fun TagInput(
+    selected: List<String>,
+    known: List<String>,
+    onAdd: (String) -> Unit,
+    onRemove: (String) -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    var browsing by remember { mutableStateOf(false) }
+    val draft = query.trim()
+    val (suggestions, canCreate) = tagInputSuggestions(known = known, selected = selected, rawQuery = query)
+    val panelOpen = draft.isNotBlank() || browsing
+
+    Column {
+        if (selected.isNotEmpty()) {
+            selected.chunked(3).forEach { rowTags ->
+                Row(horizontalArrangement = Arrangement.spacedBy(7.dp), modifier = Modifier.padding(bottom = 7.dp)) {
+                    rowTags.forEach { tag -> RemovableTagChip(label = tag, onRemove = { onRemove(tag) }) }
+                }
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            Box(modifier = Modifier.weight(1f)) {
+                SearchField(query = query, onQueryChange = { query = it }, placeholder = tr(Tr.TAG_ADD_PLACEHOLDER))
+            }
+            // ▾ browse: show every known tag without typing.
+            Box(
+                modifier =
+                    Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(9.dp))
+                        .background(if (browsing) WColor.raised else WColor.bg)
+                        .border(1.dp, if (browsing) WColor.accent.copy(alpha = 0.55f) else WColor.border, RoundedCornerShape(9.dp))
+                        .clickable { browsing = !browsing },
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "▾", style = WTypography.labelMedium.copy(color = WColor.muted, lineHeight = 12.sp))
+            }
+        }
+        if (panelOpen) {
+            Spacer(modifier = Modifier.height(6.dp))
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 180.dp)
+                        .clip(RoundedCornerShape(9.dp))
+                        .background(WColor.bg)
+                        .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                        .verticalScroll(rememberScrollState())
+            ) {
+                if (canCreate) {
+                    TagOptionRow(text = "${tr(Tr.TAG_CREATE)} \"$draft\"", glyph = "＋", accent = true, onClick = {
+                        onAdd(draft)
+                        query = ""
+                    })
+                }
+                suggestions.forEach { tag ->
+                    // Keep the panel open (browsing) so several tags can be added in a row.
+                    TagOptionRow(text = tag, glyph = "#", accent = false, onClick = { onAdd(tag) })
+                }
+                if (suggestions.isEmpty() && !canCreate) {
+                    Text(
+                        text = tr(Tr.TAG_NONE_LEFT),
+                        style = WTypography.labelSmall.copy(color = WColor.faint),
+                        modifier = Modifier.padding(horizontal = 11.dp, vertical = 10.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagOptionRow(
+    text: String,
+    glyph: String,
+    accent: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 11.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = glyph,
+            style = WTypography.labelSmall.copy(color = if (accent) WColor.accent2 else WColor.faint)
+        )
+        Text(
+            text = text,
+            style = WTypography.bodyMedium.copy(color = if (accent) WColor.accent2 else WColor.text),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun RemovableTagChip(
+    label: String,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(WColor.raised)
+                .border(1.dp, WColor.accent2.copy(alpha = 0.35f), RoundedCornerShape(999.dp))
+                .padding(start = 9.dp, end = 6.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp)
+    ) {
+        Text(
+            text = label,
+            style = WTypography.labelSmall.copy(color = WColor.text),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Box(
+            modifier = Modifier.clip(RoundedCornerShape(999.dp)).clickable(onClick = onRemove).padding(horizontal = 3.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "✕", style = WTypography.labelSmall.copy(color = WColor.muted))
         }
     }
 }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
@@ -33,6 +33,8 @@ fun UiState.toHistoryEntry(
     note: String?,
     createdAt: Long,
     dataVersion: String,
+    tags: List<String> = emptyList(),
+    folder: String? = null,
 ): HistoryEntry? {
     val build = this.build ?: return null
     return HistoryEntry(
@@ -62,8 +64,19 @@ fun UiState.toHistoryEntry(
                 match = match.toDouble(),
                 optimal = optimal
             ),
-        zenithUrl = zenithUrl
+        zenithUrl = zenithUrl,
+        tags = tags,
+        folder = folder
     )
+}
+
+/** Trim, drop blanks, dedupe case-insensitively keeping the first-seen casing for display. */
+fun normalizeTags(raw: List<String>): List<String> {
+    val seen = HashSet<String>()
+    return raw
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .filter { seen.add(it.lowercase()) }
 }
 
 /** Flattens a skill allocation to `skill name → points` for storage. */

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/LibraryScreen.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/LibraryScreen.kt
@@ -1,26 +1,35 @@
 package me.chosante.ui.history
 
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.TooltipArea
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,12 +46,25 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import me.chosante.common.CharacterClass
 import me.chosante.common.history.HistoryEntry
 import me.chosante.ui.components.ItemThumbnail
 import me.chosante.ui.i18n.Tr
 import me.chosante.ui.i18n.tr
+import me.chosante.ui.paperdoll.bottomSlots
+import me.chosante.ui.paperdoll.leftSlots
+import me.chosante.ui.paperdoll.rightSlots
+import me.chosante.ui.paperdoll.slotAssignments
+import me.chosante.ui.state.LibraryFolderFilter
+import me.chosante.ui.state.LibraryGroup
+import me.chosante.ui.state.LibrarySort
 import me.chosante.ui.state.UiState
+import me.chosante.ui.state.classCounts
+import me.chosante.ui.state.color
+import me.chosante.ui.state.folderCounts
 import me.chosante.ui.state.formatCompact
+import me.chosante.ui.state.libraryLabel
+import me.chosante.ui.state.organizeLibrary
 import me.chosante.ui.theme.WColor
 import me.chosante.ui.theme.WDimens
 import me.chosante.ui.theme.WType
@@ -53,9 +75,10 @@ import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
 /**
- * The "My Builds" library: a searchable grid of saved-build cards. Every card can be loaded back
- * into the workspace, pinned into the compare view, renamed or deleted. Reads entirely off the
- * in-memory [UiState.savedBuilds]; all writes go through the model's callbacks.
+ * The "My Builds" library: a sidebar (all-builds + per-class filters) beside a toolbar (search,
+ * sort, group-by-class) and a grid of saved-build cards. Every card can be loaded back into the
+ * workspace, pinned into the compare view, renamed or deleted. Reads entirely off the in-memory
+ * [UiState]; all writes/filters go through the model's callbacks.
  */
 @Composable
 fun LibraryScreen(
@@ -63,69 +86,546 @@ fun LibraryScreen(
     onLoad: (String) -> Unit,
     onCompare: (String) -> Unit,
     onDuplicate: (String) -> Unit,
-    onRename: (String, String) -> Unit,
+    onEdit: (String) -> Unit,
     onDelete: (String, String) -> Unit,
+    onToggleTag: (String) -> Unit,
+    onCreateTag: () -> Unit,
+    onRenameTag: (String) -> Unit,
+    onDeleteTag: (String) -> Unit,
+    onFolderFilterChange: (LibraryFolderFilter) -> Unit,
+    onRenameFolder: (String) -> Unit,
+    onDeleteFolder: (String) -> Unit,
     onGoBuilder: () -> Unit,
+    onSearchChange: (String) -> Unit,
+    onSortChange: (LibrarySort) -> Unit,
+    onClassFilterChange: (CharacterClass?) -> Unit,
+    onToggleGroup: () -> Unit,
+    onClearFilters: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var query by remember { mutableStateOf("") }
-    val filtered =
-        remember(ui.savedBuilds, query) {
-            val q = query.trim()
-            if (q.isBlank()) {
-                ui.savedBuilds
-            } else {
-                ui.savedBuilds.filter { it.name.contains(q, ignoreCase = true) || it.request.clazz.contains(q, ignoreCase = true) }
-            }
+    if (ui.savedBuilds.isEmpty()) {
+        Column(
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .background(WColor.bg)
+                    .verticalScroll(rememberScrollState())
+                    .padding(WDimens.pad),
+            verticalArrangement = Arrangement.spacedBy(WDimens.gap)
+        ) {
+            Header(count = 0)
+            EmptyState(onGoBuilder = onGoBuilder)
         }
-    val scroll = rememberScrollState()
-    // A fresh duplicate lands at the top (newest first); bring it into view so the highlight is seen.
-    LaunchedEffect(ui.lastDuplicatedBuildId) {
-        if (ui.lastDuplicatedBuildId != null) scroll.animateScrollTo(0)
+        return
     }
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(WColor.bg)
-                .verticalScroll(scroll)
-                .padding(WDimens.pad),
-        verticalArrangement = Arrangement.spacedBy(WDimens.gap)
-    ) {
-        Header(count = ui.savedBuilds.size)
-        if (ui.savedBuilds.isNotEmpty()) {
-            SearchField(query = query, onQueryChange = { query = it })
-        }
-        when {
-            ui.savedBuilds.isEmpty() -> EmptyState(onGoBuilder = onGoBuilder)
-            filtered.isEmpty() ->
-                Text(
-                    text = tr(Tr.LIBRARY_NO_MATCH),
-                    style = WTypography.bodyMedium.copy(color = WColor.muted),
-                    modifier = Modifier.padding(vertical = 24.dp)
-                )
 
-            else ->
-                filtered.chunked(2).forEach { row ->
-                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(WDimens.gap)) {
-                        row.forEach { entry ->
-                            Box(modifier = Modifier.weight(1f)) {
-                                BuildCard(
-                                    entry = entry,
-                                    isActive = entry.id == ui.activeBuildId,
-                                    isJustDuplicated = entry.id == ui.lastDuplicatedBuildId,
-                                    onLoad = { onLoad(entry.id) },
-                                    onCompare = { onCompare(entry.id) },
-                                    onDuplicate = { onDuplicate(entry.id) },
-                                    onRename = { onRename(entry.id, entry.name) },
-                                    onDelete = { onDelete(entry.id, entry.name) }
-                                )
-                            }
+    val groups =
+        remember(
+            ui.savedBuilds,
+            ui.librarySearch,
+            ui.librarySort,
+            ui.libraryClassFilter,
+            ui.libraryGroupByClass,
+            ui.librarySelectedTags,
+            ui.libraryFolder
+        ) {
+            organizeLibrary(
+                builds = ui.savedBuilds,
+                search = ui.librarySearch,
+                sort = ui.librarySort,
+                classFilter = ui.libraryClassFilter,
+                groupByClass = ui.libraryGroupByClass,
+                selectedTags = ui.librarySelectedTags,
+                folder = ui.libraryFolder
+            )
+        }
+
+    // A fresh duplicate lands at the top (newest first); bring it into view so the highlight is seen.
+    val gridScroll = rememberScrollState()
+    LaunchedEffect(ui.lastDuplicatedBuildId) {
+        if (ui.lastDuplicatedBuildId != null) gridScroll.animateScrollTo(0)
+    }
+
+    Row(modifier = modifier.fillMaxSize().background(WColor.bg)) {
+        LibrarySidebar(
+            ui = ui,
+            onClassFilterChange = onClassFilterChange,
+            onToggleTag = onToggleTag,
+            onCreateTag = onCreateTag,
+            onRenameTag = onRenameTag,
+            onDeleteTag = onDeleteTag,
+            onFolderFilterChange = onFolderFilterChange,
+            onRenameFolder = onRenameFolder,
+            onDeleteFolder = onDeleteFolder
+        )
+        Column(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .verticalScroll(gridScroll)
+                    .padding(WDimens.pad),
+            verticalArrangement = Arrangement.spacedBy(WDimens.gap)
+        ) {
+            Header(count = ui.savedBuilds.size)
+            LibraryToolbar(
+                ui = ui,
+                onSearchChange = onSearchChange,
+                onSortChange = onSortChange,
+                onToggleGroup = onToggleGroup
+            )
+            if (groups.all { it.builds.isEmpty() }) {
+                NoResults(onClearFilters = onClearFilters)
+            } else {
+                BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                    // Responsive card grid: compact cards (the U-shaped slot block fills each edge-to-
+                    // edge), up to 6 per row — wide enough that the Load button + 4 action icons fit.
+                    val columns = (maxWidth / 230.dp).toInt().coerceIn(2, 6)
+                    Column(verticalArrangement = Arrangement.spacedBy(WDimens.gap)) {
+                        groups.forEach { group ->
+                            LibraryGroupSection(
+                                group = group,
+                                ui = ui,
+                                columns = columns,
+                                onLoad = onLoad,
+                                onCompare = onCompare,
+                                onDuplicate = onDuplicate,
+                                onEdit = onEdit,
+                                onDelete = onDelete
+                            )
                         }
-                        if (row.size == 1) Spacer(modifier = Modifier.weight(1f))
                     }
                 }
+            }
         }
+    }
+}
+
+@Composable
+private fun LibraryGroupSection(
+    group: LibraryGroup,
+    ui: UiState,
+    columns: Int,
+    onLoad: (String) -> Unit,
+    onCompare: (String) -> Unit,
+    onDuplicate: (String) -> Unit,
+    onEdit: (String) -> Unit,
+    onDelete: (String, String) -> Unit,
+) {
+    if (group.builds.isEmpty()) return
+    if (group.clazz != null) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = group.clazz.libraryLabel(),
+                style = WTypography.labelMedium.copy(color = WColor.muted, fontWeight = FontWeight.SemiBold)
+            )
+            Text(
+                text = "${group.builds.size}",
+                style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.faint)
+            )
+        }
+    }
+    group.builds.chunked(columns).forEach { row ->
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(WDimens.gap)) {
+            row.forEach { entry ->
+                Box(modifier = Modifier.weight(1f)) {
+                    BuildCard(
+                        entry = entry,
+                        isActive = entry.id == ui.activeBuildId,
+                        isJustDuplicated = entry.id == ui.lastDuplicatedBuildId,
+                        onLoad = { onLoad(entry.id) },
+                        onCompare = { onCompare(entry.id) },
+                        onDuplicate = { onDuplicate(entry.id) },
+                        onEdit = { onEdit(entry.id) },
+                        onDelete = { onDelete(entry.id, entry.name) }
+                    )
+                }
+            }
+            // Pad the final, partially-filled row so its cards keep the same width as full rows.
+            repeat(columns - row.size) { Spacer(modifier = Modifier.weight(1f)) }
+        }
+    }
+}
+
+@Composable
+private fun NoResults(onClearFilters: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(WDimens.gap)) {
+        Text(
+            text = tr(Tr.LIBRARY_NO_MATCH),
+            style = WTypography.bodyMedium.copy(color = WColor.muted),
+            modifier = Modifier.padding(vertical = 24.dp)
+        )
+        CardButton(
+            text = tr(Tr.LIBRARY_CLEAR_FILTERS),
+            filled = false,
+            color = WColor.accent2,
+            onClick = onClearFilters,
+            modifier = Modifier.widthIn(min = 160.dp)
+        )
+    }
+}
+
+// ── Sidebar ──────────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun LibrarySidebar(
+    ui: UiState,
+    onClassFilterChange: (CharacterClass?) -> Unit,
+    onToggleTag: (String) -> Unit,
+    onCreateTag: () -> Unit,
+    onRenameTag: (String) -> Unit,
+    onDeleteTag: (String) -> Unit,
+    onFolderFilterChange: (LibraryFolderFilter) -> Unit,
+    onRenameFolder: (String) -> Unit,
+    onDeleteFolder: (String) -> Unit,
+) {
+    val counts = remember(ui.savedBuilds) { classCounts(ui.savedBuilds) }
+    val tagBuildCounts =
+        remember(ui.savedBuilds) {
+            ui.savedBuilds
+                .flatMap { it.tags }
+                .groupingBy { it.lowercase() }
+                .eachCount()
+        }
+    val folders = remember(ui.savedBuilds) { folderCounts(ui.savedBuilds) }
+    val unfiledCount = remember(ui.savedBuilds) { ui.savedBuilds.count { it.folder == null } }
+    Column(
+        modifier =
+            Modifier
+                .width(210.dp)
+                .fillMaxHeight()
+                .background(WColor.surface)
+                .border(1.dp, WColor.hairline)
+                .verticalScroll(rememberScrollState())
+                .padding(WDimens.pad),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        SidebarRow(
+            label = tr(Tr.LIBRARY_ALL_BUILDS),
+            count = ui.savedBuilds.size,
+            selected = ui.libraryClassFilter == null && ui.libraryFolder == LibraryFolderFilter.All,
+            onClick = {
+                onFolderFilterChange(LibraryFolderFilter.All)
+                onClassFilterChange(null)
+            }
+        )
+        if (folders.isNotEmpty()) {
+            SidebarHeader(text = tr(Tr.LIBRARY_FOLDERS))
+            folders.forEach { (name, count) ->
+                ManagedSidebarRow(
+                    label = name,
+                    count = count,
+                    selected = ui.libraryFolder == LibraryFolderFilter.Named(name),
+                    onClick = { onFolderFilterChange(LibraryFolderFilter.Named(name)) },
+                    onRename = { onRenameFolder(name) },
+                    onDelete = { onDeleteFolder(name) }
+                )
+            }
+            if (unfiledCount > 0) {
+                SidebarRow(
+                    label = tr(Tr.LIBRARY_UNFILED),
+                    count = unfiledCount,
+                    selected = ui.libraryFolder == LibraryFolderFilter.Unfiled,
+                    onClick = { onFolderFilterChange(LibraryFolderFilter.Unfiled) }
+                )
+            }
+        }
+        var tagsCollapsed by remember { mutableStateOf(false) }
+        SidebarSectionHeader(
+            text = tr(Tr.LIBRARY_TAGS),
+            collapsed = tagsCollapsed,
+            onToggleCollapsed = { tagsCollapsed = !tagsCollapsed },
+            onAdd = onCreateTag
+        )
+        if (!tagsCollapsed) {
+            ui.knownTags.forEach { tag ->
+                ManagedSidebarRow(
+                    label = tag,
+                    count = tagBuildCounts[tag.lowercase()] ?: 0,
+                    selected = tag.lowercase() in ui.librarySelectedTags,
+                    onClick = { onToggleTag(tag) },
+                    onRename = { onRenameTag(tag) },
+                    onDelete = { onDeleteTag(tag) }
+                )
+            }
+        }
+        if (counts.isNotEmpty()) {
+            SidebarHeader(text = tr(Tr.LIBRARY_CLASSES))
+            counts.forEach { (clazz, count) ->
+                val selected = ui.libraryClassFilter == clazz
+                SidebarRow(
+                    label = clazz.libraryLabel(),
+                    count = count,
+                    selected = selected,
+                    onClick = { onClassFilterChange(if (selected) null else clazz) }
+                )
+            }
+        }
+    }
+}
+
+/** A sidebar filter row that can also be renamed/deleted — shared by Folders and Tags. */
+@Composable
+private fun ManagedSidebarRow(
+    label: String,
+    count: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(if (selected) WColor.accent.copy(alpha = 0.12f) else Color.Transparent)
+                .border(
+                    1.dp,
+                    if (selected) WColor.accent.copy(alpha = 0.55f) else Color.Transparent,
+                    RoundedCornerShape(8.dp)
+                ).padding(end = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // The whole label+count area is the toggle target (not just the text), so the click zone
+        // spans most of the row width; the hover highlight then reads as a clean full-width row.
+        Row(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(onClick = onClick)
+                    .padding(start = 9.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style = WTypography.bodyMedium.copy(color = if (selected) WColor.text else WColor.muted),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = "$count",
+                style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.faint)
+            )
+        }
+        MiniIconButton(glyph = "✎", onClick = onRename)
+        MiniIconButton(glyph = "✕", onClick = onDelete, hoverColor = WColor.danger)
+    }
+}
+
+@Composable
+private fun MiniIconButton(
+    glyph: String,
+    onClick: () -> Unit,
+    hoverColor: Color? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val tint = if (hovered && hoverColor != null) hoverColor else WColor.muted
+    Box(
+        modifier =
+            Modifier
+                .size(22.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .hoverable(interaction)
+                .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = glyph, style = WTypography.labelSmall.copy(color = tint, lineHeight = 12.sp))
+    }
+}
+
+@Composable
+private fun SidebarHeader(text: String) {
+    Spacer(modifier = Modifier.height(6.dp))
+    Text(text = text, style = WTypography.labelMedium.copy(color = WColor.muted))
+    Spacer(modifier = Modifier.height(2.dp))
+}
+
+/** A collapsible section header with a trailing ＋ button (used by Tags). Click the label/chevron to
+ * fold the section away when the list grows long. */
+@Composable
+private fun SidebarSectionHeader(
+    text: String,
+    collapsed: Boolean,
+    onToggleCollapsed: () -> Unit,
+    onAdd: () -> Unit,
+) {
+    Spacer(modifier = Modifier.height(6.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(end = 3.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(6.dp))
+                    .clickable(onClick = onToggleCollapsed)
+                    .padding(vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
+            Text(
+                text = if (collapsed) "▸" else "▾",
+                style = WTypography.labelSmall.copy(color = WColor.faint, lineHeight = 10.sp)
+            )
+            Text(text = text, style = WTypography.labelMedium.copy(color = WColor.muted))
+        }
+        MiniIconButton(glyph = "＋", onClick = onAdd)
+    }
+    Spacer(modifier = Modifier.height(2.dp))
+}
+
+@Composable
+private fun SidebarRow(
+    label: String,
+    count: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(if (selected) WColor.accent.copy(alpha = 0.12f) else Color.Transparent)
+                .border(
+                    1.dp,
+                    if (selected) WColor.accent.copy(alpha = 0.55f) else Color.Transparent,
+                    RoundedCornerShape(8.dp)
+                ).clickable(onClick = onClick)
+                .padding(horizontal = 9.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = WTypography.bodyMedium.copy(color = if (selected) WColor.text else WColor.muted),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = "$count",
+            style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.faint)
+        )
+    }
+}
+
+// ── Toolbar (search + sort + group) ──────────────────────────────────────────────────────────
+
+@Composable
+private fun LibraryToolbar(
+    ui: UiState,
+    onSearchChange: (String) -> Unit,
+    onSortChange: (LibrarySort) -> Unit,
+    onToggleGroup: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(WDimens.gap),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            SearchField(query = ui.librarySearch, onQueryChange = onSearchChange)
+        }
+        SortDropdown(selected = ui.librarySort, onSelect = onSortChange)
+        GroupToggle(checked = ui.libraryGroupByClass, onToggle = onToggleGroup)
+    }
+}
+
+private fun LibrarySort.labelKey(): Tr =
+    when (this) {
+        LibrarySort.NEWEST -> Tr.SORT_NEWEST
+        LibrarySort.OLDEST -> Tr.SORT_OLDEST
+        LibrarySort.NAME -> Tr.SORT_NAME
+        LibrarySort.LEVEL -> Tr.SORT_LEVEL
+    }
+
+@Composable
+private fun SortDropdown(
+    selected: LibrarySort,
+    onSelect: (LibrarySort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        Row(
+            modifier =
+                Modifier
+                    .height(40.dp)
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(WColor.surface)
+                    .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                    .clickable { expanded = true }
+                    .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = tr(Tr.LIBRARY_SORT), style = WTypography.labelSmall.copy(color = WColor.muted))
+            Spacer(modifier = Modifier.width(7.dp))
+            Text(text = tr(selected.labelKey()), style = WTypography.labelMedium.copy(color = WColor.text))
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "▾", style = WTypography.labelSmall.copy(lineHeight = 10.sp))
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            containerColor = WColor.surface,
+            border = BorderStroke(1.dp, WColor.border)
+        ) {
+            LibrarySort.entries.forEach { sort ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = tr(sort.labelKey()),
+                            style = WTypography.bodyMedium.copy(color = if (sort == selected) WColor.accent else WColor.text)
+                        )
+                    },
+                    onClick = {
+                        onSelect(sort)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupToggle(
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .height(40.dp)
+                .clip(RoundedCornerShape(9.dp))
+                .background(WColor.surface)
+                .border(1.dp, if (checked) WColor.accent.copy(alpha = 0.55f) else WColor.border, RoundedCornerShape(9.dp))
+                .clickable(onClick = onToggle)
+                .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(16.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(if (checked) WColor.accent else Color.Transparent)
+                    .border(1.dp, if (checked) WColor.accent else WColor.border, RoundedCornerShape(4.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            if (checked) {
+                Text(text = "✓", style = WTypography.labelSmall.copy(color = WColor.bg, lineHeight = 12.sp))
+            }
+        }
+        Text(
+            text = tr(Tr.LIBRARY_GROUP_BY_CLASS),
+            style = WTypography.labelMedium.copy(color = if (checked) WColor.text else WColor.muted)
+        )
     }
 }
 
@@ -153,7 +653,7 @@ private fun BuildCard(
     onLoad: () -> Unit,
     onCompare: () -> Unit,
     onDuplicate: () -> Unit,
-    onRename: () -> Unit,
+    onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val dateFormatter = remember { DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM) }
@@ -191,24 +691,27 @@ private fun BuildCard(
     ) {
         Row(verticalAlignment = Alignment.Top) {
             Column(modifier = Modifier.weight(1f)) {
-                // Full name on hover — long names (and the "(copy)" suffix) get ellipsized in the card.
-                LabelTooltip(text = entry.name, modifier = Modifier.fillMaxWidth()) {
+                // Full name in a tooltip too, so a name truncated at two lines stays fully readable.
+                WTooltip(text = entry.name) {
                     Text(
                         text = entry.name,
                         style = WTypography.titleMedium.copy(color = WColor.text, fontWeight = FontWeight.SemiBold),
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
                 Text(
-                    text = "${entry.classDisplayName()} · ${tr(Tr.LEVEL_SHORT)} ${entry.request.level} · $date",
+                    text = date,
                     style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.muted)
                 )
             }
+            Spacer(modifier = Modifier.width(8.dp))
             HeadlineBadge(entry = entry)
         }
+        Spacer(modifier = Modifier.height(9.dp))
+        PillsRow(entry = entry)
         Spacer(modifier = Modifier.height(11.dp))
-        IconBand(entry = entry)
+        SlotMiniGrid(entry = entry)
         if (entry.note != null) {
             Spacer(modifier = Modifier.height(9.dp))
             Text(
@@ -219,14 +722,83 @@ private fun BuildCard(
             )
         }
         Spacer(modifier = Modifier.height(12.dp))
-        // One compact row: the two primary actions stay labelled; the rest are tooltipped icons so
-        // more cards fit on screen at once.
-        Row(horizontalArrangement = Arrangement.spacedBy(7.dp), verticalAlignment = Alignment.CenterVertically) {
-            CardButton(text = tr(Tr.ACTION_LOAD), filled = true, color = WColor.accent, onClick = onLoad, modifier = Modifier.weight(1f))
-            CardButton(text = tr(Tr.ACTION_COMPARE), filled = false, color = WColor.accent2, onClick = onCompare, modifier = Modifier.weight(1f))
-            IconButton(glyph = "🗐", tooltip = tr(Tr.ACTION_DUPLICATE), onClick = onDuplicate)
-            IconButton(glyph = "✎", tooltip = tr(Tr.ACTION_RENAME), onClick = onRename)
-            IconButton(glyph = "🗑", tooltip = tr(Tr.ACTION_DELETE), onClick = onDelete)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(7.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Primary action keeps a text label (clearest); secondary actions are compact glyphs.
+            CardButton(
+                text = tr(Tr.ACTION_LOAD),
+                filled = true,
+                color = WColor.accent,
+                onClick = onLoad,
+                modifier = Modifier.weight(1f)
+            )
+            ActionIconButton(glyph = "⇄", tooltip = tr(Tr.ACTION_COMPARE), onClick = onCompare)
+            ActionIconButton(glyph = "⧉", tooltip = tr(Tr.ACTION_DUPLICATE), onClick = onDuplicate)
+            ActionIconButton(glyph = "✎", tooltip = tr(Tr.ACTION_RENAME), onClick = onEdit)
+            ActionIconButton(glyph = "✕", tooltip = tr(Tr.ACTION_DELETE), hoverColor = WColor.danger, onClick = onDelete)
+        }
+    }
+}
+
+/** A small Compose-Desktop tooltip wrapper in the app's dark style. */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun WTooltip(
+    text: String,
+    content: @Composable () -> Unit,
+) {
+    TooltipArea(
+        delayMillis = 350,
+        tooltip = {
+            Box(
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(7.dp))
+                        .background(WColor.raised)
+                        .border(1.dp, WColor.border, RoundedCornerShape(7.dp))
+                        .padding(horizontal = 9.dp, vertical = 6.dp)
+            ) {
+                Text(text = text, style = WTypography.labelSmall.copy(color = WColor.text))
+            }
+        },
+        content = content
+    )
+}
+
+/**
+ * A square line-glyph action button (theme-consistent monochrome, not emoji) with a tooltip. Stays
+ * neutral by default; if [hoverColor] is set, the glyph and border take that colour on hover (used to
+ * flag the destructive delete action in red).
+ */
+@Composable
+private fun ActionIconButton(
+    glyph: String,
+    tooltip: String,
+    onClick: () -> Unit,
+    hoverColor: Color? = null,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val active = hovered && hoverColor != null
+    WTooltip(text = tooltip) {
+        Box(
+            modifier =
+                Modifier
+                    .size(34.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(WColor.raised)
+                    .border(1.dp, if (active) hoverColor!!.copy(alpha = 0.6f) else WColor.border, RoundedCornerShape(8.dp))
+                    .hoverable(interaction)
+                    .clickable(onClick = onClick),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = glyph,
+                style = WTypography.titleMedium.copy(color = if (active) hoverColor!! else WColor.muted, lineHeight = 16.sp)
+            )
         }
     }
 }
@@ -249,16 +821,114 @@ private fun HeadlineBadge(entry: HistoryEntry) {
 }
 
 @Composable
-private fun IconBand(entry: HistoryEntry) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        entry.result.equipments.take(14).forEach { equipment ->
-            Box(modifier = Modifier.weight(1f, fill = false)) {
-                ItemThumbnail(equipment = equipment, size = 26.dp)
+private fun PillsRow(entry: HistoryEntry) {
+    // Meta pills first, then up to 4 user-tag pills (a "+n" pill standing in for the rest). Pills
+    // wrap 3-per-row so a long set never overflows the card.
+    val metaPills =
+        listOf(
+            entry.classDisplayName(),
+            "${tr(Tr.LEVEL_SHORT)} ${entry.request.level}",
+            tr(if (entry.isMasteryMode()) Tr.MODE_MASTERIES else Tr.MODE_PRECISION)
+        )
+    val tagAccent = WColor.accent2.copy(alpha = 0.35f)
+    val shownTags = entry.tags.take(4)
+    val overflow = entry.tags.size - shownTags.size
+    val pills =
+        metaPills.map { it to WColor.border } +
+            shownTags.map { it to tagAccent } +
+            if (overflow > 0) listOf("+$overflow" to tagAccent) else emptyList()
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        pills.chunked(3).forEach { rowPills ->
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                rowPills.forEach { (text, color) -> MetaPill(text = text, borderColor = color) }
             }
+        }
+    }
+}
+
+@Composable
+private fun MetaPill(
+    text: String,
+    borderColor: Color = WColor.border,
+) {
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(WColor.raised)
+                .border(1.dp, borderColor, RoundedCornerShape(999.dp))
+                .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(
+            text = text,
+            style = WTypography.labelSmall.copy(color = WColor.text),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+// A compact echo of the paperdoll: two flanking columns (left + right gear) with the central area
+// left empty (no character render, by design), and the weapons / pet / mount along the bottom.
+// A two-handed weapon shows in both weapon tiles (mirrors the paperdoll); legitimately-empty slots
+// stay visible as dimmed glyph tiles (the solver leaves e.g. the mount empty by design).
+@Composable
+private fun SlotMiniGrid(entry: HistoryEntry) {
+    val assignments = remember(entry.result.equipments) { slotAssignments(entry.result.equipments) }
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val gap = 4.dp
+        // Tiles sized so the 4-wide bottom row spans the full card width → the U is flush to the edges.
+        val tile = ((maxWidth - gap * 3) / 4).coerceAtLeast(18.dp)
+        // Spread the two arms so they line up with the outer tiles of the bottom row → a U.
+        val armGap = tile * 2 + gap * 3
+
+        @Composable
+        fun tileFor(slot: me.chosante.ui.paperdoll.DollSlot) = SlotTile(equipment = assignments[slot.id], glyph = slot.glyph, size = tile)
+
+        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(gap)) {
+            // Five paired rows: left-column gear | empty centre | right-column gear.
+            leftSlots.indices.forEach { i ->
+                Row(horizontalArrangement = Arrangement.spacedBy(armGap), verticalAlignment = Alignment.CenterVertically) {
+                    tileFor(leftSlots[i])
+                    tileFor(rightSlots[i])
+                }
+            }
+            // Weapons + pet + mount close the U along the bottom.
+            Row(horizontalArrangement = Arrangement.spacedBy(gap)) {
+                bottomSlots.forEach { tileFor(it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SlotTile(
+    equipment: me.chosante.common.Equipment?,
+    glyph: String,
+    size: androidx.compose.ui.unit.Dp,
+) {
+    if (equipment != null) {
+        Box(
+            modifier =
+                Modifier
+                    .size(size)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(WColor.raised)
+                    .border(1.dp, equipment.rarity.color().copy(alpha = 0.55f), RoundedCornerShape(6.dp))
+        ) {
+            ItemThumbnail(equipment = equipment, size = size)
+        }
+    } else {
+        Box(
+            modifier =
+                Modifier
+                    .size(size)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(WColor.raised)
+                    .border(1.dp, WColor.hairline, RoundedCornerShape(6.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = glyph, style = WTypography.labelSmall.copy(color = WColor.faint))
         }
     }
 }
@@ -288,59 +958,6 @@ private fun CardButton(
             overflow = TextOverflow.Ellipsis
         )
     }
-}
-
-@Composable
-private fun IconButton(
-    glyph: String,
-    tooltip: String,
-    onClick: () -> Unit,
-) {
-    LabelTooltip(text = tooltip) {
-        Box(
-            modifier =
-                Modifier
-                    .size(34.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(WColor.raised)
-                    .border(1.dp, WColor.border, RoundedCornerShape(8.dp))
-                    .clickable(onClick = onClick),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(text = glyph, style = WTypography.labelMedium.copy(color = WColor.muted, lineHeight = 14.sp))
-        }
-    }
-}
-
-/**
- * Wraps [content] with a hover tooltip showing a short [text] label, styled like the rest of the app
- * (raised pill, hairline border). Used to name the icon-only card actions and to spell out a build's
- * full name when the card ellipsizes it.
- */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun LabelTooltip(
-    text: String,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    TooltipArea(
-        modifier = modifier,
-        delayMillis = 350,
-        tooltip = {
-            Text(
-                text = text,
-                style = WTypography.labelSmall.copy(color = WColor.text),
-                modifier =
-                    Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(WColor.raised)
-                        .border(1.dp, WColor.border, RoundedCornerShape(8.dp))
-                        .padding(horizontal = 9.dp, vertical = 6.dp)
-            )
-        },
-        content = content
-    )
 }
 
 @Composable

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -198,6 +198,30 @@ enum class Tr(
     LIBRARY_SEARCH("Search builds…", "Rechercher un build…"),
     LIBRARY_NO_MATCH("No build matches your search", "Aucun build ne correspond"),
     LIBRARY_COUNT("saved", "enregistrés"),
+    LIBRARY_ALL_BUILDS("All builds", "Tous les builds"),
+    LIBRARY_CLASSES("Classes", "Classes"),
+    LIBRARY_TAGS("Tags", "Tags"),
+    LIBRARY_SORT("Sort", "Tri"),
+    SORT_NEWEST("Newest", "Plus récents"),
+    SORT_OLDEST("Oldest", "Plus anciens"),
+    SORT_NAME("Name (A–Z)", "Nom (A–Z)"),
+    SORT_LEVEL("Level", "Niveau"),
+    LIBRARY_GROUP_BY_CLASS("Group by class", "Grouper par classe"),
+    LIBRARY_CLEAR_FILTERS("Clear filters", "Effacer les filtres"),
+    LIBRARY_FOLDERS("Folders", "Dossiers"),
+    LIBRARY_UNFILED("Unfiled", "Sans dossier"),
+    FOLDER_LABEL("Folder", "Dossier"),
+    FOLDER_NONE("None", "Aucun"),
+    FOLDER_NEW("New folder…", "Nouveau dossier…"),
+    RENAME_FOLDER_TITLE("Rename folder", "Renommer le dossier"),
+    DELETE_FOLDER_TITLE("Delete folder", "Supprimer le dossier"),
+    DELETE_FOLDER_HINT(
+        "The builds inside are kept and become unfiled.",
+        "Les builds qu'il contient sont conservés et redeviennent sans dossier."
+    ),
+    TOAST_FOLDER_RENAMED("Folder renamed", "Dossier renommé"),
+    TOAST_FOLDERS_MERGED("Folders merged", "Dossiers fusionnés"),
+    TOAST_FOLDER_DELETED("Folder deleted — builds kept", "Dossier supprimé — builds conservés"),
     ACTION_LOAD("Load", "Charger"),
     ACTION_COMPARE("Compare", "Comparer"),
     ACTION_DUPLICATE("Duplicate", "Dupliquer"),
@@ -207,8 +231,24 @@ enum class Tr(
     /** Suffix appended to a duplicated build's name, e.g. "Cra 110 (copy)". */
     DUPLICATE_SUFFIX("copy", "copie"),
 
-    // Rename / delete dialogs
-    RENAME_TITLE("Rename build", "Renommer le build"),
+    // Edit / delete dialogs
+    EDIT_BUILD_TITLE("Edit build", "Modifier le build"),
+    TAGS_LABEL("Tags", "Tags"),
+    TAG_ADD_PLACEHOLDER("Type or pick a tag…", "Tape ou choisis un tag…"),
+    TAG_ADD("Add", "Ajouter"),
+    TAG_CREATE("Create", "Créer"),
+    TAG_NONE_LEFT("No tag matches — type to create one", "Aucun tag — tape pour en créer un"),
+    TAG_NEW("New tag", "Nouveau tag"),
+    CREATE_TAG_TITLE("New tag", "Nouveau tag"),
+    RENAME_TAG_TITLE("Rename tag", "Renommer le tag"),
+    DELETE_TAG_TITLE("Delete tag", "Supprimer le tag"),
+    DELETE_TAG_HINT(
+        "The tag is removed from every build. The builds themselves are kept.",
+        "Le tag est retiré de tous les builds. Les builds eux-mêmes sont conservés."
+    ),
+    TOAST_TAG_RENAMED("Tag renamed", "Tag renommé"),
+    TOAST_TAGS_MERGED("Tags merged", "Tags fusionnés"),
+    TOAST_TAG_DELETED("Tag deleted from all builds", "Tag supprimé de tous les builds"),
     DELETE_TITLE("Delete this build?", "Supprimer ce build ?"),
     DELETE_HINT("This permanently removes it from your local library.", "Le retire définitivement de ta bibliothèque locale."),
 

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/DollSlots.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/DollSlots.kt
@@ -1,0 +1,73 @@
+package me.chosante.ui.paperdoll
+
+import me.chosante.common.Equipment
+import me.chosante.common.ItemType
+import me.chosante.ui.i18n.Tr
+
+// The 14 paperdoll slots and the (tricky) item → slot mapping. Shared by the paperdoll panel and
+// the library's build-card mini-grid so the slot layout is derived in exactly one place. The
+// ring1/ring2 split and the two-handed-weapon-fills-both-weapon-tiles rule live here and nowhere
+// else — see DollSlotsTest for the pinned contract.
+
+internal data class DollSlot(
+    val id: String,
+    val labelKey: Tr,
+    val glyph: String,
+)
+
+internal val leftSlots =
+    listOf(
+        DollSlot("helmet", Tr.SLOT_HELMET, "⛨"),
+        DollSlot("amulet", Tr.SLOT_AMULET, "◌"),
+        DollSlot("epaul", Tr.SLOT_EPAULETTES, "▱"),
+        DollSlot("chest", Tr.SLOT_BREASTPLATE, "▢"),
+        DollSlot("cape", Tr.SLOT_CAPE, "⊳")
+    )
+
+internal val rightSlots =
+    listOf(
+        DollSlot("emblem", Tr.SLOT_EMBLEM, "✦"),
+        DollSlot("belt", Tr.SLOT_BELT, "═"),
+        DollSlot("ring1", Tr.SLOT_RING_I, "◯"),
+        DollSlot("ring2", Tr.SLOT_RING_II, "◯"),
+        DollSlot("boots", Tr.SLOT_BOOTS, "⊓")
+    )
+
+internal val bottomSlots =
+    listOf(
+        DollSlot("weapon", Tr.SLOT_WEAPON, "⚔"),
+        DollSlot("weapon2", Tr.SLOT_SECOND_WEAPON, "⛉"),
+        DollSlot("pet", Tr.SLOT_PET, "❀"),
+        DollSlot("mount", Tr.SLOT_MOUNT, "≋")
+    )
+
+internal fun slotAssignments(equipments: List<Equipment>): Map<String, Equipment> {
+    val rings = equipments.filter { it.itemType == ItemType.RING }
+    val twoHanded = equipments.firstOrNull { it.itemType == ItemType.TWO_HANDED_WEAPONS }
+    val oneHanded = equipments.firstOrNull { it.itemType == ItemType.ONE_HANDED_WEAPONS }
+    val offHand = equipments.firstOrNull { it.itemType == ItemType.OFF_HAND_WEAPONS }
+    return buildMap {
+        putFirst("helmet", equipments, ItemType.HELMET)
+        putFirst("amulet", equipments, ItemType.AMULET)
+        putFirst("epaul", equipments, ItemType.SHOULDER_PADS)
+        putFirst("chest", equipments, ItemType.CHEST_PLATE)
+        putFirst("cape", equipments, ItemType.CAPE)
+        putFirst("emblem", equipments, ItemType.EMBLEM)
+        putFirst("belt", equipments, ItemType.BELT)
+        rings.getOrNull(0)?.let { put("ring1", it) }
+        rings.getOrNull(1)?.let { put("ring2", it) }
+        putFirst("boots", equipments, ItemType.BOOTS)
+        (twoHanded ?: oneHanded)?.let { put("weapon", it) }
+        (if (twoHanded != null) twoHanded else offHand)?.let { put("weapon2", it) }
+        putFirst("pet", equipments, ItemType.PETS)
+        putFirst("mount", equipments, ItemType.MOUNTS)
+    }
+}
+
+internal fun MutableMap<String, Equipment>.putFirst(
+    key: String,
+    equipments: List<Equipment>,
+    type: ItemType,
+) {
+    equipments.firstOrNull { it.itemType == type }?.let { put(key, it) }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.PopupPositionProvider
 import me.chosante.common.Equipment
-import me.chosante.common.ItemType
 import me.chosante.common.RuneColor
 import me.chosante.common.RuneType
 import me.chosante.ui.components.RarityIcon
@@ -838,69 +837,6 @@ private fun SlotMeta(
             }
         }
     }
-}
-
-private data class DollSlot(
-    val id: String,
-    val labelKey: Tr,
-    val glyph: String,
-)
-
-private val leftSlots =
-    listOf(
-        DollSlot("helmet", Tr.SLOT_HELMET, "⛨"),
-        DollSlot("amulet", Tr.SLOT_AMULET, "◌"),
-        DollSlot("epaul", Tr.SLOT_EPAULETTES, "▱"),
-        DollSlot("chest", Tr.SLOT_BREASTPLATE, "▢"),
-        DollSlot("cape", Tr.SLOT_CAPE, "⊳")
-    )
-
-private val rightSlots =
-    listOf(
-        DollSlot("emblem", Tr.SLOT_EMBLEM, "✦"),
-        DollSlot("belt", Tr.SLOT_BELT, "═"),
-        DollSlot("ring1", Tr.SLOT_RING_I, "◯"),
-        DollSlot("ring2", Tr.SLOT_RING_II, "◯"),
-        DollSlot("boots", Tr.SLOT_BOOTS, "⊓")
-    )
-
-private val bottomSlots =
-    listOf(
-        DollSlot("weapon", Tr.SLOT_WEAPON, "⚔"),
-        DollSlot("weapon2", Tr.SLOT_SECOND_WEAPON, "⛉"),
-        DollSlot("pet", Tr.SLOT_PET, "❀"),
-        DollSlot("mount", Tr.SLOT_MOUNT, "≋")
-    )
-
-private fun slotAssignments(equipments: List<Equipment>): Map<String, Equipment> {
-    val rings = equipments.filter { it.itemType == ItemType.RING }
-    val twoHanded = equipments.firstOrNull { it.itemType == ItemType.TWO_HANDED_WEAPONS }
-    val oneHanded = equipments.firstOrNull { it.itemType == ItemType.ONE_HANDED_WEAPONS }
-    val offHand = equipments.firstOrNull { it.itemType == ItemType.OFF_HAND_WEAPONS }
-    return buildMap {
-        putFirst("helmet", equipments, ItemType.HELMET)
-        putFirst("amulet", equipments, ItemType.AMULET)
-        putFirst("epaul", equipments, ItemType.SHOULDER_PADS)
-        putFirst("chest", equipments, ItemType.CHEST_PLATE)
-        putFirst("cape", equipments, ItemType.CAPE)
-        putFirst("emblem", equipments, ItemType.EMBLEM)
-        putFirst("belt", equipments, ItemType.BELT)
-        rings.getOrNull(0)?.let { put("ring1", it) }
-        rings.getOrNull(1)?.let { put("ring2", it) }
-        putFirst("boots", equipments, ItemType.BOOTS)
-        (twoHanded ?: oneHanded)?.let { put("weapon", it) }
-        (if (twoHanded != null) twoHanded else offHand)?.let { put("weapon2", it) }
-        putFirst("pet", equipments, ItemType.PETS)
-        putFirst("mount", equipments, ItemType.MOUNTS)
-    }
-}
-
-private fun MutableMap<String, Equipment>.putFirst(
-    key: String,
-    equipments: List<Equipment>,
-    type: ItemType,
-) {
-    equipments.firstOrNull { it.itemType == type }?.let { put(key, it) }
 }
 
 /** True when [equipment] is currently pinned as required. Matched on the French name, like ItemChip. */

--- a/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
@@ -38,6 +38,7 @@ import me.chosante.ui.state.Modal
 import me.chosante.ui.state.Phase
 import me.chosante.ui.state.PickerMode
 import me.chosante.ui.state.Screen
+import me.chosante.ui.state.folderCounts
 import me.chosante.ui.state.statCatalog
 import me.chosante.ui.stats.StatsPanel
 import me.chosante.ui.theme.WColor
@@ -108,9 +109,21 @@ fun AppShell(
                                 onLoad = model::loadBuild,
                                 onCompare = model::startCompare,
                                 onDuplicate = model::duplicateBuild,
-                                onRename = model::requestRename,
+                                onEdit = model::requestEdit,
                                 onDelete = model::requestDelete,
-                                onGoBuilder = { model.goToScreen(Screen.Builder) }
+                                onToggleTag = model::toggleLibraryTag,
+                                onCreateTag = model::requestCreateTag,
+                                onRenameTag = model::requestRenameTag,
+                                onDeleteTag = model::requestDeleteTag,
+                                onFolderFilterChange = model::setLibraryFolderFilter,
+                                onRenameFolder = model::requestRenameFolder,
+                                onDeleteFolder = model::requestDeleteFolder,
+                                onGoBuilder = { model.goToScreen(Screen.Builder) },
+                                onSearchChange = model::setLibrarySearch,
+                                onSortChange = model::setLibrarySort,
+                                onClassFilterChange = model::setLibraryClassFilter,
+                                onToggleGroup = model::toggleLibraryGroupByClass,
+                                onClearFilters = model::clearLibraryFilters
                             )
 
                         Screen.Compare ->
@@ -133,10 +146,27 @@ fun AppShell(
                 onDismiss = model::closeModal,
                 suggestedSaveName = model.suggestedSaveName(),
                 isEditingExisting = ui.activeBuildId != null,
-                takenNames = model.takenBuildNames(),
+                // Save dialog excludes the *active* build's name; the Edit dialog must exclude the
+                // *edited* build's name (it may differ from the active build) so its inline
+                // duplicate-name warning matches what editBuild() will actually accept.
+                takenNames =
+                    (ui.modal as? Modal.EditBuild)?.let { m ->
+                        ui.savedBuilds
+                            .filter { it.id != m.id }
+                            .map { it.name.trim().lowercase() }
+                            .toSet()
+                    } ?: model.takenBuildNames(),
+                editingEntry = (ui.modal as? Modal.EditBuild)?.let { m -> ui.savedBuilds.firstOrNull { it.id == m.id } },
+                existingFolders = folderCounts(ui.savedBuilds).map { it.first },
+                existingTags = ui.knownTags,
                 onSaveBuild = model::saveBuild,
-                onRenameBuild = model::renameBuild,
+                onEditBuild = model::editBuild,
                 onDeleteBuild = model::deleteBuild,
+                onRenameFolder = model::renameFolder,
+                onDeleteFolder = model::deleteFolder,
+                onCreateTag = model::createTag,
+                onRenameTag = model::renameTag,
+                onDeleteTag = model::deleteTag,
                 onConfirmReSearch = model::confirmReSearch
             )
         }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -31,6 +31,7 @@ import me.chosante.createZenithBuild
 import me.chosante.ui.components.IconPreloader
 import me.chosante.ui.components.warmUpPaths
 import me.chosante.ui.history.HistoryRepository
+import me.chosante.ui.history.normalizeTags
 import me.chosante.ui.history.restoredClass
 import me.chosante.ui.history.restoredMode
 import me.chosante.ui.history.suggestedBuildName
@@ -99,8 +100,10 @@ class BuildSearchModel(
     private val openBrowser: (String) -> Unit = { link -> Desktop.getDesktop().browse(URI(link)) },
     private val copyToClipboard: (String) -> Unit = { link -> Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(link), null) },
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Swing,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val historyRepository: HistoryRepository = HistoryRepository(),
+    /** Persisted library view options (sort + group-by-class). Injectable for tests. */
+    private val libraryPreferences: LibraryPreferences = LibraryPreferences(),
     /** Wakfu game-data version stamped onto saved builds (injectable for tests). */
     private val dataVersion: String = WakfuBestBuildFinderAlgorithm.dataVersion,
     private val idGenerator: () -> String = {
@@ -141,6 +144,17 @@ class BuildSearchModel(
 
     private var job: Job? = null
 
+    /** Persisted tag registry (display casing). Tags here survive having no build, until deleted. */
+    private var tagRegistry: List<String> = emptyList()
+
+    /** Union of the registry and tags currently on [builds], de-duped case-insensitively, A–Z. */
+    private fun computeKnownTags(builds: List<me.chosante.common.history.HistoryEntry>): List<String> =
+        (tagRegistry + builds.flatMap { it.tags })
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinctBy { it.lowercase() }
+            .sortedBy { it.lowercase() }
+
     /** Mirrors [me.chosante.ui.SCREENSHOT_PATH_PROPERTY] / `WAKFU_COMPOSE_SCREENSHOT` (see Main.kt). */
     private val isScreenshotMode =
         System.getProperty("wakfu.compose.screenshot") != null ||
@@ -162,11 +176,15 @@ class BuildSearchModel(
             System.getenv("WAKFU_COMPOSE_SCREENSHOT_VARY_PRIORITY") != null
 
     init {
+        // Seed the persisted library view options + tag registry before any UI reads them.
+        tagRegistry = libraryPreferences.loadTags()
+        ui = ui.copy(librarySort = libraryPreferences.loadSort(), libraryGroupByClass = libraryPreferences.loadGroupByClass())
+
         // Load the saved-build library off the UI thread. A read failure must never block startup —
         // it just yields an empty library that fills in as the user saves builds.
         scope.launch(ioDispatcher) {
             val all = runCatching { historyRepository.loadAll() }.getOrDefault(emptyList())
-            withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all) }
+            withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all, knownTags = computeKnownTags(all)) }
         }
 
         if (isScreenshotMode) {
@@ -714,6 +732,48 @@ class BuildSearchModel(
         ui = ui.copy(screen = screen)
     }
 
+    // --- Library organize (search / sort / filter / group) ---
+
+    fun setLibrarySearch(query: String) {
+        ui = ui.copy(librarySearch = query)
+    }
+
+    fun setLibrarySort(sort: LibrarySort) {
+        ui = ui.copy(librarySort = sort)
+        libraryPreferences.saveSort(sort)
+    }
+
+    /** Single-select class filter; passing the already-selected class (or null) clears it. */
+    fun setLibraryClassFilter(clazz: me.chosante.common.CharacterClass?) {
+        ui = ui.copy(libraryClassFilter = clazz)
+    }
+
+    /** Toggles a tag in the active filter (OR semantics: builds matching any selected tag are shown). */
+    fun toggleLibraryTag(tag: String) {
+        val key = tag.lowercase()
+        ui =
+            ui.copy(
+                librarySelectedTags = if (key in ui.librarySelectedTags) ui.librarySelectedTags - key else ui.librarySelectedTags + key
+            )
+    }
+
+    fun toggleLibraryGroupByClass() {
+        val next = !ui.libraryGroupByClass
+        ui = ui.copy(libraryGroupByClass = next)
+        libraryPreferences.saveGroupByClass(next)
+    }
+
+    /** Resets the in-memory library filters (search + class + tags + folder). Sort/group are durable. */
+    fun clearLibraryFilters() {
+        ui =
+            ui.copy(
+                librarySearch = "",
+                libraryClassFilter = null,
+                librarySelectedTags = emptySet(),
+                libraryFolder = LibraryFolderFilter.All
+            )
+    }
+
     /** Opens the save dialog, pre-filling the name (existing name when editing a loaded build). */
     fun requestSaveBuild() {
         if (ui.build == null) return
@@ -745,16 +805,29 @@ class BuildSearchModel(
         asNew: Boolean,
     ) {
         val trimmedName = name.trim().ifBlank { ui.suggestedBuildName() }
-        val id = if (!asNew && ui.activeBuildId != null) ui.activeBuildId!! else idGenerator()
-        val entry = ui.toHistoryEntry(id = id, name = trimmedName, note = note, createdAt = clock(), dataVersion = dataVersion) ?: return
+        val overwrite = !asNew && ui.activeBuildId != null
+        val id = if (overwrite) ui.activeBuildId!! else idGenerator()
+        // Overwriting rebuilds the entry from the workspace, which doesn't carry user metadata (tags,
+        // folder) — re-read them from the existing entry so an "Update build" never silently wipes them.
+        val existing = if (overwrite) ui.savedBuilds.firstOrNull { it.id == id } else null
+        val entry =
+            ui.toHistoryEntry(
+                id = id,
+                name = trimmedName,
+                note = note,
+                createdAt = clock(),
+                dataVersion = dataVersion,
+                tags = existing?.tags ?: emptyList(),
+                folder = existing?.folder
+            ) ?: return
         // Note: saving does NOT lock search. The lock guards *revisiting* a build loaded from the
         // library (a deliberate act); right after saving you should stay free to keep iterating.
         ui = ui.copy(modal = null, activeBuildId = id, activeBuildName = trimmedName)
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             runCatching { historyRepository.save(entry) }
                 .onSuccess {
                     val all = historyRepository.loadAll()
-                    withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all, toast = Tr.TOAST_BUILD_SAVED.value(ui.lang)) }
+                    withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all, knownTags = computeKnownTags(all), toast = Tr.TOAST_BUILD_SAVED.value(ui.lang)) }
                 }.onFailure { throwable ->
                     withContext(mainDispatcher) { ui = ui.copy(error = throwable.message ?: "Could not save build") }
                 }
@@ -815,16 +888,22 @@ class BuildSearchModel(
         ui = UiState(lang = ui.lang, savedBuilds = ui.savedBuilds, screen = Screen.Builder)
     }
 
-    fun requestRename(
-        id: String,
-        currentName: String,
-    ) {
-        ui = ui.copy(modal = Modal.RenameBuild(id, currentName))
+    /** Opens the Edit-build dialog (name + note + tags + folder). The dialog resolves the entry by id. */
+    fun requestEdit(id: String) {
+        ui = ui.copy(modal = Modal.EditBuild(id))
     }
 
-    fun renameBuild(
+    /**
+     * Saves edited metadata for a saved build (name, note, tags, folder). This is also how a build
+     * moves between folders and how a new folder is created (a folder exists iff a build references
+     * it). Keeps names unique and updates the active-build name.
+     */
+    fun editBuild(
         id: String,
         newName: String,
+        note: String?,
+        tags: List<String>,
+        folder: String?,
     ) {
         val trimmed = newName.trim()
         val entry = ui.savedBuilds.firstOrNull { it.id == id }
@@ -832,18 +911,35 @@ class BuildSearchModel(
             ui = ui.copy(modal = null)
             return
         }
-        // Reject a rename that would collide with a *different* build's name, keeping names unique.
+        // Reject an edit that would collide with a *different* build's name, keeping names unique.
         val collides = ui.savedBuilds.any { it.id != id && it.name.trim().equals(trimmed, ignoreCase = true) }
         if (collides) {
             ui = ui.copy(modal = null, toast = Tr.SAVE_NAME_TAKEN.value(ui.lang))
             return
         }
-        val renamed = entry.copy(name = trimmed)
+        val normalizedTags = normalizeTags(tags)
+        val edited =
+            entry.copy(
+                name = trimmed,
+                note = note?.takeIf { it.isNotBlank() },
+                tags = normalizedTags,
+                folder = canonicalFolder(folder)
+            )
+        // Assigning a tag also registers it (so it persists even once removed from every build).
+        registerTags(normalizedTags)
         ui = ui.copy(modal = null, activeBuildName = if (ui.activeBuildId == id) trimmed else ui.activeBuildName)
-        scope.launch(Dispatchers.IO) {
-            runCatching { historyRepository.save(renamed) }
+        scope.launch(ioDispatcher) {
+            runCatching { historyRepository.save(edited) }
             val all = historyRepository.loadAll()
-            withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all) }
+            withContext(mainDispatcher) {
+                ui =
+                    ui.copy(
+                        savedBuilds = all,
+                        knownTags = computeKnownTags(all),
+                        libraryFolder = ui.libraryFolder.coercedTo(all),
+                        librarySelectedTags = ui.librarySelectedTags.coercedToTags(all)
+                    )
+            }
         }
     }
 
@@ -857,7 +953,7 @@ class BuildSearchModel(
     fun duplicateBuild(id: String) {
         val source = ui.savedBuilds.firstOrNull { it.id == id } ?: return
         val copy = source.copy(id = idGenerator(), name = uniqueCopyName(source.name), createdAt = clock())
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             runCatching { historyRepository.save(copy) }
                 .onSuccess {
                     val all = historyRepository.loadAll()
@@ -891,7 +987,7 @@ class BuildSearchModel(
     /**
      * A unique "<name> (copy)" — falling back to "(copy 2)", "(copy 3)", … when needed — so a
      * duplicate never collides with an existing build name. Names are kept unique so the library and
-     * compare view stay unambiguous, mirroring the [renameBuild]/[saveBuild] guards.
+     * compare view stay unambiguous, mirroring the [editBuild]/[saveBuild] guards.
      */
     private fun uniqueCopyName(baseName: String): String {
         val suffix = Tr.DUPLICATE_SUFFIX.value(ui.lang)
@@ -902,6 +998,183 @@ class BuildSearchModel(
         var n = 2
         while ("$base ($suffix $n)".lowercase() in taken) n++
         return "$base ($suffix $n)"
+    }
+
+    /** Adds [tags] to the persisted registry (case-insensitively de-duped) and saves it. */
+    private fun registerTags(tags: List<String>) {
+        val merged = (tagRegistry + tags).map { it.trim() }.filter { it.isNotBlank() }.distinctBy { it.lowercase() }
+        if (merged.size != tagRegistry.size) {
+            tagRegistry = merged
+            libraryPreferences.saveTags(merged)
+        }
+    }
+
+    // --- Folders (implicit: a folder exists iff ≥1 build references it) ---
+
+    fun setLibraryFolderFilter(filter: LibraryFolderFilter) {
+        ui = ui.copy(libraryFolder = filter)
+    }
+
+    fun requestRenameFolder(name: String) {
+        ui = ui.copy(modal = Modal.RenameFolder(name))
+    }
+
+    fun requestDeleteFolder(name: String) {
+        ui = ui.copy(modal = Modal.ConfirmDeleteFolder(name))
+    }
+
+    /**
+     * Renames [oldName] to [newNameRaw] across every member. If another folder already matches
+     * case-insensitively, this **merges** into that folder's canonical casing. No-op when blank or
+     * unchanged. Runs as a single IO pass with one reload at the end.
+     */
+    fun renameFolder(
+        oldName: String,
+        newNameRaw: String,
+    ) {
+        val newName = newNameRaw.trim()
+        if (newName.isBlank() || newName == oldName) {
+            ui = ui.copy(modal = null)
+            return
+        }
+        // Merge when the target name already exists (case-insensitively): adopt its canonical casing.
+        val existingMatch = ui.savedBuilds.mapNotNull { it.folder }.firstOrNull { it.equals(newName, ignoreCase = true) && it != oldName }
+        val canonical = existingMatch ?: newName
+        val merged = existingMatch != null
+        val members = ui.savedBuilds.filter { it.folder == oldName }
+        ui =
+            ui.copy(
+                modal = null,
+                toast = (if (merged) Tr.TOAST_FOLDERS_MERGED else Tr.TOAST_FOLDER_RENAMED).value(ui.lang),
+                libraryFolder = if (ui.libraryFolder == LibraryFolderFilter.Named(oldName)) LibraryFolderFilter.Named(canonical) else ui.libraryFolder,
+                activeBuildName = ui.activeBuildName
+            )
+        scope.launch(ioDispatcher) {
+            members.forEach { runCatching { historyRepository.save(it.copy(folder = canonical)) } }
+            val all = historyRepository.loadAll()
+            withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all, libraryFolder = ui.libraryFolder.coercedTo(all)) }
+        }
+    }
+
+    /** Deletes [name] by unfiling its members (the builds themselves are kept). */
+    fun deleteFolder(name: String) {
+        val members = ui.savedBuilds.filter { it.folder == name }
+        ui =
+            ui.copy(
+                modal = null,
+                toast = Tr.TOAST_FOLDER_DELETED.value(ui.lang),
+                libraryFolder = if (ui.libraryFolder == LibraryFolderFilter.Named(name)) LibraryFolderFilter.All else ui.libraryFolder
+            )
+        scope.launch(ioDispatcher) {
+            members.forEach { runCatching { historyRepository.save(it.copy(folder = null)) } }
+            val all = historyRepository.loadAll()
+            withContext(mainDispatcher) { ui = ui.copy(savedBuilds = all, libraryFolder = ui.libraryFolder.coercedTo(all)) }
+        }
+    }
+
+    /** If a Named filter points at a folder no build references anymore, fall back to All. */
+    private fun LibraryFolderFilter.coercedTo(builds: List<me.chosante.common.history.HistoryEntry>): LibraryFolderFilter =
+        if (this is LibraryFolderFilter.Named && builds.none { it.folder == name }) LibraryFolderFilter.All else this
+
+    /**
+     * Normalizes a folder name on assignment: blank → null, and a case-variant of an existing folder
+     * adopts that folder's canonical casing (so picking "pvp" when "PvP" exists doesn't split them).
+     */
+    private fun canonicalFolder(raw: String?): String? {
+        val trimmed = raw?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        return ui.savedBuilds.mapNotNull { it.folder }.firstOrNull { it.equals(trimmed, ignoreCase = true) } ?: trimmed
+    }
+
+    // --- Tags (first-class: a registry of named tags, assignable to builds, persisted) ---
+
+    fun requestCreateTag() {
+        ui = ui.copy(modal = Modal.CreateTag)
+    }
+
+    fun requestRenameTag(name: String) {
+        ui = ui.copy(modal = Modal.RenameTag(name))
+    }
+
+    fun requestDeleteTag(name: String) {
+        ui = ui.copy(modal = Modal.ConfirmDeleteTag(name))
+    }
+
+    /** Creates a standalone tag in the registry (no build assignment). No-op on blank/duplicate. */
+    fun createTag(nameRaw: String) {
+        val name = nameRaw.trim()
+        if (name.isBlank() || tagRegistry.any { it.equals(name, ignoreCase = true) }) {
+            ui = ui.copy(modal = null)
+            return
+        }
+        tagRegistry = tagRegistry + name
+        libraryPreferences.saveTags(tagRegistry)
+        ui = ui.copy(modal = null, knownTags = computeKnownTags(ui.savedBuilds))
+    }
+
+    /**
+     * Renames tag [oldName] to [newNameRaw] across every build that carries it. If another tag already
+     * matches case-insensitively, this **merges** into that tag's canonical casing (de-duped per build).
+     * No-op when blank or unchanged. One IO pass, one reload.
+     */
+    fun renameTag(
+        oldName: String,
+        newNameRaw: String,
+    ) {
+        val newName = newNameRaw.trim()
+        if (newName.isBlank() || newName.equals(oldName, ignoreCase = true)) {
+            ui = ui.copy(modal = null)
+            return
+        }
+        val existingMatch = tagRegistry.firstOrNull { it.equals(newName, ignoreCase = true) && !it.equals(oldName, ignoreCase = true) }
+        val canonical = existingMatch ?: newName
+        val merged = existingMatch != null
+        // Update the registry: drop the old name, ensure the canonical one is present.
+        tagRegistry = (tagRegistry.filterNot { it.equals(oldName, ignoreCase = true) } + canonical).distinctBy { it.lowercase() }
+        libraryPreferences.saveTags(tagRegistry)
+        val members = ui.savedBuilds.filter { entry -> entry.tags.any { it.equals(oldName, ignoreCase = true) } }
+        ui =
+            ui.copy(
+                modal = null,
+                toast = (if (merged) Tr.TOAST_TAGS_MERGED else Tr.TOAST_TAG_RENAMED).value(ui.lang),
+                knownTags = computeKnownTags(ui.savedBuilds)
+            )
+        scope.launch(ioDispatcher) {
+            members.forEach { entry ->
+                val renamed = entry.tags.map { if (it.equals(oldName, ignoreCase = true)) canonical else it }
+                runCatching { historyRepository.save(entry.copy(tags = normalizeTags(renamed))) }
+            }
+            val all = historyRepository.loadAll()
+            withContext(mainDispatcher) {
+                ui = ui.copy(savedBuilds = all, knownTags = computeKnownTags(all), librarySelectedTags = ui.librarySelectedTags.coercedToTags(all))
+            }
+        }
+    }
+
+    /** Deletes tag [name] entirely: from the registry and from every build (the builds are kept). */
+    fun deleteTag(name: String) {
+        tagRegistry = tagRegistry.filterNot { it.equals(name, ignoreCase = true) }
+        libraryPreferences.saveTags(tagRegistry)
+        val members = ui.savedBuilds.filter { entry -> entry.tags.any { it.equals(name, ignoreCase = true) } }
+        ui = ui.copy(modal = null, toast = Tr.TOAST_TAG_DELETED.value(ui.lang), knownTags = computeKnownTags(ui.savedBuilds))
+        scope.launch(ioDispatcher) {
+            members.forEach { entry ->
+                runCatching { historyRepository.save(entry.copy(tags = entry.tags.filterNot { it.equals(name, ignoreCase = true) })) }
+            }
+            val all = historyRepository.loadAll()
+            withContext(mainDispatcher) {
+                ui = ui.copy(savedBuilds = all, knownTags = computeKnownTags(all), librarySelectedTags = ui.librarySelectedTags.coercedToTags(all))
+            }
+        }
+    }
+
+    /**
+     * Drops any active tag-filter key that no longer exists — neither carried by a build nor in the
+     * registry. A renamed/deleted tag is cleared, but a still-valid standalone (0-build) tag the user
+     * is filtering by is kept.
+     */
+    private fun Set<String>.coercedToTags(builds: List<me.chosante.common.history.HistoryEntry>): Set<String> {
+        val present = (builds.flatMap { it.tags } + tagRegistry).map { it.lowercase() }.toSet()
+        return this intersect present
     }
 
     fun requestDelete(
@@ -937,7 +1210,7 @@ class BuildSearchModel(
 
     fun deleteBuild(id: String) {
         ui = ui.copy(modal = null)
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             runCatching { historyRepository.delete(id) }
             val all = historyRepository.loadAll()
             withContext(mainDispatcher) {
@@ -949,7 +1222,10 @@ class BuildSearchModel(
                         activeBuildName = if (wasActive) null else ui.activeBuildName,
                         searchLocked = if (wasActive) false else ui.searchLocked,
                         compareA = if (ui.compareA == id) null else ui.compareA,
-                        compareB = if (ui.compareB == id) null else ui.compareB
+                        compareB = if (ui.compareB == id) null else ui.compareB,
+                        knownTags = computeKnownTags(all),
+                        libraryFolder = ui.libraryFolder.coercedTo(all),
+                        librarySelectedTags = ui.librarySelectedTags.coercedToTags(all)
                     )
             }
         }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/LibraryOrganize.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/LibraryOrganize.kt
@@ -1,0 +1,126 @@
+package me.chosante.ui.state
+
+import me.chosante.common.CharacterClass
+import me.chosante.common.history.HistoryEntry
+import me.chosante.ui.history.classDisplayName
+import me.chosante.ui.history.restoredClass
+
+// The library's filter + sort + group pipeline, kept as pure (non-Compose) functions so it can be
+// unit-tested directly and the screen stays a thin renderer over its result.
+
+/** One rendered section of the library. [clazz] is null for the single ungrouped section. */
+data class LibraryGroup(
+    val clazz: CharacterClass?,
+    val builds: List<HistoryEntry>,
+)
+
+/** Display label for a class in the library (e.g. `Cra`), matching [HistoryEntry.classDisplayName]. */
+fun CharacterClass.libraryLabel(): String = name.lowercase().replaceFirstChar { it.titlecase() }
+
+/**
+ * Filters, sorts and (optionally) groups [builds] for the library screen. Applied in order:
+ * class filter → search → sort → group. The class filter keys on the restored enum (never the raw
+ * stored string), so a build whose stored class name differs only in casing still matches. Search
+ * matches the build name OR its class display name (case-insensitive substring).
+ */
+fun organizeLibrary(
+    builds: List<HistoryEntry>,
+    search: String,
+    sort: LibrarySort,
+    classFilter: CharacterClass?,
+    groupByClass: Boolean,
+    selectedTags: Set<String> = emptySet(),
+    folder: LibraryFolderFilter = LibraryFolderFilter.All,
+): List<LibraryGroup> {
+    val query = search.trim()
+    val filtered =
+        builds
+            .filter { entry ->
+                when (folder) {
+                    LibraryFolderFilter.All -> true
+                    LibraryFolderFilter.Unfiled -> entry.folder == null
+                    is LibraryFolderFilter.Named -> entry.folder == folder.name
+                }
+            }.filter { classFilter == null || it.restoredClass() == classFilter }
+            // Tag filter is OR: with tags selected, keep builds carrying *any* of them. Empty = no filter.
+            .filter { entry -> selectedTags.isEmpty() || entry.tags.any { it.lowercase() in selectedTags } }
+            .filter { entry ->
+                query.isBlank() ||
+                    entry.name.contains(query, ignoreCase = true) ||
+                    entry.classDisplayName().contains(query, ignoreCase = true) ||
+                    entry.tags.any { it.contains(query, ignoreCase = true) }
+            }
+    val sorted = filtered.sortedWith(sort.comparator())
+    if (!groupByClass) {
+        return listOf(LibraryGroup(null, sorted))
+    }
+    return sorted
+        .groupBy { it.restoredClass() }
+        .map { (clazz, entries) -> LibraryGroup(clazz, entries) }
+        .sortedBy { it.clazz!!.libraryLabel().lowercase() }
+}
+
+/** Comparator implementing each [LibrarySort] (see the plan §2 for the exact tie-breaks). */
+private fun LibrarySort.comparator(): Comparator<HistoryEntry> =
+    when (this) {
+        LibrarySort.NEWEST -> compareByDescending { it.createdAt }
+        LibrarySort.OLDEST -> compareBy { it.createdAt }
+        LibrarySort.NAME -> compareBy<HistoryEntry> { it.name.lowercase() }.thenByDescending { it.createdAt }
+        LibrarySort.LEVEL -> compareByDescending<HistoryEntry> { it.request.level }.thenByDescending { it.createdAt }
+    }
+
+/** Classes with ≥1 saved build and their counts, ordered by display label A–Z. */
+fun classCounts(builds: List<HistoryEntry>): List<Pair<CharacterClass, Int>> =
+    builds
+        .groupingBy { it.restoredClass() }
+        .eachCount()
+        .toList()
+        .sortedBy { it.first.libraryLabel().lowercase() }
+
+/**
+ * Distinct tags across [builds] with their counts, aggregated case-insensitively (first-seen casing
+ * kept for display), ordered by display label A–Z. Drives the sidebar's tag filter section.
+ */
+fun tagCounts(builds: List<HistoryEntry>): List<Pair<String, Int>> {
+    val displayByKey = LinkedHashMap<String, String>()
+    val counts = LinkedHashMap<String, Int>()
+    builds.forEach { entry ->
+        entry.tags.forEach { tag ->
+            val key = tag.lowercase()
+            displayByKey.putIfAbsent(key, tag)
+            counts[key] = (counts[key] ?: 0) + 1
+        }
+    }
+    return counts.entries
+        .map { (key, count) -> displayByKey.getValue(key) to count }
+        .sortedBy { it.first.lowercase() }
+}
+
+/** Distinct non-null folders with their member counts, ordered by name A–Z (case-insensitive). */
+fun folderCounts(builds: List<HistoryEntry>): List<Pair<String, Int>> =
+    builds
+        .mapNotNull { it.folder }
+        .groupingBy { it }
+        .eachCount()
+        .toList()
+        .sortedBy { it.first.lowercase() }
+
+/** What the tag input offers for a query: matching known-but-unselected tags, and whether the typed
+ * value can be created as a new tag. Pure so the (otherwise Compose-only) tag input is unit-testable. */
+data class TagInputSuggestions(
+    val suggestions: List<String>,
+    val canCreate: Boolean,
+)
+
+fun tagInputSuggestions(
+    known: List<String>,
+    selected: List<String>,
+    rawQuery: String,
+): TagInputSuggestions {
+    val query = rawQuery.trim()
+
+    fun isSelected(tag: String) = selected.any { it.equals(tag, ignoreCase = true) }
+    val suggestions = known.filter { !isSelected(it) && it.contains(query, ignoreCase = true) }
+    val canCreate = query.isNotBlank() && known.none { it.equals(query, ignoreCase = true) } && !isSelected(query)
+    return TagInputSuggestions(suggestions, canCreate)
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/LibraryPreferences.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/LibraryPreferences.kt
@@ -1,0 +1,50 @@
+package me.chosante.ui.state
+
+import java.util.prefs.Preferences
+
+/**
+ * Persists the two *durable* library view options — sort order and group-by-class — across launches
+ * (the active search/class filters are deliberately in-memory and reset each launch). Mirrors
+ * [WarmupTiming]'s Preferences pattern, but as an injectable instance so tests can point it at a
+ * throwaway node. Every access is wrapped in `runCatching`: a prefs failure must never break the UI.
+ */
+class LibraryPreferences(
+    private val prefs: Preferences? =
+        runCatching { Preferences.userRoot().node("me/chosante/wakfu-autobuilder") }.getOrNull(),
+) {
+    fun loadSort(): LibrarySort = runCatching { LibrarySort.valueOf(prefs?.get(KEY_SORT, "") ?: "") }.getOrDefault(LibrarySort.NEWEST)
+
+    fun saveSort(sort: LibrarySort) {
+        runCatching { prefs?.put(KEY_SORT, sort.name) }
+    }
+
+    fun loadGroupByClass(): Boolean = runCatching { prefs?.getBoolean(KEY_GROUP, false) }.getOrNull() ?: false
+
+    fun saveGroupByClass(value: Boolean) {
+        runCatching { prefs?.putBoolean(KEY_GROUP, value) }
+    }
+
+    /**
+     * The persisted tag registry — tags exist as first-class, named entities independent of any build,
+     * so removing a tag from its last build doesn't destroy it. Stored newline-joined (tag names are
+     * single-line). Returns an empty list on any read failure or first launch.
+     */
+    fun loadTags(): List<String> =
+        runCatching {
+            prefs
+                ?.get(KEY_TAGS, "")
+                ?.split("\n")
+                ?.map { it.trim() }
+                ?.filter { it.isNotBlank() }
+        }.getOrNull() ?: emptyList()
+
+    fun saveTags(tags: List<String>) {
+        runCatching { prefs?.put(KEY_TAGS, tags.joinToString("\n")) }
+    }
+
+    private companion object {
+        const val KEY_SORT = "librarySort"
+        const val KEY_GROUP = "libraryGroupByClass"
+        const val KEY_TAGS = "knownTags"
+    }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -50,6 +50,25 @@ enum class CompareSlot {
     B,
 }
 
+/** Ordering options for the build library. See [organizeLibrary]. */
+enum class LibrarySort {
+    NEWEST,
+    OLDEST,
+    NAME,
+    LEVEL,
+}
+
+/** Folder-scoped view of the library: everything, only unfiled, or one named folder. */
+sealed interface LibraryFolderFilter {
+    data object All : LibraryFolderFilter
+
+    data object Unfiled : LibraryFolderFilter
+
+    data class Named(
+        val name: String,
+    ) : LibraryFolderFilter
+}
+
 sealed interface Modal {
     data object AddStat : Modal
 
@@ -60,15 +79,37 @@ sealed interface Modal {
     /** Save-the-current-build dialog (name + optional note). */
     data object SaveBuild : Modal
 
-    /** Rename an existing saved build. */
-    data class RenameBuild(
+    /** Edit a saved build's metadata (name, note, tags, folder). Resolves the entry at render time. */
+    data class EditBuild(
         val id: String,
-        val currentName: String,
     ) : Modal
 
     /** Confirm deleting a saved build. */
     data class ConfirmDelete(
         val id: String,
+        val name: String,
+    ) : Modal
+
+    /** Rename (or merge) a folder. */
+    data class RenameFolder(
+        val name: String,
+    ) : Modal
+
+    /** Confirm deleting a folder (members are kept, become unfiled). */
+    data class ConfirmDeleteFolder(
+        val name: String,
+    ) : Modal
+
+    /** Create a new, standalone tag (added to the registry, assignable later). */
+    data object CreateTag : Modal
+
+    /** Rename (or merge) a tag across every build that carries it. */
+    data class RenameTag(
+        val name: String,
+    ) : Modal
+
+    /** Confirm deleting a tag from every build (the builds are kept). */
+    data class ConfirmDeleteTag(
         val name: String,
     ) : Modal
 
@@ -128,6 +169,23 @@ data class UiState(
      * landed; cleared after a short delay.
      */
     val lastDuplicatedBuildId: String? = null,
+    /** Library: free-text search (matches name, class display name, or any tag). In-memory only. */
+    val librarySearch: String = "",
+    /** Active library ordering; persisted across launches via [LibraryPreferences]. */
+    val librarySort: LibrarySort = LibrarySort.NEWEST,
+    /** Single-class filter, or null for all classes. In-memory only (reset each launch). */
+    val libraryClassFilter: CharacterClass? = null,
+    /** Active tag filter (lowercase keys); OR semantics. In-memory only (reset each launch). */
+    val librarySelectedTags: Set<String> = emptySet(),
+    /**
+     * All known tags (the persisted registry ∪ tags currently on builds), display casing, A–Z. Tags
+     * are first-class: a tag stays here even when no build uses it, until explicitly deleted.
+     */
+    val knownTags: List<String> = emptyList(),
+    /** Active folder scope. In-memory only (reset each launch). */
+    val libraryFolder: LibraryFolderFilter = LibraryFolderFilter.All,
+    /** Whether the library groups its cards by class; persisted across launches. */
+    val libraryGroupByClass: Boolean = false,
 )
 
 /**

--- a/gui-compose/src/test/kotlin/me/chosante/ui/components/TagInputUiTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/components/TagInputUiTest.kt
@@ -1,0 +1,85 @@
+package me.chosante.ui.components
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TagInputUiTest {
+    @Test
+    fun `typing filters known tags and clicking a suggestion assigns it`() =
+        runComposeUiTest {
+            val selected = mutableStateListOf<String>()
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    TagInput(
+                        selected = selected.toList(),
+                        known = listOf("PvP", "Solo", "Speedrun"),
+                        onAdd = { tag -> if (selected.none { it.equals(tag, ignoreCase = true) }) selected.add(tag) },
+                        onRemove = { tag -> selected.removeAll { it.equals(tag, ignoreCase = true) } }
+                    )
+                }
+            }
+
+            // Typing filters the known tags: "pv" surfaces "PvP" but not "Solo".
+            onNode(hasSetTextAction()).performTextInput("pv")
+            onNodeWithText("PvP").assertExists()
+            onNodeWithText("Solo").assertDoesNotExist()
+
+            // Clicking the suggestion assigns the tag.
+            onNodeWithText("PvP").performClick()
+            assertThat(selected).containsExactly("PvP")
+        }
+
+    @Test
+    fun `a brand-new name can be created from the input`() =
+        runComposeUiTest {
+            val selected = mutableStateListOf<String>()
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    TagInput(
+                        selected = selected.toList(),
+                        known = listOf("PvP"),
+                        onAdd = { tag -> if (selected.none { it.equals(tag, ignoreCase = true) }) selected.add(tag) },
+                        onRemove = { tag -> selected.removeAll { it.equals(tag, ignoreCase = true) } }
+                    )
+                }
+            }
+
+            onNode(hasSetTextAction()).performTextInput("Healer")
+            // No known tag matches → the create row is offered, then assigns the new tag.
+            onNodeWithText("Create \"Healer\"").performClick()
+            assertThat(selected).containsExactly("Healer")
+        }
+
+    @Test
+    fun `removing a chip unassigns the tag`() =
+        runComposeUiTest {
+            val selected = mutableStateListOf("PvP", "Solo")
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    TagInput(
+                        selected = selected.toList(),
+                        known = listOf("PvP", "Solo"),
+                        onAdd = { tag -> if (selected.none { it.equals(tag, ignoreCase = true) }) selected.add(tag) },
+                        onRemove = { tag -> selected.removeAll { it.equals(tag, ignoreCase = true) } }
+                    )
+                }
+            }
+
+            // Each chip renders its label + a ✕; clicking the ✕ next to "Solo" removes it. (The two
+            // chips share the ✕ glyph, so target by index: chips are laid out in selection order.)
+            onAllNodesWithText("✕").get(1).performClick()
+            assertThat(selected).containsExactly("PvP")
+        }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
@@ -120,4 +120,10 @@ class HistoryMappingTest {
     fun `toHistoryEntry returns null without a build`() {
         assertThat(UiState().toHistoryEntry("id", "name", null, 0L, "v")).isNull()
     }
+
+    @Test
+    fun `normalizeTags trims, drops blanks, and dedupes case-insensitively keeping first casing`() {
+        val normalized = normalizeTags(listOf("  PvP ", "pvp", "", "   ", "Solo", "PVP", "solo"))
+        assertThat(normalized).containsExactly("PvP", "Solo")
+    }
 }

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryRepositoryTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryRepositoryTest.kt
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
+import kotlin.io.path.createDirectories
 
 // NB: each @Test uses a *block body* (not `= runBlocking { … }`). An expression body returns the
 // lambda's value, giving the test a non-Unit return type that JUnit 5 silently skips — block bodies
@@ -96,6 +97,59 @@ class HistoryRepositoryTest {
 
             val loaded = repo.loadAll()
             assertThat(loaded.map { it.name }).containsExactly("good")
+        }
+    }
+
+    @Test
+    fun `save then loadAll round-trips tags and folder`(
+        @TempDir tempDir: Path,
+    ) {
+        runBlocking {
+            val repo = HistoryRepository(baseDir = tempDir, ioDispatcher = Dispatchers.Unconfined)
+            val entry = sampleEntry(id = "t", name = "tagged").copy(tags = listOf("PvP", "Solo"), folder = "Mes builds")
+
+            repo.save(entry)
+
+            val loaded = repo.loadAll().single()
+            assertThat(loaded.tags).containsExactly("PvP", "Solo")
+            assertThat(loaded.folder).isEqualTo("Mes builds")
+        }
+    }
+
+    @Test
+    fun `loadAll defaults tags to empty for a pre-feature JSON without the key`(
+        @TempDir tempDir: Path,
+    ) {
+        runBlocking {
+            val repo = HistoryRepository(baseDir = tempDir, ioDispatcher = Dispatchers.Unconfined)
+            // Hand-written entry JSON predating the tags field — no "tags" key at all.
+            val legacy =
+                """
+                {
+                  "id": "legacy",
+                  "name": "Legacy build",
+                  "createdAt": 1700000000000,
+                  "dataVersion": "1.91.1.54",
+                  "request": {
+                    "clazz": "CRA", "level": 110, "minLevel": 80,
+                    "mode": "FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT",
+                    "maxRarity": "EPIC", "duration": "20", "stopAtMatch": false,
+                    "targets": [], "forcedItems": [], "excludedItems": []
+                  },
+                  "result": { "equipments": [], "skills": {}, "achieved": {}, "match": 90.0, "optimal": false }
+                }
+                """.trimIndent()
+            repo.directory().createDirectories()
+            repo
+                .directory()
+                .resolve("legacy.json")
+                .toFile()
+                .writeText(legacy)
+
+            val loaded = repo.loadAll().single()
+            assertThat(loaded.tags).isEmpty()
+            assertThat(loaded.folder).isNull()
+            assertThat(loaded.name).isEqualTo("Legacy build")
         }
     }
 

--- a/gui-compose/src/test/kotlin/me/chosante/ui/paperdoll/DollSlotsTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/paperdoll/DollSlotsTest.kt
@@ -1,0 +1,65 @@
+package me.chosante.ui.paperdoll
+
+import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.I18nText
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+// slotAssignments is now shared by the paperdoll panel and the library build-card mini-grid, so its
+// trickier rules (ring1/ring2 split, two-handed weapon fills both weapon tiles) are pinned here.
+class DollSlotsTest {
+    @Test
+    fun `two rings land in ring1 and ring2 in list order`() {
+        val ringA = item(1, ItemType.RING, "Anneau A")
+        val ringB = item(2, ItemType.RING, "Anneau B")
+
+        val assignments = slotAssignments(listOf(ringA, ringB))
+
+        assertThat(assignments["ring1"]).isEqualTo(ringA)
+        assertThat(assignments["ring2"]).isEqualTo(ringB)
+    }
+
+    @Test
+    fun `a two-handed weapon fills both weapon tiles`() {
+        val staff = item(3, ItemType.TWO_HANDED_WEAPONS, "Bâton")
+
+        val assignments = slotAssignments(listOf(staff))
+
+        assertThat(assignments["weapon"]).isEqualTo(staff)
+        assertThat(assignments["weapon2"]).isEqualTo(staff)
+    }
+
+    @Test
+    fun `one-handed goes to weapon and off-hand to weapon2`() {
+        val sword = item(4, ItemType.ONE_HANDED_WEAPONS, "Épée")
+        val shield = item(5, ItemType.OFF_HAND_WEAPONS, "Bouclier")
+
+        val assignments = slotAssignments(listOf(sword, shield))
+
+        assertThat(assignments["weapon"]).isEqualTo(sword)
+        assertThat(assignments["weapon2"]).isEqualTo(shield)
+    }
+
+    @Test
+    fun `an empty equipment list yields an empty map`() {
+        assertThat(slotAssignments(emptyList())).isEmpty()
+    }
+
+    private fun item(
+        id: Int,
+        type: ItemType,
+        name: String,
+    ): Equipment =
+        Equipment(
+            equipmentId = id,
+            guiId = id,
+            level = 100,
+            name = I18nText(fr = name, en = name, es = "", pt = ""),
+            rarity = Rarity.RARE,
+            itemType = type,
+            characteristics = mapOf(Characteristic.MASTERY_DISTANCE to 10)
+        )
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
@@ -101,7 +101,7 @@ class BuildSearchModelE2ETest {
                 .map { it.characteristic }
                 .filter {
                     it == MASTERY_ELEMENTARY ||
-                            it in setOf(MASTERY_ELEMENTARY_FIRE, MASTERY_ELEMENTARY_EARTH, MASTERY_ELEMENTARY_WATER, MASTERY_ELEMENTARY_WIND)
+                        it in setOf(MASTERY_ELEMENTARY_FIRE, MASTERY_ELEMENTARY_EARTH, MASTERY_ELEMENTARY_WATER, MASTERY_ELEMENTARY_WIND)
                 }.toSet()
 
         try {

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelLibraryTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelLibraryTest.kt
@@ -1,0 +1,531 @@
+package me.chosante.ui.state
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import me.chosante.autobuilder.domain.BuildCombination
+import me.chosante.autobuilder.genetic.GeneticAlgorithmResult
+import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.I18nText
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.skills.CharacterSkills
+import me.chosante.ui.history.HistoryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.math.BigDecimal
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+class BuildSearchModelLibraryTest {
+    @Test
+    fun `editBuild persists name, note and tags and updates the active name`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+
+            model.editBuild(id, "Renamed", "my note", listOf("PvP", "pvp", "Solo"), folder = null)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .firstOrNull { it.id == id }
+                    ?.tags
+                    ?.isNotEmpty() == true
+            }
+
+            val saved = model.ui.savedBuilds.single { it.id == id }
+            assertThat(saved.name).isEqualTo("Renamed")
+            assertThat(saved.note).isEqualTo("my note")
+            assertThat(saved.tags).containsExactly("PvP", "Solo") // case-insensitive dedupe
+            assertThat(model.ui.activeBuildName).isEqualTo("Renamed")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `editBuild into another build's name is rejected with a toast and no write`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val idA = saveFreshBuild(model, name = "Alpha")
+            model.clearActiveBuild()
+            val idB = saveFreshBuild(model, name = "Beta")
+
+            model.editBuild(idA, "Beta", null, emptyList(), folder = null)
+
+            assertThat(model.ui.toast).isNotNull()
+            assertThat(
+                model.ui.savedBuilds
+                    .single { it.id == idA }
+                    .name
+            ).isEqualTo("Alpha")
+            assertThat(idB).isNotEqualTo(idA)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `resaving a loaded build preserves its tags`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Tagged", null, listOf("PvP"), folder = null)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags == listOf("PvP")
+            }
+
+            model.loadBuild(id)
+            // "Update build": overwrite the same entry from the workspace (asNew = false).
+            model.saveBuild(name = "Tagged", note = null, asNew = false)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .firstOrNull { it.id == id }
+                    ?.name == "Tagged"
+            }
+
+            assertThat(
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags
+            ).containsExactly("PvP")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `editBuild creates, then clears, a folder`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+
+            model.editBuild(id, "Build", null, emptyList(), folder = "  Mes builds  ")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == "Mes builds"
+            }
+
+            model.editBuild(id, "Build", null, emptyList(), folder = "   ")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == null
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `renameFolder rewrites every member`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val a = saveFreshBuild(model, name = "A")
+            model.clearActiveBuild()
+            val b = saveFreshBuild(model, name = "B")
+            model.editBuild(a, "A", null, emptyList(), folder = "Old")
+            model.editBuild(b, "B", null, emptyList(), folder = "Old")
+            awaitUntil { model.ui.savedBuilds.count { it.folder == "Old" } == 2 }
+
+            model.renameFolder("Old", "New")
+            awaitUntil { model.ui.savedBuilds.count { it.folder == "New" } == 2 }
+            assertThat(model.ui.savedBuilds.none { it.folder == "Old" }).isTrue()
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `renameFolder into an existing name merges with the canonical casing`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val a = saveFreshBuild(model, name = "A")
+            model.clearActiveBuild()
+            val b = saveFreshBuild(model, name = "B")
+            model.editBuild(a, "A", null, emptyList(), folder = "Pvp")
+            model.editBuild(b, "B", null, emptyList(), folder = "Solo")
+            awaitUntil { model.ui.savedBuilds.any { it.folder == "Pvp" } && model.ui.savedBuilds.any { it.folder == "Solo" } }
+
+            // Rename "Solo" → "PVP": merges into the existing "Pvp" folder (its canonical casing wins).
+            model.renameFolder("Solo", "PVP")
+            awaitUntil { model.ui.savedBuilds.count { it.folder == "Pvp" } == 2 }
+            assertThat(model.ui.savedBuilds.none { it.folder == "Solo" || it.folder == "PVP" }).isTrue()
+            assertThat(model.ui.toast).isEqualTo("Folders merged")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `deleteFolder unfiles its members and resets a pointing filter`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Build", null, emptyList(), folder = "Trash")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == "Trash"
+            }
+            model.setLibraryFolderFilter(LibraryFolderFilter.Named("Trash"))
+
+            model.deleteFolder("Trash")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == null
+            }
+            assertThat(model.ui.libraryFolder).isEqualTo(LibraryFolderFilter.All)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `resaving a loaded build preserves its folder`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Filed", null, emptyList(), folder = "Keep")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == "Keep"
+            }
+
+            model.loadBuild(id)
+            model.saveBuild(name = "Filed", note = null, asNew = false)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .name == "Filed"
+            }
+
+            assertThat(
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder
+            ).isEqualTo("Keep")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `deleting the last build of the filtered folder resets the filter to All`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Only", null, emptyList(), folder = "Lonely")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .folder == "Lonely"
+            }
+            model.setLibraryFolderFilter(LibraryFolderFilter.Named("Lonely"))
+
+            model.deleteBuild(id)
+            awaitUntil { model.ui.savedBuilds.none { it.id == id } }
+            assertThat(model.ui.libraryFolder).isEqualTo(LibraryFolderFilter.All)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a tag survives being removed from every build (it stays in the registry)`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Build", null, listOf("Keep"), folder = null)
+            awaitUntil { model.ui.knownTags.contains("Keep") }
+
+            // Remove it from the only build that had it.
+            model.editBuild(id, "Build", null, emptyList(), folder = null)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags
+                    .isEmpty()
+            }
+
+            // The tag is still known (assignable again) — it wasn't implicitly destroyed.
+            assertThat(model.ui.knownTags).contains("Keep")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `createTag adds a standalone tag with no build assignment`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            saveFreshBuild(model)
+
+            model.createTag("  Solo  ")
+            assertThat(model.ui.knownTags).contains("Solo")
+            assertThat(model.ui.savedBuilds.flatMap { it.tags }).doesNotContain("Solo")
+
+            // Duplicates (case-insensitive) are ignored.
+            model.createTag("solo")
+            assertThat(model.ui.knownTags.count { it.equals("solo", ignoreCase = true) }).isEqualTo(1)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `renameTag rewrites the tag on every build that carries it`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val a = saveFreshBuild(model, name = "A")
+            model.clearActiveBuild()
+            val b = saveFreshBuild(model, name = "B")
+            model.editBuild(a, "A", null, listOf("Old"), folder = null)
+            model.editBuild(b, "B", null, listOf("Old", "Keep"), folder = null)
+            awaitUntil { model.ui.savedBuilds.count { it.tags.contains("Old") } == 2 }
+
+            model.renameTag("Old", "New")
+            awaitUntil { model.ui.savedBuilds.count { it.tags.contains("New") } == 2 }
+            assertThat(model.ui.savedBuilds.none { it.tags.contains("Old") }).isTrue()
+            // Unrelated tags are untouched.
+            assertThat(
+                model.ui.savedBuilds
+                    .single { it.id == b }
+                    .tags
+            ).containsExactlyInAnyOrder("New", "Keep")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `renameTag into an existing tag merges with its canonical casing`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val a = saveFreshBuild(model, name = "A")
+            model.clearActiveBuild()
+            val b = saveFreshBuild(model, name = "B")
+            model.editBuild(a, "A", null, listOf("Pvp"), folder = null)
+            model.editBuild(b, "B", null, listOf("Solo"), folder = null)
+            awaitUntil { model.ui.savedBuilds.any { it.tags.contains("Pvp") } && model.ui.savedBuilds.any { it.tags.contains("Solo") } }
+
+            // "Solo" → "PVP" merges into the existing "Pvp" tag (its casing wins).
+            model.renameTag("Solo", "PVP")
+            awaitUntil { model.ui.savedBuilds.count { it.tags.contains("Pvp") } == 2 }
+            assertThat(model.ui.savedBuilds.none { it.tags.any { t -> t == "Solo" || t == "PVP" } }).isTrue()
+            assertThat(model.ui.toast).isEqualTo("Tags merged")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `deleteTag removes the tag from every build and clears a pointing filter`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.editBuild(id, "Build", null, listOf("Gone", "Keep"), folder = null)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags
+                    .contains("Gone")
+            }
+            model.toggleLibraryTag("Gone")
+            assertThat(model.ui.librarySelectedTags).contains("gone")
+
+            model.deleteTag("Gone")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags == listOf("Keep")
+            }
+            assertThat(model.ui.librarySelectedTags).doesNotContain("gone")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a selected standalone (zero-build) tag filter survives an unrelated edit`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val id = saveFreshBuild(model)
+            model.createTag("Wip") // standalone, on zero builds
+            model.toggleLibraryTag("Wip")
+            assertThat(model.ui.librarySelectedTags).contains("wip")
+
+            // Editing an unrelated build triggers a reload + filter coercion; the registry tag must stay.
+            model.editBuild(id, "Build", null, listOf("Other"), folder = null)
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == id }
+                    .tags == listOf("Other")
+            }
+
+            assertThat(model.ui.librarySelectedTags).contains("wip")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `assigning a folder adopts the casing of an existing one (no case-variant duplicate)`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            val a = saveFreshBuild(model, name = "A")
+            model.clearActiveBuild()
+            val b = saveFreshBuild(model, name = "B")
+            model.editBuild(a, "A", null, emptyList(), folder = "PvP")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == a }
+                    .folder == "PvP"
+            }
+
+            // Assign a case-variant of the existing folder → canonicalized to "PvP", not a new "pvp".
+            model.editBuild(b, "B", null, emptyList(), folder = "pvp")
+            awaitUntil {
+                model.ui.savedBuilds
+                    .single { it.id == b }
+                    .folder != null
+            }
+
+            assertThat(
+                model.ui.savedBuilds
+                    .single { it.id == b }
+                    .folder
+            ).isEqualTo("PvP")
+            assertThat(
+                model.ui.savedBuilds
+                    .mapNotNull { it.folder }
+                    .toSet()
+            ).containsExactly("PvP")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+    private fun model(
+        scope: CoroutineScope,
+        tempDir: Path,
+    ): BuildSearchModel =
+        BuildSearchModel(
+            scope = scope,
+            buildFinder = {
+                flowOf(
+                    GeneticAlgorithmResult(
+                        individual = fakeBuild(),
+                        matchPercentage = BigDecimal("100"),
+                        progressPercentage = 100,
+                        isOptimal = true
+                    )
+                )
+            },
+            zenithBuilder = { "" },
+            mainDispatcher = Dispatchers.Unconfined,
+            historyRepository = HistoryRepository(baseDir = tempDir, ioDispatcher = Dispatchers.Unconfined),
+            libraryPreferences = LibraryPreferences(null)
+        )
+
+    /** Runs a search to populate a workspace build, then saves it as a new library entry. Returns its id. */
+    private suspend fun saveFreshBuild(
+        model: BuildSearchModel,
+        name: String = "Build",
+    ): String {
+        model.setDuration("1")
+        model.search()
+        awaitUntil { model.ui.phase == Phase.Done }
+        model.saveBuild(name = name, note = null, asNew = true)
+        awaitUntil { model.ui.savedBuilds.any { it.name == name } }
+        return model.ui.savedBuilds
+            .first { it.name == name }
+            .id
+    }
+
+    private fun fakeBuild(): BuildCombination =
+        BuildCombination(
+            equipments =
+                listOf(
+                    Equipment(
+                        equipmentId = 1,
+                        guiId = 1,
+                        level = 110,
+                        name = I18nText(fr = "Cape", en = "Cape", es = "", pt = ""),
+                        rarity = Rarity.LEGENDARY,
+                        itemType = ItemType.CAPE,
+                        characteristics = mapOf(Characteristic.MASTERY_DISTANCE to 60)
+                    )
+                ),
+            characterSkills = CharacterSkills(110)
+        )
+
+    private suspend fun awaitUntil(predicate: () -> Boolean) {
+        withTimeout(25.seconds) {
+            while (!predicate()) {
+                delay(25)
+            }
+        }
+    }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/LibraryOrganizeTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/LibraryOrganizeTest.kt
@@ -1,0 +1,282 @@
+package me.chosante.ui.state
+
+import me.chosante.common.CharacterClass
+import me.chosante.common.Rarity
+import me.chosante.common.history.HistoryEntry
+import me.chosante.common.history.RequestSnapshot
+import me.chosante.common.history.ResultSnapshot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.prefs.Preferences
+
+class LibraryOrganizeTest {
+    @Test
+    fun `NEWEST and OLDEST order by createdAt`() {
+        val builds = listOf(entry("a", clazz = "CRA", createdAt = 1_000), entry("b", clazz = "CRA", createdAt = 3_000), entry("c", clazz = "CRA", createdAt = 2_000))
+
+        assertThat(organize(builds, sort = LibrarySort.NEWEST).single().builds.map { it.name })
+            .containsExactly("b", "c", "a")
+        assertThat(organize(builds, sort = LibrarySort.OLDEST).single().builds.map { it.name })
+            .containsExactly("a", "c", "b")
+    }
+
+    @Test
+    fun `NAME sorts case-insensitively and tie-breaks on createdAt desc`() {
+        val builds =
+            listOf(
+                entry("banana", createdAt = 1),
+                entry("Apple", createdAt = 1),
+                entry("apple", createdAt = 5)
+            )
+        // "apple"/"Apple" tie on lowercase name → newer (createdAt 5) first.
+        assertThat(organize(builds, sort = LibrarySort.NAME).single().builds.map { it.name })
+            .containsExactly("apple", "Apple", "banana")
+    }
+
+    @Test
+    fun `LEVEL sorts by request level desc, tie-break createdAt desc`() {
+        val builds =
+            listOf(
+                entry("low", level = 50, createdAt = 9),
+                entry("high-old", level = 200, createdAt = 1),
+                entry("high-new", level = 200, createdAt = 7)
+            )
+        assertThat(organize(builds, sort = LibrarySort.LEVEL).single().builds.map { it.name })
+            .containsExactly("high-new", "high-old", "low")
+    }
+
+    @Test
+    fun `search matches name and class display name, case-insensitively`() {
+        val builds =
+            listOf(
+                entry("My Distance Build", clazz = "CRA"),
+                entry("Tank", clazz = "FECA")
+            )
+        assertThat(organize(builds, search = "distance").single().builds.map { it.name }).containsExactly("My Distance Build")
+        // Class display name is "Feca"; matching by class works case-insensitively.
+        assertThat(organize(builds, search = "fec").single().builds.map { it.name }).containsExactly("Tank")
+        assertThat(organize(builds, search = "zzz").single().builds).isEmpty()
+    }
+
+    @Test
+    fun `class filter matches via the restored enum, regardless of stored casing`() {
+        val builds =
+            listOf(
+                entry("a", clazz = "cra"), // lowercase stored name still resolves to CRA
+                entry("b", clazz = "IOP")
+            )
+        assertThat(organize(builds, classFilter = CharacterClass.CRA).single().builds.map { it.name }).containsExactly("a")
+    }
+
+    @Test
+    fun `groupByClass keys on the enum, orders groups by label, preserves in-group sort`() {
+        val builds =
+            listOf(
+                entry("iop1", clazz = "IOP", createdAt = 1),
+                entry("cra1", clazz = "CRA", createdAt = 5),
+                entry("cra2", clazz = "CRA", createdAt = 9),
+                entry("iop2", clazz = "IOP", createdAt = 3)
+            )
+        val groups = organize(builds, sort = LibrarySort.NEWEST, groupByClass = true)
+        // Groups ordered by label A–Z: Cra before Iop.
+        assertThat(groups.map { it.clazz }).containsExactly(CharacterClass.CRA, CharacterClass.IOP)
+        assertThat(groups[0].builds.map { it.name }).containsExactly("cra2", "cra1")
+        assertThat(groups[1].builds.map { it.name }).containsExactly("iop2", "iop1")
+    }
+
+    @Test
+    fun `empty input yields one empty ungrouped section`() {
+        val groups = organize(emptyList())
+        assertThat(groups).hasSize(1)
+        assertThat(groups.single().clazz).isNull()
+        assertThat(groups.single().builds).isEmpty()
+    }
+
+    @Test
+    fun `classCounts lists only classes present, ordered by label`() {
+        val builds = listOf(entry("a", clazz = "IOP"), entry("b", clazz = "CRA"), entry("c", clazz = "CRA"))
+        assertThat(classCounts(builds)).containsExactly(CharacterClass.CRA to 2, CharacterClass.IOP to 1)
+    }
+
+    @Test
+    fun `tag filter is OR and case-insensitive`() {
+        val builds =
+            listOf(
+                entry("both", tags = listOf("PvP", "Solo")),
+                entry("pvp-only", tags = listOf("pvp")),
+                entry("solo-only", tags = listOf("Solo")),
+                entry("none", tags = emptyList())
+            )
+        // Single tag selects every build carrying it (case-insensitively).
+        assertThat(organize(builds, selectedTags = setOf("pvp")).single().builds.map { it.name })
+            .containsExactlyInAnyOrder("both", "pvp-only")
+        // Multiple tags = OR: any build carrying at least one of them.
+        assertThat(organize(builds, selectedTags = setOf("pvp", "solo")).single().builds.map { it.name })
+            .containsExactlyInAnyOrder("both", "pvp-only", "solo-only")
+    }
+
+    @Test
+    fun `search matches a tag`() {
+        val builds = listOf(entry("a", tags = listOf("Speedrun")), entry("b", tags = emptyList()))
+        assertThat(organize(builds, search = "speed").single().builds.map { it.name }).containsExactly("a")
+    }
+
+    @Test
+    fun `tagCounts aggregates case-insensitively keeping first casing, ordered by label`() {
+        val builds =
+            listOf(
+                entry("a", tags = listOf("PvP", "Solo")),
+                entry("b", tags = listOf("pvp"))
+            )
+        assertThat(tagCounts(builds)).containsExactly("PvP" to 2, "Solo" to 1)
+    }
+
+    // ── LibraryPreferences ──────────────────────────────────────────────────────────────────
+
+    private val testNode: Preferences = Preferences.userRoot().node("me/chosante/wakfu-autobuilder-test")
+
+    @AfterEach
+    fun cleanup() {
+        runCatching { testNode.removeNode() }
+    }
+
+    @Test
+    fun `LibraryPreferences round-trips sort and group`() {
+        val prefs = LibraryPreferences(testNode)
+        prefs.saveSort(LibrarySort.LEVEL)
+        prefs.saveGroupByClass(true)
+
+        val reloaded = LibraryPreferences(testNode)
+        assertThat(reloaded.loadSort()).isEqualTo(LibrarySort.LEVEL)
+        assertThat(reloaded.loadGroupByClass()).isTrue()
+    }
+
+    @Test
+    fun `LibraryPreferences falls back on an invalid stored sort`() {
+        testNode.put("librarySort", "NOT_A_REAL_SORT")
+        assertThat(LibraryPreferences(testNode).loadSort()).isEqualTo(LibrarySort.NEWEST)
+    }
+
+    @Test
+    fun `LibraryPreferences round-trips the tag registry`() {
+        LibraryPreferences(testNode).saveTags(listOf("PvP", "Solo", "Speedrun"))
+        assertThat(LibraryPreferences(testNode).loadTags()).containsExactly("PvP", "Solo", "Speedrun")
+    }
+
+    @Test
+    fun `LibraryPreferences loads an empty tag registry by default`() {
+        assertThat(LibraryPreferences(testNode).loadTags()).isEmpty()
+    }
+
+    @Test
+    fun `LibraryPreferences defaults when nothing stored`() {
+        val prefs = LibraryPreferences(testNode)
+        assertThat(prefs.loadSort()).isEqualTo(LibrarySort.NEWEST)
+        assertThat(prefs.loadGroupByClass()).isFalse()
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `folder filter selects All, Unfiled, or a named folder`() {
+        val builds =
+            listOf(
+                entry("filed-a", folder = "Pvp"),
+                entry("filed-b", folder = "Solo"),
+                entry("loose", folder = null)
+            )
+        assertThat(organize(builds, folder = LibraryFolderFilter.All).single().builds).hasSize(3)
+        assertThat(organize(builds, folder = LibraryFolderFilter.Unfiled).single().builds.map { it.name }).containsExactly("loose")
+        assertThat(organize(builds, folder = LibraryFolderFilter.Named("Pvp")).single().builds.map { it.name }).containsExactly("filed-a")
+    }
+
+    // ── tagInputSuggestions (the tag input's pure filter/create logic) ───────────────────────
+
+    @Test
+    fun `tagInputSuggestions filters known tags by query, excluding already-selected ones`() {
+        val result = tagInputSuggestions(known = listOf("PvP", "Solo", "Speedrun"), selected = listOf("Solo"), rawQuery = "s")
+        // "s" matches Solo & Speedrun, but Solo is already selected → only Speedrun is offered.
+        assertThat(result.suggestions).containsExactly("Speedrun")
+        assertThat(result.canCreate).isTrue() // "s" isn't an exact known/selected tag
+    }
+
+    @Test
+    fun `tagInputSuggestions offers create only for a genuinely new name`() {
+        val known = listOf("PvP")
+        assertThat(tagInputSuggestions(known, selected = emptyList(), rawQuery = "  Healer ").canCreate).isTrue()
+        // Exact (case-insensitive) match to a known tag → no create.
+        assertThat(tagInputSuggestions(known, selected = emptyList(), rawQuery = "pvp").canCreate).isFalse()
+        // Already selected → no create.
+        assertThat(tagInputSuggestions(known, selected = listOf("Healer"), rawQuery = "healer").canCreate).isFalse()
+        // Blank → no create.
+        assertThat(tagInputSuggestions(known, selected = emptyList(), rawQuery = "   ").canCreate).isFalse()
+    }
+
+    @Test
+    fun `tagInputSuggestions with a blank query lists every unselected tag`() {
+        val result = tagInputSuggestions(known = listOf("PvP", "Solo"), selected = listOf("PvP"), rawQuery = "")
+        assertThat(result.suggestions).containsExactly("Solo")
+        assertThat(result.canCreate).isFalse()
+    }
+
+    @Test
+    fun `folderCounts lists non-null folders ordered by name`() {
+        val builds =
+            listOf(
+                entry("a", folder = "Zeta"),
+                entry("b", folder = "alpha"),
+                entry("c", folder = "alpha"),
+                entry("d", folder = null)
+            )
+        assertThat(folderCounts(builds)).containsExactly("alpha" to 2, "Zeta" to 1)
+    }
+
+    private fun organize(
+        builds: List<HistoryEntry>,
+        search: String = "",
+        sort: LibrarySort = LibrarySort.NEWEST,
+        classFilter: CharacterClass? = null,
+        groupByClass: Boolean = false,
+        selectedTags: Set<String> = emptySet(),
+        folder: LibraryFolderFilter = LibraryFolderFilter.All,
+    ): List<LibraryGroup> = organizeLibrary(builds, search, sort, classFilter, groupByClass, selectedTags, folder)
+
+    private fun entry(
+        name: String,
+        clazz: String = "CRA",
+        level: Int = 110,
+        createdAt: Long = 0L,
+        tags: List<String> = emptyList(),
+        folder: String? = null,
+    ): HistoryEntry =
+        HistoryEntry(
+            id = name,
+            name = name,
+            createdAt = createdAt,
+            dataVersion = "1.91.1.54",
+            tags = tags,
+            folder = folder,
+            request =
+                RequestSnapshot(
+                    clazz = clazz,
+                    level = level,
+                    minLevel = 80,
+                    mode = "FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT",
+                    maxRarity = Rarity.EPIC,
+                    duration = "20",
+                    stopAtMatch = false,
+                    targets = emptyList(),
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList()
+                ),
+            result =
+                ResultSnapshot(
+                    equipments = emptyList(),
+                    skills = emptyMap(),
+                    achieved = emptyMap(),
+                    match = 90.0,
+                    optimal = false
+                )
+        )
+}


### PR DESCRIPTION
## What

Reworks the **My Builds** library (`gui-compose`) from a flat, newest-first grid into a fully organizable collection.

### Sidebar + toolbar
- Left sidebar: **All builds**, **Folders**, **Tags**, **Classes** filters (with counts).
- Toolbar: **search** (name / class / tag), **sort** (newest / oldest / name / level), **group by class**.
- Sort + group-by-class **persist across launches** (Preferences); active search/class/tag/folder filters are in-memory (reset each launch).

### Redesigned build card
- Meta pills (`class · level · mode`) + user-tag pills.
- Compact **U-shaped slot mini-grid** echoing the paperdoll layout (no character render), flush to the card edges.
- **Responsive grid** (up to ~8 cards per row by window width).
- 2-line title with a tooltip showing the full name when truncated.
- Theme-consistent monochrome actions: a text **Load** button + `⇄` Compare / `✎` Edit / `✕` Delete glyph buttons, each with a tooltip; delete turns **red on hover**.

### Tags
- Free-form per-build tags (trim + case-insensitive dedupe), **AND**-filter, sidebar section, pills on cards.
- Edited via the new **Edit build** dialog (replaces rename-only).

### Folders
- **Implicit** folders (exist via membership — no registry, no empty folders).
- Folder picker in the Edit dialog (incl. *New folder…*).
- **Rename** (case-insensitive **merge** into an existing folder) and **delete** (members kept, become unfiled). A `Named` filter pointing at an empty folder auto-resets to *All*.

## Notes
- **Backward compatible**: `tags` and `folder` are defaulted fields on `HistoryEntry`, so pre-feature JSON saves load unchanged (covered by a legacy-JSON test).
- Slot-assignment logic extracted to `DollSlots.kt` and **shared** with the paperdoll (single source of truth).
- The filter/sort/group pipeline is a pure, unit-tested function (`LibraryOrganize.kt`).
- **Regression guard**: the "Update build" path re-reads `tags`/`folder` so re-saving a loaded build never wipes them (dedicated test).

## Tests
New: `LibraryOrganizeTest`, `DollSlotsTest`, `BuildSearchModelLibraryTest`; extended `HistoryRepositoryTest` (tag/folder round-trip + legacy JSON) and `HistoryMappingTest` (`normalizeTags`).

`./gradlew :common-lib:test :gui-compose:test :gui-compose:ktlintCheck :common-lib:ktlintCheck` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)