### PR TITLE
fix(enchant): cap rune/shard level by item level, not character level

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
@@ -83,6 +83,7 @@ import me.chosante.common.Characteristic.WILLPOWER
 import me.chosante.common.Characteristic.WISDOM
 import me.chosante.common.Equipment
 import me.chosante.common.Rarity
+import me.chosante.common.RuneType
 import me.chosante.common.skills.Assignable
 import me.chosante.createZenithBuild
 import kotlin.system.exitProcess
@@ -526,6 +527,10 @@ HUPPERMAGE"""
                         terminal.println(it.characterSkills.agility.asASCIITable())
                         terminal.println("Major")
                         terminal.println(it.characterSkills.major.asASCIITable())
+                        if (it.runes.isNotEmpty()) {
+                            terminal.println("Runes")
+                            terminal.println(it.runes.asRunesASCIITable())
+                        }
                     }
 
             if (createZenithBuild) {
@@ -575,6 +580,37 @@ HUPPERMAGE"""
                 cellBorders = Borders.TOP_BOTTOM
                 this@asASCIITable.forEach {
                     row(it.name.en, it.itemType, it.level, it.rarity)
+                }
+            }
+        }
+
+    // Socketed runes per item. The enchantment level is capped by the carrier item's level
+    // (Ankama's table), so it is derived per row from RuneType.maxLevel(item level).
+    private fun Map<Equipment, List<RuneType>>.asRunesASCIITable() =
+        table {
+            borderType = SQUARE_DOUBLE_SECTION_SEPARATOR
+            borderStyle = rgb("#4b25b9")
+            align = TextAlign.RIGHT
+            tableBorders = Borders.NONE
+            header {
+                style = TextColors.brightRed + TextStyles.bold
+                row("Item", "Rune", "Count", "Enchant level") { cellBorders = Borders.BOTTOM }
+            }
+            body {
+                style = TextColors.green
+                column(0) {
+                    align = TextAlign.LEFT
+                    cellBorders = Borders.ALL
+                    style = TextColors.brightBlue
+                }
+                rowStyles(TextStyle(), TextStyles.dim.style)
+                cellBorders = Borders.TOP_BOTTOM
+                this@asRunesASCIITable.forEach { (equipment, runes) ->
+                    runes
+                        .groupBy { it.characteristic }
+                        .forEach { (characteristic, sameStat) ->
+                            row(equipment.name.en, characteristic, sameStat.size, sameStat.first().maxLevel(equipment.level))
+                        }
                 }
             }
         }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindClosestBuildFromInputScoring.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindClosestBuildFromInputScoring.kt
@@ -168,12 +168,11 @@ fun computeCharacteristicsValues(
     // carrier item's favoured slots), folded into the fixed sum before the elemental folding and the
     // percent pass — exactly as the OR-Tools solver adds them in StatBuilder.prePercentStat, so the
     // recomputed score matches the solver's objective.
-    val characterLevel = buildCombination.characterSkills.level
     val runeContributions =
         buildMap<Characteristic, Int> {
             buildCombination.runes.forEach { (equipment, runes) ->
                 runes.forEach { rune ->
-                    merge(rune.characteristic, rune.valueOn(equipment.itemType, characterLevel), Int::plus)
+                    merge(rune.characteristic, rune.valueOn(equipment.itemType, equipment.level), Int::plus)
                 }
             }
         }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -375,7 +375,7 @@ object WakfuBuildSolver {
             addLessOrEqual(capExpr.build(), 0L)
             runeVars[equip] = perStat
         }
-        return RuneModel(runeByCharacteristic, runeVars, params.character.level)
+        return RuneModel(runeByCharacteristic, runeVars)
     }
 
     /**
@@ -1287,7 +1287,7 @@ object WakfuBuildSolver {
                 runeModel.runeByCharacteristic[char]?.let { rune ->
                     for ((equip, perStat) in runeModel.runeVars) {
                         val runeVar = perStat[char] ?: continue
-                        val coefficient = rune.valueOn(equip.itemType, runeModel.characterLevel).toLong()
+                        val coefficient = rune.valueOn(equip.itemType, equip.level).toLong()
                         if (coefficient != 0L) {
                             terms.add(Term(runeVar, coefficient))
                         }
@@ -1321,10 +1321,9 @@ object WakfuBuildSolver {
     private class RuneModel(
         val runeByCharacteristic: Map<Characteristic, RuneType>,
         val runeVars: Map<Equipment, Map<Characteristic, IntVar>>,
-        val characterLevel: Int,
     ) {
         companion object {
-            val EMPTY = RuneModel(emptyMap(), emptyMap(), 0)
+            val EMPTY = RuneModel(emptyMap(), emptyMap())
         }
     }
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -852,7 +852,7 @@ class WakfuBuildSolverTest {
     // ---------------------------------------------------------------------------------------------
 
     @Test
-    fun `rune value uses max level for the character and doubles only on favoured slots`() {
+    fun `rune value uses the item-level-capped max level and doubles only on favoured slots`() {
         // Distance-mastery rune: favoured slots (doubleBonusPosition) are belt (rawId 10) and the
         // primary weapon (rawId 15). It doubles only there.
         val distanceRune =
@@ -864,13 +864,37 @@ class WakfuBuildSolverTest {
                 doubleBonusPosition = listOf(10, 15),
                 gfxId = 0
             )
-        // Level 245 -> max rune level 11 -> base mastery value 33.
+        // Item level 245 -> max enchant level 11 -> base mastery value 33.
         assertThat(distanceRune.valueOn(ItemType.AMULET, 245)).isEqualTo(33)
         assertThat(distanceRune.valueOn(ItemType.BELT, 245)).isEqualTo(66)
         assertThat(distanceRune.valueOn(ItemType.TWO_HANDED_WEAPONS, 245)).isEqualTo(66)
-        // Level gating: at level 1 only rune level 1 is usable -> base value 1 (doubled to 2 on a belt).
+        // Item-level gating: a level-1 item caps at enchant level 1 -> base value 1 (doubled to 2 on a belt).
         assertThat(distanceRune.valueOn(ItemType.AMULET, 1)).isEqualTo(1)
         assertThat(distanceRune.valueOn(ItemType.BELT, 1)).isEqualTo(2)
+    }
+
+    @Test
+    fun `rune max level is capped by the carrier item level, not the character level`() {
+        // Regression for the level-50 amulet getting a level-3 shard: the enchant level cap follows
+        // the item's level per Ankama's table (lvl 2 needs item >= 36, lvl 3 needs item >= 51, ...).
+        val rune =
+            RuneType(27098, I18nText("d", "d", "d", "d"), RuneColor.RED, Characteristic.MASTERY_DISTANCE, listOf(10, 15), 0)
+
+        assertThat(rune.maxLevel(1)).isEqualTo(1)
+        assertThat(rune.maxLevel(35)).isEqualTo(1)
+        assertThat(rune.maxLevel(36)).isEqualTo(2)
+        assertThat(rune.maxLevel(50)).isEqualTo(2) // the reported bug: a level-50 item must cap at 2, not 3
+        assertThat(rune.maxLevel(51)).isEqualTo(3)
+        assertThat(rune.maxLevel(65)).isEqualTo(3)
+        assertThat(rune.maxLevel(66)).isEqualTo(4)
+        assertThat(rune.maxLevel(81)).isEqualTo(5)
+        assertThat(rune.maxLevel(96)).isEqualTo(6)
+        assertThat(rune.maxLevel(126)).isEqualTo(7)
+        assertThat(rune.maxLevel(141)).isEqualTo(8)
+        assertThat(rune.maxLevel(171)).isEqualTo(9)
+        assertThat(rune.maxLevel(186)).isEqualTo(10)
+        assertThat(rune.maxLevel(216)).isEqualTo(11)
+        assertThat(rune.maxLevel(245)).isEqualTo(11)
     }
 
     @Test
@@ -879,7 +903,7 @@ class WakfuBuildSolverTest {
             val level = 245
             val characterSkills = CharacterSkills(level)
             val character = Character(CharacterClass.CRA, level, level, characterSkills)
-            val amulet = equipment(1, ItemType.AMULET, "Amu", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4)
+            val amulet = equipment(1, ItemType.AMULET, "Amu", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4, level = 245)
             val distanceRune =
                 RuneType(27098, I18nText("d", "d", "d", "d"), RuneColor.RED, Characteristic.MASTERY_DISTANCE, listOf(10, 15), 0)
             val targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 1)))
@@ -965,7 +989,7 @@ class WakfuBuildSolverTest {
             val level = 245
             val characterSkills = CharacterSkills(level)
             val character = Character(CharacterClass.CRA, level, level, characterSkills)
-            val amulet = equipment(1, ItemType.AMULET, "Amu", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4)
+            val amulet = equipment(1, ItemType.AMULET, "Amu", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4, level = 245)
             val distanceRune =
                 RuneType(27098, I18nText("d", "d", "d", "d"), RuneColor.RED, Characteristic.MASTERY_DISTANCE, listOf(10, 15), 0)
             val targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 1)))
@@ -1107,11 +1131,12 @@ class WakfuBuildSolverTest {
         name: String,
         stats: Map<Characteristic, Int>,
         maxShardSlots: Int = 0,
+        level: Int = 1,
     ): Equipment =
         Equipment(
             equipmentId = id,
             guiId = id,
-            level = 1,
+            level = level,
             name = I18nText(name, name, name, name),
             rarity = Rarity.COMMON,
             itemType = type,

--- a/common-lib/src/main/kotlin/me/chosante/common/RuneType.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/RuneType.kt
@@ -27,8 +27,9 @@ enum class RuneColor(
  * modeled here because they have no [Characteristic] equivalent in the current engine.
  *
  * Values follow the **best-achievable / BiS** model (see docs/ENCHANTMENTS_PLAN.md and the
- * `autobuilder-optimistic-modeling` decision): the rune is always at the **max level** the character
- * can equip, and it **doubles** on its favoured equipment slots ([doubleBonusPosition]) exactly as
+ * `autobuilder-optimistic-modeling` decision): the rune is always at the **max level the carrier
+ * item's level allows** (see [maxLevel]), and it **doubles** on its favoured equipment slots
+ * ([doubleBonusPosition]) exactly as
  * WakForge models it — which is also the optimum a committed player can actually reach (socket colours
  * are re-rollable, but a rune can only double on the slots whose native colour matches it).
  *
@@ -45,19 +46,25 @@ data class RuneType(
     val doubleBonusPosition: List<Int>,
     val gfxId: Int,
 ) {
-    /** Best (max) rune level usable at [characterLevel], 1..11, gated by [RUNE_LEVEL_REQUIREMENTS]. */
-    fun maxLevel(characterLevel: Int): Int = RUNE_LEVEL_REQUIREMENTS.count { it <= characterLevel }.coerceIn(1, RUNE_LEVEL_REQUIREMENTS.size)
+    /**
+     * Best (max) enchantment level reachable on an item of [itemLevel], 1..11, gated by
+     * [RUNE_LEVEL_REQUIREMENTS]. The enchantment-level cap is a property of the **item's level** (an
+     * item of level 50 caps at level 2, since level 3 requires an item of level >= 51) — *not* the
+     * character's level. Socketing a rune above this cap is not possible in-game, so the engine and
+     * the Zenith export both feed the carrier item's level here.
+     */
+    fun maxLevel(itemLevel: Int): Int = RUNE_LEVEL_REQUIREMENTS.count { it <= itemLevel }.coerceIn(1, RUNE_LEVEL_REQUIREMENTS.size)
 
     /**
-     * Flat value this rune contributes when socketed on an item of [itemType] for a character of
-     * [characterLevel]: max-level base value, doubled when [itemType]'s slot raw id is one of the
-     * rune's favoured [doubleBonusPosition] slots.
+     * Flat value this rune contributes when socketed on an item of [itemType] and [itemLevel]:
+     * max-level base value (capped by [itemLevel] via [maxLevel]), doubled when [itemType]'s slot
+     * raw id is one of the rune's favoured [doubleBonusPosition] slots.
      */
     fun valueOn(
         itemType: ItemType,
-        characterLevel: Int,
+        itemLevel: Int,
     ): Int {
-        val base = baseValueTable()[maxLevel(characterLevel) - 1]
+        val base = baseValueTable()[maxLevel(itemLevel) - 1]
         val doubled = slotRawIds(itemType).any { it in doubleBonusPosition }
         return if (doubled) base * 2 else base
     }
@@ -86,7 +93,9 @@ data class RuneType(
         }
 
     companion object {
-        // Character level required to equip a rune of level 1..11. Transcribed from WakForge.
+        // Minimum *item* level required for an enchantment of level 1..11 (Ankama's official table:
+        // lvl 1 -> item 1, lvl 2 -> 36, lvl 3 -> 51, 4 -> 66, 5 -> 81, 6 -> 96, 7 -> 126, 8 -> 141,
+        // 9 -> 171, 10 -> 186, 11 -> 216). The cap follows the item's level, not the character's.
         val RUNE_LEVEL_REQUIREMENTS = listOf(0, 36, 51, 66, 81, 96, 126, 141, 171, 186, 216)
 
         // Per-rune-level value tables (index by level-1). WakForge's resistance table carries a 12th

--- a/common-lib/src/main/kotlin/me/chosante/common/history/HistoryEntry.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/history/HistoryEntry.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 import me.chosante.common.Characteristic
 import me.chosante.common.Equipment
 import me.chosante.common.Rarity
+import me.chosante.common.RuneType
 
 /**
  * The persisted, on-disk shape of a saved build. **Deliberately decoupled from the live engine
@@ -101,4 +102,11 @@ data class ResultSnapshot(
     /** Match percentage (0..100). Stored as Double to preserve the engine's BigDecimal value. */
     val match: Double,
     val optimal: Boolean,
+    /**
+     * Socketed runes per equipped item, keyed by `equipmentId` (the per-item rune list, in socket
+     * order). [RuneType] is `@Serializable`; the displayed enchantment level is derived from the
+     * carrier item's level (see `RuneType.maxLevel`), so it round-trips for free with the equipment.
+     * Empty for rune-less builds and pre-feature saves.
+     */
+    val runes: Map<Int, List<RuneType>> = emptyMap(),
 )

--- a/docs/ENCHANTMENTS_PLAN.md
+++ b/docs/ENCHANTMENTS_PLAN.md
@@ -8,7 +8,8 @@ combination/epic/relic effects). This document is the research + the concrete, p
 (`1.91.1.54`); no version bump required to start.
 
 **Decisions locked:**
-- **Runes are always at max level** for the character's level, and **doubling uses WakForge's exact
+- **Runes are always at max level** allowed by the **carrier item's level** (Ankama's table gates the
+  enchantment level by item level, not character level), and **doubling uses WakForge's exact
   model** (a rune doubles on its 2 favoured equipment slots — see §4e/§5). This is the *best
   achievable* setup, which is what an autobuilder should target — not a conservative lower bound.
 - **Sublimations:** out of scope for the mastery objective. The real home for them is a **future
@@ -40,7 +41,7 @@ combination/epic/relic effects). This document is the research + the concrete, p
 ### Runes (a.k.a. shards / "éclats")
 You socket a rune into a socket to add a stat. There are **17 runes**, one per stat. Each rune:
 - has a **colour** (1=red / 2=green / 3=blue),
-- has a **level (1→10)**, gated by character level (`shardLevelRequirement = [0,36,51,66,81,96,126,141,171,186,216]`),
+- has a **level (1→11)**, gated by the **item's level** (`shardLevelRequirement = [0,36,51,66,81,96,126,141,171,186,216]`: lvl 2 needs item ≥36, lvl 3 needs item ≥51, …),
   whose magnitude follows a **global curve** `shardLevelingCurve = [1,2,4,8,16,32,64,192,576,2304,9216]`,
 - **doubles** its value when the rune colour matches the socket colour (white sockets match any).
   Because colours are re-rollable, in BiS the player always matches → runes are effectively doubled.
@@ -160,9 +161,9 @@ it to the shown value is undocumented and irregular. So the practical answer (an
 community tool does) is to use the **final per-level value tables** directly. WakForge already
 transcribed them from in-game (`useConstants.js`); copy them verbatim. See the tables in §6.
 
-`runeValue(stat, itemSlot)` is then a **constant** (given character level), no extra variable:
+`runeValue(stat, itemSlot)` is then a **constant** (given the item's level), no extra variable:
 ```
-level     = max rune level allowed by character level   (RUNE_LEVEL_REQUIREMENTS, §6)
+level     = max rune level allowed by the item's level   (RUNE_LEVEL_REQUIREMENTS, §6)
 baseValue = LEVEL_TABLE(stat)[level - 1]                 (one of the 6 tables, §6)
 runeValue = baseValue * (itemSlot.rawId ∈ rune.doubleBonusPosition ? 2 : 1)
 ```
@@ -251,7 +252,7 @@ Global rune curve: `shardLevelingCurve = [1,2,4,8,16,32,64,192,576,2304,9216]`,
 ### Rune value per level (transcribed from WakForge `useConstants.js` — the calibration, §4e)
 Index by rune level (1 → 11); double on favoured slots. Cross-check in-game per patch.
 ```
-RUNE_LEVEL_REQUIREMENTS         = [0, 36, 51, 66, 81, 96, 126, 141, 171, 186, 216]  // char lvl gating rune lvl 1..11
+RUNE_LEVEL_REQUIREMENTS         = [0, 36, 51, 66, 81, 96, 126, 141, 171, 186, 216]  // item lvl gating rune lvl 1..11
 RUNE_MASTERY_LEVEL_VALUES       = [1, 3, 4, 6, 7, 10, 15, 19, 24, 30, 33]   // melee/distance/berserk/critical/rear/healing
 RUNE_ELEMENTAL_MASTERY_VALUES   = [1, 2, 3, 4, 5, 7, 10, 13, 16, 20, 22]    // generic elemental mastery
 RUNE_RESISTANCE_LEVEL_VALUES    = [2, 5, 7, 10, 12, 15, 17, 20, 22, 25, 27, 30]   // earth/fire/water/air resistance

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/HistoryMapping.kt
@@ -76,7 +76,8 @@ fun UiState.toHistoryEntry(
                 skills = build.characterSkills.toFlatMap(),
                 achieved = achieved,
                 match = match.toDouble(),
-                optimal = optimal
+                optimal = optimal,
+                runes = build.runes.entries.associate { (equip, runes) -> equip.equipmentId to runes }
             ),
         zenithUrl = zenithUrl,
         tags = tags,
@@ -117,12 +118,19 @@ fun reconstructSkills(
     return skills
 }
 
-/** Reconstructs the discovered build (equipment + skills) for display when loading an entry. */
-fun HistoryEntry.toBuildCombination(): BuildCombination =
-    BuildCombination(
+/** Reconstructs the discovered build (equipment + skills + socketed runes) for display when loading an entry. */
+fun HistoryEntry.toBuildCombination(): BuildCombination {
+    val equipmentById = result.equipments.associateBy { it.equipmentId }
+    val runes =
+        result.runes
+            .mapNotNull { (equipmentId, runeList) -> equipmentById[equipmentId]?.let { it to runeList } }
+            .toMap()
+    return BuildCombination(
         equipments = result.equipments,
-        characterSkills = reconstructSkills(request.level, result.skills)
+        characterSkills = reconstructSkills(request.level, result.skills),
+        runes = runes
     )
+}
 
 /** Restores the saved target list into displayable [TargetRow]s (catalog-backed, like defaults). */
 fun HistoryEntry.toTargetRows(): List<TargetRow> = request.targets.mapNotNull { statDefFor(it.characteristic)?.toRow(it.value)?.copy(weight = it.weight) }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -91,6 +91,7 @@ enum class Tr(
     ),
     EMPTY("empty", "vide"),
     LEVEL_PREFIX_LONG("Level", "Niveau"),
+    LEVEL_PREFIX_SHORT("Lv", "Niv"),
     DISCLAIMER(
         "Unofficial fan tool - not affiliated with Ankama - item art © Ankama (community-sourced)",
         "Outil de fan non officiel - non affilié à Ankama - visuels © Ankama (communautaires)"

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
@@ -573,7 +573,13 @@ private fun ItemTooltip(
             runes
                 .groupBy { it.characteristic }
                 .forEach { (_, sameStatRunes) ->
-                    TooltipRuneRow(rune = sameStatRunes.first(), count = sameStatRunes.size, lang = lang)
+                    TooltipRuneRow(
+                        rune = sameStatRunes.first(),
+                        count = sameStatRunes.size,
+                        // Enchantment level is gated by the carrier item's level (Ankama's table).
+                        level = sameStatRunes.first().maxLevel(equipment.level),
+                        lang = lang
+                    )
                 }
         }
     }
@@ -628,6 +634,7 @@ private fun RuneShape(
 private fun TooltipRuneRow(
     rune: RuneType,
     count: Int,
+    level: Int,
     lang: Lang,
 ) {
     Row(
@@ -650,6 +657,16 @@ private fun TooltipRuneRow(
             modifier = Modifier.weight(1f),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
+        )
+        // Enchantment level, capped by the carrier item's level (e.g. "Lv 3").
+        Text(
+            text = "${tr(Tr.LEVEL_PREFIX_SHORT)} $level",
+            style =
+                WTypography.labelSmall.copy(
+                    fontFamily = WType.mono,
+                    fontWeight = FontWeight.SemiBold,
+                    color = WColor.faint
+                )
         )
     }
 }

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
@@ -8,6 +8,9 @@ import me.chosante.common.Equipment
 import me.chosante.common.I18nText
 import me.chosante.common.ItemType
 import me.chosante.common.Rarity
+import me.chosante.common.RuneColor
+import me.chosante.common.RuneType
+import me.chosante.common.history.HistoryEntry
 import me.chosante.common.skills.CharacterSkills
 import me.chosante.ui.state.ItemChip
 import me.chosante.ui.state.UiState
@@ -114,6 +117,65 @@ class HistoryMappingTest {
         val rebuilt = entry.toBuildCombination()
         assertThat(rebuilt.equipments).isEqualTo(listOf(cape))
         assertThat(rebuilt.characterSkills.allCharacteristicValues).isEqualTo(skills.allCharacteristicValues)
+    }
+
+    @Test
+    fun `socketed runes survive a clipboard export-import round-trip and reattach to their item`() {
+        // A level-50 amulet enchanted with two distance runes: the enchant level is item-level-gated
+        // (item 50 -> level 2), so it must be derivable after a full JSON round-trip.
+        val amulet =
+            Equipment(
+                equipmentId = 7,
+                guiId = 7,
+                level = 50,
+                name = I18nText(fr = "Amulette", en = "Amulet", es = "", pt = ""),
+                rarity = Rarity.RARE,
+                itemType = ItemType.AMULET,
+                characteristics = mapOf(Characteristic.MASTERY_DISTANCE to 30),
+                maxShardSlots = 2
+            )
+        val distanceRune =
+            RuneType(
+                id = 27098,
+                name = I18nText("Distance", "Distance", "", ""),
+                color = RuneColor.RED,
+                characteristic = Characteristic.MASTERY_DISTANCE,
+                doubleBonusPosition = listOf(10, 15),
+                gfxId = 0
+            )
+        val build =
+            BuildCombination(
+                equipments = listOf(amulet),
+                characterSkills = CharacterSkills(110),
+                runes = mapOf(amulet to listOf(distanceRune, distanceRune))
+            )
+        val ui =
+            UiState(
+                clazz = CharacterClass.CRA,
+                level = 110,
+                minLevel = 110,
+                mode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                maxRarity = Rarity.EPIC,
+                duration = "30",
+                stopAtMatch = false,
+                targets = listOfNotNull(statDefFor(Characteristic.MASTERY_DISTANCE)?.toRow("1")),
+                build = build,
+                achieved = mapOf(Characteristic.MASTERY_DISTANCE to 100),
+                match = BigDecimal("100"),
+                optimal = true
+            )
+
+        val entry = ui.toHistoryEntry(id = "id-2", name = "Runed", note = null, createdAt = 1L, dataVersion = "v")!!
+        // Go through the very JSON codec used by the clipboard export/import.
+        val restored = historyJson.decodeFromString(HistoryEntry.serializer(), historyJson.encodeToString(HistoryEntry.serializer(), entry))
+
+        val rebuilt = restored.toBuildCombination()
+        val rebuiltAmulet = rebuilt.equipments.single()
+        val runes = rebuilt.runes[rebuiltAmulet].orEmpty()
+        assertThat(runes).hasSize(2)
+        assertThat(runes).allMatch { it.characteristic == Characteristic.MASTERY_DISTANCE }
+        // Item-level-gated enchant level is preserved (derived from the carrier item's level 50 -> 2).
+        assertThat(runes.first().maxLevel(rebuiltAmulet.level)).isEqualTo(2)
     }
 
     @Test

--- a/zenith-builder/src/main/kotlin/me/chosante/ZenithBuilder.kt
+++ b/zenith-builder/src/main/kotlin/me/chosante/ZenithBuilder.kt
@@ -51,7 +51,7 @@ suspend fun ZenithInputParameters.createZenithBuild() =
                                     runeId = rune.id,
                                     position = index,
                                     side = sideValue,
-                                    level = rune.maxLevel(character.level)
+                                    level = rune.maxLevel(equipment.level)
                                 )
                             }
                         }


### PR DESCRIPTION
## The bug

A level-50 amulet was being given a **level-3 shard** when exported to Zenith. In Wakfu the **enchantment level of an item is gated by the item's level**, per Ankama's official table:

| Enchant level | Min item level |
|---|---|
| 1 | 1 |
| 2 | 36 |
| 3 | 51 |
| 4 | 66 |
| 5 | 81 |
| 6 | 96 |
| 7 | 126 |
| 8 | 141 |
| 9 | 171 |
| 10 | 186 |
| 11 | 216 |

So a level-50 item caps at enchant level **2** (level 3 requires item ≥ 51).

The code had the threshold table right (`RUNE_LEVEL_REQUIREMENTS = [0,36,51,66,…]`) but indexed it by the **character's level** instead of the **item's level**. On a level-51+ character, a level-50 item therefore got a level-3 shard. Beyond the wrong Zenith export, the solver also **over-valued runes on low-level items** (`valueOn` used the character level), skewing the optimization.

## The fix

Cap the enchantment level by the **carrier item's level** everywhere a rune is valued or exported:

- `RuneType.maxLevel(itemLevel)` / `valueOn(itemType, itemLevel)` — param renamed + docs corrected.
- `WakfuBuildSolver` uses `equip.level` (and drops the now-dead `RuneModel.characterLevel`).
- `FindClosestBuildFromInputScoring` uses `equipment.level`.
- `ZenithBuilder` export uses `equipment.level`.
- `docs/ENCHANTMENTS_PLAN.md` corrected (item level, not character level).

Since equippable items are filtered to `equipment.level <= character.level`, the item level is always the binding (≤) cap.

## Test

Adds a regression test walking the full threshold table — item 35 → 1, **50 → 2** (the reported bug), 51 → 3, 65 → 3, 66 → 4, … 216 → 11. The existing `valueOn` test was reframed in item-level terms.

## Verification

`./gradlew test ktlintCheck` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)