### PR TITLE
feat(gui): import/export builds + search-responsiveness fixes

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -613,13 +613,18 @@ object WakfuBuildSolver {
         val solver = CpSolver()
         solver.parameters.logSearchProgress = false
         if (tuning == null) {
-            // Production: a parallel portfolio across all cores (CP-SAT's equivalent of the GA's
-            // parallel scoring), bounded by the user's wall-clock search duration. Presolve is capped
-            // because full presolve on this objective never terminates within that budget; the
-            // prefiltered (small) model keeps even a light presolve effective.
+            // Production: a parallel portfolio (CP-SAT's equivalent of the GA's parallel scoring),
+            // bounded by the user's wall-clock search duration. Presolve is capped because full
+            // presolve on this objective never terminates within that budget; the prefiltered
+            // (small) model keeps even a light presolve effective.
+            //
+            // We deliberately leave one core for the host: CP-SAT spawns this many *native* threads
+            // and pins them at 100%, which otherwise starves the Compose render thread / EDT and
+            // makes the GUI window visibly freeze during a search. One fewer worker is a negligible
+            // throughput loss next to a responsive UI (and keeps the terminal responsive for the CLI).
             solver.parameters.maxPresolveIterations = 1
             solver.parameters.maxTimeInSeconds = params.searchDuration.inWholeSeconds.toDouble()
-            solver.parameters.numSearchWorkers = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
+            solver.parameters.numSearchWorkers = (Runtime.getRuntime().availableProcessors() - 1).coerceAtLeast(1)
         } else {
             // Deterministic, machine-independent solve for tests — see [SolverTuning]. A fixed worker
             // count + seed + a deterministic-time budget (not wall-clock) make CP-SAT reach the same

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
@@ -85,6 +85,9 @@ fun ModalHost(
     onRenameTag: (oldName: String, newName: String) -> Unit = { _, _ -> },
     onDeleteTag: (name: String) -> Unit = {},
     onConfirmReSearch: () -> Unit = {},
+    onImportBuild: (json: String) -> Unit = {},
+    validateImport: (json: String) -> Boolean = { false },
+    onClipboardText: () -> String = { "" },
 ) {
     if (modal == null) return
     Scrim(onDismiss = onDismiss) {
@@ -108,6 +111,14 @@ fun ModalHost(
                     isEditingExisting = isEditingExisting,
                     takenNames = takenNames,
                     onSave = onSaveBuild,
+                    onCancel = onDismiss
+                )
+
+            Modal.ImportBuild ->
+                ImportBuildModal(
+                    validate = validateImport,
+                    clipboardText = onClipboardText,
+                    onImport = onImportBuild,
                     onCancel = onDismiss
                 )
 
@@ -627,6 +638,76 @@ private fun SaveBuildModal(
                     modifier = Modifier.weight(1f)
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ImportBuildModal(
+    validate: (String) -> Boolean,
+    clipboardText: () -> String,
+    onImport: (String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    val valid = remember(text) { validate(text) }
+    val showInvalid = text.isNotBlank() && !valid
+    ModalCard(title = tr(Tr.IMPORT_DIALOG_TITLE)) {
+        Text(
+            text = tr(Tr.IMPORT_DIALOG_HINT),
+            style = WTypography.bodyMedium.copy(color = WColor.muted, lineHeight = 19.sp)
+        )
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        MultilineField(value = text, onValueChange = { text = it }, placeholder = tr(Tr.IMPORT_PLACEHOLDER))
+        if (showInvalid) {
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(text = tr(Tr.IMPORT_INVALID), style = WTypography.labelSmall.copy(color = WColor.danger))
+        }
+        Spacer(modifier = Modifier.height(WDimens.gap))
+        Row(horizontalArrangement = Arrangement.spacedBy(9.dp), verticalAlignment = Alignment.CenterVertically) {
+            // Convenience: fill the field straight from the clipboard (paste also works via the field).
+            DialogButton(text = tr(Tr.IMPORT_PASTE), filled = false, color = WColor.accent2, onClick = { text = clipboardText() })
+            Spacer(modifier = Modifier.weight(1f))
+            DialogButton(text = tr(Tr.CANCEL), filled = false, color = WColor.border, onClick = onCancel)
+            DialogButton(
+                text = tr(Tr.IMPORT_CONFIRM),
+                filled = true,
+                color = WColor.accent,
+                enabled = valid,
+                onClick = { onImport(text) }
+            )
+        }
+    }
+}
+
+/** Scrollable, monospace multi-line input — used by the import dialog to paste an exported build. */
+@Composable
+private fun MultilineField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+) {
+    val scroll = rememberScrollState()
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(150.dp)
+                .clip(RoundedCornerShape(9.dp))
+                .background(WColor.bg)
+                .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                .padding(horizontal = 11.dp, vertical = 9.dp)
+    ) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = false,
+            cursorBrush = SolidColor(WColor.accent),
+            textStyle = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.text, lineHeight = 16.sp),
+            modifier = Modifier.fillMaxSize().verticalScroll(scroll)
+        )
+        if (value.isEmpty()) {
+            Text(text = placeholder, style = WTypography.bodyMedium.copy(color = WColor.faint))
         }
     }
 }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
@@ -1,5 +1,6 @@
 package me.chosante.ui.history
 
+import kotlinx.serialization.json.Json
 import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
 import me.chosante.autobuilder.genetic.wakfu.isMaximizableMastery
@@ -22,6 +23,19 @@ import me.chosante.ui.state.toRow
 // Mappers between the live UiState / engine objects and the persisted HistoryEntry DTO. Kept in one
 // place so the (de)serialization rules — and the deliberate decoupling from the engine graph — live
 // next to the format they serve.
+
+/**
+ * The single JSON codec for [HistoryEntry] — shared by the on-disk library
+ * ([HistoryRepository]) and the clipboard export/import (see `BuildSearchModel.exportBuild` /
+ * `importBuild`) so the two never drift. `prettyPrint` keeps an exported build readable when pasted
+ * into a chat; `ignoreUnknownKeys` lets a build exported by a newer/older app version still load.
+ */
+internal val historyJson: Json =
+    Json {
+        prettyPrint = true
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
 
 /**
  * Snapshots the current workspace into a savable [HistoryEntry]. Returns `null` when there is no

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryRepository.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryRepository.kt
@@ -3,7 +3,6 @@ package me.chosante.ui.history
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import me.chosante.common.history.HistoryEntry
 import java.nio.file.Files
 import java.nio.file.Path
@@ -58,12 +57,9 @@ class HistoryRepository(
 ) {
     private val historyDir: Path = baseDir.resolve("history")
 
-    private val json =
-        Json {
-            prettyPrint = true
-            ignoreUnknownKeys = true
-            encodeDefaults = true
-        }
+    // Reuses the shared [historyJson] codec (see HistoryMapping) so the on-disk format and the
+    // clipboard export/import stay byte-for-byte compatible.
+    private val json = historyJson
 
     /**
      * Loads every saved build, newest first. Corrupt or unreadable files are skipped (never throw)

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/LibraryScreen.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/LibraryScreen.kt
@@ -83,6 +83,7 @@ import java.time.format.FormatStyle
 @Composable
 fun LibraryScreen(
     ui: UiState,
+    onImport: () -> Unit,
     onLoad: (String) -> Unit,
     onCompare: (String) -> Unit,
     onDuplicate: (String) -> Unit,
@@ -113,7 +114,7 @@ fun LibraryScreen(
                     .padding(WDimens.pad),
             verticalArrangement = Arrangement.spacedBy(WDimens.gap)
         ) {
-            Header(count = 0)
+            Header(count = 0, onImport = onImport)
             EmptyState(onGoBuilder = onGoBuilder)
         }
         return
@@ -167,7 +168,7 @@ fun LibraryScreen(
                     .padding(WDimens.pad),
             verticalArrangement = Arrangement.spacedBy(WDimens.gap)
         ) {
-            Header(count = ui.savedBuilds.size)
+            Header(count = ui.savedBuilds.size, onImport = onImport)
             LibraryToolbar(
                 ui = ui,
                 onSearchChange = onSearchChange,
@@ -630,7 +631,10 @@ private fun GroupToggle(
 }
 
 @Composable
-private fun Header(count: Int) {
+private fun Header(
+    count: Int,
+    onImport: () -> Unit,
+) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Column(modifier = Modifier.weight(1f)) {
             Text(text = tr(Tr.LIBRARY_TITLE), style = WTypography.headlineLarge.copy(fontWeight = FontWeight.Bold))
@@ -641,6 +645,20 @@ private fun Header(count: Int) {
                 text = "$count ${tr(Tr.LIBRARY_COUNT)}",
                 style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted)
             )
+            Spacer(modifier = Modifier.width(14.dp))
+        }
+        // Paste a build a tester exported (input + result) — added to the library and opened.
+        Box(
+            modifier =
+                Modifier
+                    .clip(RoundedCornerShape(9.dp))
+                    .background(WColor.raised)
+                    .border(1.dp, WColor.border, RoundedCornerShape(9.dp))
+                    .clickable(onClick = onImport)
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = tr(Tr.IMPORT_BUILD), style = WTypography.labelMedium.copy(color = WColor.text))
         }
     }
 }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -132,6 +132,7 @@ enum class Tr(
     OPEN_IN_ZENITH("Open in Zenith ↗", "Ouvrir dans Zenith ↗"),
     OPENING("Opening...", "Ouverture..."),
     COPY_BUILD_LINK("Copy build link", "Copier le lien"),
+    EXPORT_BUILD("Export build", "Exporter le build"),
     NO_BUILD_YET("No build yet", "Aucun build"),
     NO_BUILD_HINT(
         "Set your target stats & constraints on the left, then hit Search. " +
@@ -162,11 +163,25 @@ enum class Tr(
     RUNES("Runes", "Châsses"),
     LOADING_ITEMS("Loading item database…", "Chargement de la base d'objets…"),
 
+    // Import-build dialog
+    IMPORT_DIALOG_TITLE("Import a build", "Importer un build"),
+    IMPORT_DIALOG_HINT(
+        "Paste a build exported from this app (input + result). It's added to your library and opened.",
+        "Colle un build exporté depuis l'app (entrée + résultat). Il est ajouté à ta bibliothèque et ouvert."
+    ),
+    IMPORT_PLACEHOLDER("Paste the exported build here…", "Colle ici le build exporté…"),
+    IMPORT_PASTE("Paste", "Coller"),
+    IMPORT_INVALID("That doesn't look like an exported build.", "Cela ne ressemble pas à un build exporté."),
+    IMPORT_CONFIRM("Import", "Importer"),
+    IMPORTED_BUILD_NAME("Imported build", "Build importé"),
+
     // Toasts (read off the composition by the state holder)
     TOAST_ZENITH_COPIED("Zenith link copied", "Lien Zenith copié"),
     TOAST_ZENITH_READY("Zenith build ready", "Build Zenith prêt"),
     TOAST_BUILD_SAVED("Build saved", "Build enregistré"),
     TOAST_BUILD_DUPLICATED("Build duplicated", "Build dupliqué"),
+    TOAST_BUILD_EXPORTED("Build copied to clipboard", "Build copié dans le presse-papiers"),
+    TOAST_BUILD_IMPORTED("Build imported", "Build importé"),
 
     // Navigation / active build
     NAV_BUILDER("Builder", "Builder"),
@@ -190,6 +205,7 @@ enum class Tr(
     // Library
     LIBRARY_TITLE("My Builds", "Mes builds"),
     LIBRARY_SUBTITLE("Saved locally on this computer", "Enregistrés localement sur cet ordinateur"),
+    IMPORT_BUILD("⤓ Import", "⤓ Importer"),
     LIBRARY_EMPTY("No saved builds yet", "Aucun build enregistré"),
     LIBRARY_EMPTY_HINT(
         "Run a search in the Builder, then hit Save — your builds show up here.",

--- a/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
@@ -106,6 +106,7 @@ fun AppShell(
                         Screen.Library ->
                             LibraryScreen(
                                 ui = ui,
+                                onImport = model::requestImport,
                                 onLoad = model::loadBuild,
                                 onCompare = model::startCompare,
                                 onDuplicate = model::duplicateBuild,
@@ -167,7 +168,10 @@ fun AppShell(
                 onCreateTag = model::createTag,
                 onRenameTag = model::renameTag,
                 onDeleteTag = model::deleteTag,
-                onConfirmReSearch = model::confirmReSearch
+                onConfirmReSearch = model::confirmReSearch,
+                onImportBuild = model::importBuild,
+                validateImport = model::canParseImport,
+                onClipboardText = model::clipboardText
             )
         }
     }
@@ -234,7 +238,8 @@ private fun BuilderBody(
                 ui = ui,
                 onOpenZenith = model::openZenithBuild,
                 onCopyZenith = model::copyZenithLink,
-                onSaveBuild = model::requestSaveBuild
+                onSaveBuild = model::requestSaveBuild,
+                onExport = model::exportBuild
             )
         }
     }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/shell/TopBar.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/shell/TopBar.kt
@@ -1,5 +1,11 @@
 package me.chosante.ui.shell
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -19,6 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.DropdownMenu
@@ -105,7 +112,15 @@ fun TopBar(
                     isError = ui.minLevel > ui.level
                 )
                 Spacer(modifier = Modifier.width(22.dp))
-                TopMeter(label = tr(Tr.PROGRESS), value = "${ui.progress}%", fill = ui.progress / 100f, color = WColor.accent2)
+                TopMeter(
+                    label = tr(Tr.PROGRESS),
+                    value = "${ui.progress}%",
+                    fill = ui.progress / 100f,
+                    color = WColor.accent2,
+                    // A pulsing dot while the engine runs: the bar already advances on a timer, this is
+                    // a second, always-visible "still working" cue so the app never looks frozen.
+                    pulsing = ui.phase == Phase.Searching
+                )
                 Spacer(modifier = Modifier.width(16.dp))
                 if (ui.mode == ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT) {
                     // Most-masteries: no exact-target "% match"; show the cumulated requested mastery.
@@ -407,11 +422,35 @@ private fun TopMeter(
     value: String,
     fill: Float?,
     color: androidx.compose.ui.graphics.Color,
+    pulsing: Boolean = false,
 ) {
     Column(modifier = Modifier.width(112.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(text = label, style = WTypography.labelSmall)
             Spacer(modifier = Modifier.weight(1f))
+            if (pulsing) {
+                // Gently breathing dot — an unmistakable "the search is alive" signal that, unlike the
+                // bar, stays visible even when progress is near 0 or momentarily static.
+                val transition = rememberInfiniteTransition(label = "search-pulse")
+                val dotAlpha by transition.animateFloat(
+                    initialValue = 0.2f,
+                    targetValue = 1f,
+                    animationSpec =
+                        infiniteRepeatable(
+                            animation = tween(durationMillis = 750, easing = LinearEasing),
+                            repeatMode = RepeatMode.Reverse
+                        ),
+                    label = "search-pulse-alpha"
+                )
+                Box(
+                    modifier =
+                        Modifier
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            .background(color.copy(alpha = dotAlpha))
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+            }
             Text(
                 text = value,
                 style =

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -547,6 +547,23 @@ class BuildSearchModel(
             )
         job =
             scope.launch(Dispatchers.Default) {
+                // The CP-SAT solver only reports progress when it finds a *better* solution, which can
+                // be many seconds apart — or stop entirely once the first good build is found — so the
+                // bar would sit frozen and the app looks dead mid-search. The budget is wall-clock, so
+                // we drive the bar smoothly from elapsed time here; the solver callbacks below keep
+                // refreshing the actual build/mastery. Child of `job`, so it dies with the search.
+                val searchStartMs = clock()
+                val searchDurationMs = params.searchDuration.inWholeMilliseconds.coerceAtLeast(1)
+                val progressTicker =
+                    launch(mainDispatcher) {
+                        while (isActive) {
+                            if (ui.phase == Phase.Searching) {
+                                val pct = ((clock() - searchStartMs).toDouble() / searchDurationMs * 100).toInt().coerceIn(0, 99)
+                                if (pct > ui.progress) ui = ui.copy(progress = pct)
+                            }
+                            delay(120)
+                        }
+                    }
                 try {
                     var hasResult = false
                     buildFinder(params)
@@ -564,7 +581,8 @@ class BuildSearchModel(
                                 val landedEquipmentId = newlyLandedEquipmentId(ui.build, result.individual)
                                 ui =
                                     ui.copy(
-                                        progress = result.progressPercentage,
+                                        // `progress` is driven smoothly by progressTicker (time-based);
+                                        // the solver only emits on improvements, so don't set it here.
                                         match = result.matchPercentage,
                                         optimal = result.isOptimal,
                                         build = result.individual,
@@ -586,7 +604,9 @@ class BuildSearchModel(
                         }
                     withContext(mainDispatcher) {
                         if (ui.phase == Phase.Searching && hasResult) {
-                            ui = ui.copy(phase = Phase.Done, lastLandedEquipmentId = null)
+                            // Snap the time-based bar to a clean 100% on completion (the solver may
+                            // have proven the optimum well before the wall-clock budget ran out).
+                            ui = ui.copy(phase = Phase.Done, progress = 100, lastLandedEquipmentId = null)
                         } else if (ui.phase == Phase.Searching) {
                             ui =
                                 ui.copy(
@@ -608,6 +628,8 @@ class BuildSearchModel(
                     withContext(mainDispatcher) {
                         ui = ui.copy(phase = Phase.Idle, error = message)
                     }
+                } finally {
+                    progressTicker.cancel()
                 }
             }
     }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -27,10 +27,12 @@ import me.chosante.autobuilder.genetic.wakfu.isMaximizableMastery
 import me.chosante.common.Character
 import me.chosante.common.Characteristic
 import me.chosante.common.Rarity
+import me.chosante.common.history.HistoryEntry
 import me.chosante.createZenithBuild
 import me.chosante.ui.components.IconPreloader
 import me.chosante.ui.components.warmUpPaths
 import me.chosante.ui.history.HistoryRepository
+import me.chosante.ui.history.historyJson
 import me.chosante.ui.history.normalizeTags
 import me.chosante.ui.history.restoredClass
 import me.chosante.ui.history.restoredMode
@@ -43,6 +45,7 @@ import me.chosante.ui.history.toTargetRows
 import me.chosante.ui.i18n.Tr
 import java.awt.Desktop
 import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.net.URI
 import java.util.concurrent.CancellationException
@@ -99,6 +102,9 @@ class BuildSearchModel(
     private val zenithBuilder: ZenithBuilder = { it.createZenithBuild() },
     private val openBrowser: (String) -> Unit = { link -> Desktop.getDesktop().browse(URI(link)) },
     private val copyToClipboard: (String) -> Unit = { link -> Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(link), null) },
+    private val readClipboard: () -> String = {
+        runCatching { Toolkit.getDefaultToolkit().systemClipboard.getData(DataFlavor.stringFlavor) as? String }.getOrNull().orEmpty()
+    },
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Swing,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val historyRepository: HistoryRepository = HistoryRepository(),
@@ -661,6 +667,29 @@ class BuildSearchModel(
         }
     }
 
+    /**
+     * Copies the current build — its full request (input) *and* discovered result (output) — to the
+     * clipboard as a [HistoryEntry] JSON, so a tester can hand you a build without a screenshot. The
+     * same payload re-imports losslessly via [importBuild]. Reflects the live workspace; when a saved
+     * build is loaded its metadata (note/tags/folder/created date) is preserved.
+     */
+    fun exportBuild() {
+        if (ui.build == null) return
+        val active = ui.activeBuildId?.let { id -> ui.savedBuilds.firstOrNull { it.id == id } }
+        val entry =
+            ui.toHistoryEntry(
+                id = active?.id ?: idGenerator(),
+                name = ui.activeBuildName ?: ui.suggestedBuildName(),
+                note = active?.note,
+                createdAt = active?.createdAt ?: clock(),
+                dataVersion = dataVersion,
+                tags = active?.tags ?: emptyList(),
+                folder = active?.folder
+            ) ?: return
+        copyToClipboard(historyJson.encodeToString(HistoryEntry.serializer(), entry))
+        ui = ui.copy(toast = Tr.TOAST_BUILD_EXPORTED.value(ui.lang))
+    }
+
     private fun createZenithLink(onReady: (String) -> Unit) {
         val build = ui.build ?: return
         ui = ui.copy(zenith = ZenithState.Loading, error = null, toast = null)
@@ -893,6 +922,56 @@ class BuildSearchModel(
                 activeBuildName = entry.name,
                 searchLocked = true
             )
+    }
+
+    /** Opens the import dialog, where a build exported via [exportBuild] is pasted. See [importBuild]. */
+    fun requestImport() {
+        ui = ui.copy(modal = Modal.ImportBuild)
+    }
+
+    /** Best-effort read of the system clipboard for the import dialog's "Paste" button. */
+    fun clipboardText(): String = readClipboard()
+
+    /** True when [rawJson] decodes to a valid exported build — gates the import dialog's confirm button. */
+    fun canParseImport(rawJson: String): Boolean = rawJson.isNotBlank() && runCatching { historyJson.decodeFromString(HistoryEntry.serializer(), rawJson.trim()) }.isSuccess
+
+    /**
+     * Imports a build exported via [exportBuild]: parses the pasted [HistoryEntry] JSON, saves it as a
+     * fresh library entry (new id + a name made unique, so it never overwrites an existing build), then
+     * loads it into the workspace so it's visible at once. The denormalized result lets it display even
+     * if its items left the catalog or the data version differs. Invalid JSON is a no-op (toast only).
+     */
+    fun importBuild(rawJson: String) {
+        val parsed = runCatching { historyJson.decodeFromString(HistoryEntry.serializer(), rawJson.trim()) }.getOrNull()
+        if (parsed == null) {
+            ui = ui.copy(modal = null, toast = Tr.IMPORT_INVALID.value(ui.lang))
+            return
+        }
+        val entry = parsed.copy(id = idGenerator(), name = uniqueLibraryName(parsed.name), createdAt = clock())
+        ui = ui.copy(modal = null)
+        scope.launch(ioDispatcher) {
+            runCatching { historyRepository.save(entry) }
+                .onSuccess {
+                    val all = historyRepository.loadAll()
+                    withContext(mainDispatcher) {
+                        ui = ui.copy(savedBuilds = all, knownTags = computeKnownTags(all))
+                        loadBuild(entry.id)
+                        ui = ui.copy(toast = Tr.TOAST_BUILD_IMPORTED.value(ui.lang))
+                    }
+                }.onFailure { throwable ->
+                    withContext(mainDispatcher) { ui = ui.copy(error = throwable.message ?: "Could not import build") }
+                }
+        }
+    }
+
+    /** A library name unique against existing builds: keeps [base] if free, else appends " (2)", " (3)"… */
+    private fun uniqueLibraryName(base: String): String {
+        val trimmed = base.trim().ifBlank { Tr.IMPORTED_BUILD_NAME.value(ui.lang) }
+        val taken = ui.savedBuilds.map { it.name.trim().lowercase() }.toSet()
+        if (trimmed.lowercase() !in taken) return trimmed
+        var n = 2
+        while ("$trimmed ($n)".lowercase() in taken) n++
+        return "$trimmed ($n)"
     }
 
     /** Clears the active-build identity (the workspace becomes an "unsaved build" again, unlocked). */

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -79,6 +79,12 @@ sealed interface Modal {
     /** Save-the-current-build dialog (name + optional note). */
     data object SaveBuild : Modal
 
+    /**
+     * Paste a build exported from this app (a [me.chosante.common.history.HistoryEntry] JSON, input +
+     * result) to add it to the library and open it — so testers can share a build without a screenshot.
+     */
+    data object ImportBuild : Modal
+
     /** Edit a saved build's metadata (name, note, tags, folder). Resolves the entry at render time. */
     data class EditBuild(
         val id: String,

--- a/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
@@ -65,6 +65,7 @@ fun StatsPanel(
     onOpenZenith: () -> Unit,
     onCopyZenith: () -> Unit,
     onSaveBuild: () -> Unit,
+    onExport: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scroll = rememberScrollState()
@@ -90,7 +91,8 @@ fun StatsPanel(
                     ui = ui,
                     onOpenZenith = onOpenZenith,
                     onCopyZenith = onCopyZenith,
-                    onSaveBuild = onSaveBuild
+                    onSaveBuild = onSaveBuild,
+                    onExport = onExport
                 )
                 MasterySummary(ui)
                 DesiredVsAchieved(ui)
@@ -613,6 +615,7 @@ private fun ActionsCard(
     onOpenZenith: () -> Unit,
     onCopyZenith: () -> Unit,
     onSaveBuild: () -> Unit,
+    onExport: () -> Unit,
 ) {
     ResultCard {
         if (ui.error != null) {
@@ -642,6 +645,17 @@ private fun ActionsCard(
             enabled = ui.phase == Phase.Done && ui.zenith != ZenithState.Loading,
             borderColor = WColor.border,
             onClick = onCopyZenith
+        )
+        Spacer(modifier = Modifier.height(9.dp))
+        // Copies the whole build (request + result) as JSON so testers can hand it back without a
+        // screenshot; re-imported from the library's Import button. Independent of the Zenith link.
+        ActionButton(
+            text = tr(Tr.EXPORT_BUILD),
+            color = Color.Transparent,
+            contentColor = WColor.accent2,
+            enabled = ui.phase == Phase.Done && ui.build != null,
+            borderColor = WColor.border,
+            onClick = onExport
         )
         ui.zenithUrl?.let { link ->
             Text(

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelLibraryTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelLibraryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.genetic.GeneticAlgorithmResult
+import me.chosante.common.CharacterClass
 import me.chosante.common.Characteristic
 import me.chosante.common.Equipment
 import me.chosante.common.I18nText
@@ -460,6 +461,80 @@ class BuildSearchModelLibraryTest {
                     .mapNotNull { it.folder }
                     .toSet()
             ).containsExactly("PvP")
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `export then import round-trips a build through the clipboard`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        var clipboard = ""
+        val model =
+            BuildSearchModel(
+                scope = scope,
+                buildFinder = {
+                    flowOf(
+                        GeneticAlgorithmResult(
+                            individual = fakeBuild(),
+                            matchPercentage = BigDecimal("100"),
+                            progressPercentage = 100,
+                            isOptimal = true
+                        )
+                    )
+                },
+                zenithBuilder = { "" },
+                copyToClipboard = { clipboard = it },
+                readClipboard = { clipboard },
+                mainDispatcher = Dispatchers.Unconfined,
+                historyRepository = HistoryRepository(baseDir = tempDir, ioDispatcher = Dispatchers.Unconfined),
+                libraryPreferences = LibraryPreferences(null)
+            )
+        try {
+            // A non-default class so the round-trip is observable (defaults are CRA).
+            model.setClass(CharacterClass.IOP)
+            model.setDuration("1")
+            model.search()
+            awaitUntil { model.ui.phase == Phase.Done }
+
+            // Export copies a parseable HistoryEntry (input + result) to the clipboard.
+            model.exportBuild()
+            assertThat(clipboard).isNotBlank()
+            assertThat(model.canParseImport(clipboard)).isTrue()
+            assertThat(model.ui.toast).isNotNull()
+
+            // Importing that exact payload adds it to the library and opens it in the workspace.
+            model.importBuild(clipboard)
+            awaitUntil { model.ui.savedBuilds.isNotEmpty() && model.ui.build != null }
+
+            assertThat(model.ui.savedBuilds).hasSize(1)
+            val imported = model.ui.savedBuilds.single()
+            assertThat(imported.request.clazz).isEqualTo("IOP")
+            assertThat(imported.result.equipments.map { it.equipmentId }).contains(1)
+            assertThat(model.ui.activeBuildId).isEqualTo(imported.id)
+            assertThat(model.ui.clazz).isEqualTo(CharacterClass.IOP)
+            assertThat(model.ui.screen).isEqualTo(Screen.Builder)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `importBuild rejects malformed json without touching the library`(
+        @TempDir tempDir: Path,
+    ) = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val model = model(scope, tempDir)
+        try {
+            assertThat(model.canParseImport("not a build")).isFalse()
+
+            model.importBuild("not a build")
+
+            assertThat(model.ui.savedBuilds).isEmpty()
+            assertThat(model.ui.modal).isNull()
+            assertThat(model.ui.toast).isNotNull()
         } finally {
             scope.cancel()
         }


### PR DESCRIPTION
Surfaces work that had been stashed off `main` (`import-export-build WIP`), split into three focused, independently-reviewable commits.

## Commits
1. **fix(engine): leave one CPU core free during CP-SAT search** — CP-SAT pinned every core at 100% with native threads, starving the host (Compose render thread / EDT, CLI terminal) and visibly freezing the GUI mid-search. Reserve one core for the host.
2. **fix(gui): keep the search progress bar alive during a search** — CP-SAT only emits on an improved solution, so the bar sat frozen and the app looked dead. Drive the bar from elapsed wall-clock time with a ticker, snap to 100% on completion, and add a pulsing "still working" dot in the top meter.
3. **feat(gui): import/export builds via the clipboard** — Export copies the current build (full request + discovered result) to the clipboard as a `HistoryEntry` JSON; Import pastes it back, validates, saves it under a unique name, and opens it. The library codec is now shared (`historyJson`) so the on-disk and clipboard formats never drift; the denormalized result lets imported builds display even if items left the catalog or the data version differs.

## Verification
- `./gradlew :autobuilder:ktlintCheck :gui-compose:ktlintCheck :autobuilder:test :gui-compose:test` — **BUILD SUCCESSFUL** (incl. the export→import round-trip + malformed-JSON-rejection tests in `BuildSearchModelLibraryTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)