### PR TITLE
fix(gui): keep priority-meter clicks bound to their row across add/remove

### DIFF
--- a/gui-compose/build.gradle.kts
+++ b/gui-compose/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.assertj.core)
+    testImplementation(compose.desktop.uiTestJUnit4) // Compose UI test harness (runComposeUiTest) for widget tests
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Per-machine artifacts Conveyor packages for each target: that OS's Compose Desktop (Skiko) +

--- a/gui-compose/src/main/kotlin/me/chosante/ui/request/RequestPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/request/RequestPanel.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -352,7 +355,7 @@ private fun SectionHeader(title: String) {
 }
 
 @Composable
-private fun TargetRowList(
+internal fun TargetRowList(
     mode: ScoreComputationMode,
     targets: List<TargetRow>,
     onValueChange: (String, String) -> Unit,
@@ -360,14 +363,20 @@ private fun TargetRowList(
     onRemove: (String) -> Unit,
 ) {
     targets.forEachIndexed { index, target ->
-        if (index > 0) Hairline()
-        TargetStatRow(
-            target = target,
-            kind = tr(if (target.isExact(mode)) Tr.KIND_EXACT else Tr.KIND_MAXIMIZE),
-            onValueChange = { onValueChange(target.id, it) },
-            onWeightChange = { onWeightChange(target.id, it) },
-            onRemove = { onRemove(target.id) }
-        )
+        // Stable per-row identity: without it Compose tracks rows positionally, so adding/removing a row
+        // leaves each slot's remembered state (notably the PriorityMeter gesture coroutine) bound to the
+        // row that *used* to sit there — clicks then land on the wrong row. `target.id` is the unique,
+        // stable characteristic name, the same key the state model updates by.
+        key(target.id) {
+            if (index > 0) Hairline()
+            TargetStatRow(
+                target = target,
+                kind = tr(if (target.isExact(mode)) Tr.KIND_EXACT else Tr.KIND_MAXIMIZE),
+                onValueChange = { onValueChange(target.id, it) },
+                onWeightChange = { onWeightChange(target.id, it) },
+                onRemove = { onRemove(target.id) }
+            )
+        }
     }
 }
 
@@ -519,7 +528,11 @@ private fun TargetStatRow(
             width = 62.dp
         )
         Spacer(modifier = Modifier.width(10.dp))
-        PriorityMeter(weight = target.weight, onChange = onWeightChange)
+        PriorityMeter(
+            weight = target.weight,
+            onChange = onWeightChange,
+            modifier = Modifier.testTag(priorityMeterTestTag(target.id))
+        )
         Spacer(modifier = Modifier.width(8.dp))
         Box(
             modifier =
@@ -543,6 +556,9 @@ private fun TargetStatRow(
 }
 
 private const val PRIORITY_MAX = 5
+
+/** Test tag for a row's priority meter, keyed by the row id so UI tests can target one specific row. */
+internal fun priorityMeterTestTag(rowId: String): String = "priority-meter-$rowId"
 
 /** Gradient ends for the priority bar: yellow = least important, red = most important. */
 private val PriorityLow = Color(0xFFE6C34A)
@@ -573,8 +589,13 @@ private fun levelForX(
 private fun PriorityMeter(
     weight: Int,
     onChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val level = weight.coerceIn(1, PRIORITY_MAX)
+    // `pointerInput(Unit)` launches its gesture coroutine once and captures `onChange` from that first
+    // composition only. When this meter is reused for a different row (rows added/removed), a captured
+    // stale lambda would drive clicks to the wrong row, so read the latest one via rememberUpdatedState.
+    val currentOnChange by rememberUpdatedState(onChange)
     TooltipArea(
         delayMillis = 350,
         tooltip = {
@@ -596,15 +617,15 @@ private fun PriorityMeter(
     ) {
         Row(
             modifier =
-                Modifier
+                modifier
                     .pointerInput(Unit) {
-                        detectTapGestures { offset -> onChange(levelForX(offset.x, size.width)) }
+                        detectTapGestures { offset -> currentOnChange(levelForX(offset.x, size.width)) }
                     }.pointerInput(Unit) {
                         detectHorizontalDragGestures(
-                            onDragStart = { offset -> onChange(levelForX(offset.x, size.width)) }
+                            onDragStart = { offset -> currentOnChange(levelForX(offset.x, size.width)) }
                         ) { change, _ ->
                             change.consume()
-                            onChange(levelForX(change.position.x, size.width))
+                            currentOnChange(levelForX(change.position.x, size.width))
                         }
                     },
             horizontalArrangement = Arrangement.spacedBy(3.dp),

--- a/gui-compose/src/test/kotlin/me/chosante/ui/request/TargetRowPrioritySyncTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/request/TargetRowPrioritySyncTest.kt
@@ -1,0 +1,160 @@
+package me.chosante.ui.request
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
+import me.chosante.common.Characteristic
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import me.chosante.ui.state.TargetRow
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression cover for the priority-meter desync: adding/removing constraint rows used to leave a
+ * meter's click handler bound to whatever row originally sat in that slot (positional identity +
+ * `pointerInput(Unit)` capturing its callback once), so clicks landed on the wrong row. The fix is a
+ * stable `key(target.id)` per row plus `rememberUpdatedState` in the meter. These tests drive the real
+ * [TargetRowList] through heavy churn and assert every click stays bound to the *displayed* row.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TargetRowPrioritySyncTest {
+    private fun row(
+        characteristic: Characteristic,
+        weight: Int = 1,
+    ): TargetRow =
+        TargetRow(
+            id = characteristic.name,
+            characteristic = characteristic,
+            label = characteristic.name,
+            glyph = "",
+            color = Color.White,
+            value = "100",
+            weight = weight
+        )
+
+    @Test
+    fun `priority clicks stay bound to the displayed row across many add and remove cycles`() =
+        runComposeUiTest {
+            val targets =
+                mutableStateListOf(
+                    row(Characteristic.ACTION_POINT),
+                    row(Characteristic.MOVEMENT_POINT),
+                    row(Characteristic.HP)
+                )
+            // (rowId, weight) reported by the meter, in order — `last()` is the most recent click.
+            val recorded = mutableListOf<Pair<String, Int>>()
+
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    Column {
+                        TargetRowList(
+                            mode = ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT,
+                            targets = targets,
+                            onValueChange = { _, _ -> },
+                            onWeightChange = { id, weight ->
+                                recorded += id to weight
+                                // Mirror the real model: persist the new weight so the row recomposes.
+                                val index = targets.indexOfFirst { it.id == id }
+                                if (index >= 0) targets[index] = targets[index].copy(weight = weight)
+                            },
+                            onRemove = { id -> targets.removeAll { it.id == id } }
+                        )
+                    }
+                }
+            }
+
+            // Clicking the centre of a 5-segment bar selects level 3 — see levelForX.
+            fun clickAndAssert(characteristic: Characteristic) {
+                onNodeWithTag(priorityMeterTestTag(characteristic.name)).performTouchInput { click(center) }
+                waitForIdle()
+                assertThat(recorded.last()).isEqualTo(characteristic.name to 3)
+            }
+
+            // Baseline: each row's bar reports its own id.
+            clickAndAssert(Characteristic.ACTION_POINT)
+            clickAndAssert(Characteristic.MOVEMENT_POINT)
+            clickAndAssert(Characteristic.HP)
+
+            // Remove the MIDDLE row — HP shifts up a slot. This is the case that desynced pre-fix.
+            runOnIdle { targets.removeAll { it.id == Characteristic.MOVEMENT_POINT.name } }
+            waitForIdle()
+            onNodeWithTag(priorityMeterTestTag(Characteristic.MOVEMENT_POINT.name)).assertDoesNotExist()
+            clickAndAssert(Characteristic.HP)
+            clickAndAssert(Characteristic.ACTION_POINT)
+
+            // Append two fresh rows and click them.
+            runOnIdle {
+                targets.add(row(Characteristic.RANGE))
+                targets.add(row(Characteristic.MASTERY_CRITICAL))
+            }
+            waitForIdle()
+            clickAndAssert(Characteristic.RANGE)
+            clickAndAssert(Characteristic.MASTERY_CRITICAL)
+            clickAndAssert(Characteristic.HP)
+
+            // Drop the FIRST row and a middle one — now [HP, MASTERY_CRITICAL].
+            runOnIdle {
+                targets.removeAll { it.id == Characteristic.ACTION_POINT.name }
+                targets.removeAll { it.id == Characteristic.RANGE.name }
+            }
+            waitForIdle()
+            clickAndAssert(Characteristic.HP)
+            clickAndAssert(Characteristic.MASTERY_CRITICAL)
+
+            // Churn: insert at the FRONT (shifts every existing slot down) then remove, six times over,
+            // re-checking both the toggled row and the slot-shifted neighbour each round.
+            repeat(6) {
+                runOnIdle { targets.add(0, row(Characteristic.WISDOM)) }
+                waitForIdle()
+                clickAndAssert(Characteristic.WISDOM)
+                clickAndAssert(Characteristic.HP)
+                runOnIdle { targets.removeAll { it.id == Characteristic.WISDOM.name } }
+                waitForIdle()
+                onNodeWithTag(priorityMeterTestTag(Characteristic.WISDOM.name)).assertDoesNotExist()
+                clickAndAssert(Characteristic.HP)
+            }
+        }
+
+    @Test
+    fun `priority meter maps the click position to a 1 to 5 level`() =
+        runComposeUiTest {
+            var lastWeight = -1
+
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    Column {
+                        TargetRowList(
+                            mode = ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT,
+                            targets = listOf(row(Characteristic.MASTERY_DISTANCE)),
+                            onValueChange = { _, _ -> },
+                            onWeightChange = { _, weight -> lastWeight = weight },
+                            onRemove = {}
+                        )
+                    }
+                }
+            }
+
+            val tag = priorityMeterTestTag(Characteristic.MASTERY_DISTANCE.name)
+
+            onNodeWithTag(tag).performTouchInput { click(Offset(left + 1f, centerY)) }
+            waitForIdle()
+            assertThat(lastWeight).isEqualTo(1)
+
+            onNodeWithTag(tag).performTouchInput { click(center) }
+            waitForIdle()
+            assertThat(lastWeight).isEqualTo(3)
+
+            onNodeWithTag(tag).performTouchInput { click(Offset(right - 1f, centerY)) }
+            waitForIdle()
+            assertThat(lastWeight).isEqualTo(5)
+        }
+}


### PR DESCRIPTION
## Problem

Reported (FR): the priority controls sometimes get "stuck" — after adding and removing target-stat rows, clicks stop landing on the right row ("ce n'est plus synchronisé").

## Root cause

Two interacting Compose pitfalls in the Target Stats editor:

1. `TargetRowList` rendered rows with `forEachIndexed` and **no stable `key()`** — Compose then tracks rows by position, so when the list shifts (add/remove) each slot keeps its previously-remembered state.
2. `PriorityMeter` detects taps/drags inside `pointerInput(Unit)`. With the constant `Unit` key, the gesture coroutine captures the `onChange` lambda **once** and never refreshes it.

Together, a meter keeps invoking the handler bound to whatever row *originally* occupied its slot → clicks update the wrong row. Only the priority bars were affected; the number field reads its callback fresh on each recomposition, so it stayed in sync.

## Fix

- `key(target.id)` around each row → stable identity; the whole subtree (including the gesture coroutine) moves with its row.
- `rememberUpdatedState(onChange)` in `PriorityMeter` → the gesture always calls the current lambda.

Either change alone resolves the desync; both together keep the list and the widget correct independently.

## Tests

New `TargetRowPrioritySyncTest` (Compose UI test via `runComposeUiTest`) driving the **real** `TargetRowList`:

- **Sync under churn** — many add/remove cycles (including front-insertion that shifts every slot); asserts each click stays bound to the *displayed* row.
- **Mapping** — left / centre / right click → level 1 / 3 / 5.

Validated as a genuine regression test: reverting the fix makes it fail with `expected: (HP, 3) but was: (MOVEMENT_POINT, 3)` — the exact wrong-row symptom. Full `gui-compose` suite: **38 tests, 0 failures**. Confirmed to run with `java.awt.headless=true` (CI is `ubuntu-latest`).

Adds a test-only dependency (`compose.desktop.uiTestJUnit4`) and makes `TargetRowList` / a `priorityMeterTestTag` helper `internal` for the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
