### PR TITLE
feat(gui): show app and game-data versions in the footer

### DIFF
--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -96,6 +96,8 @@ enum class Tr(
         "Unofficial fan tool - not affiliated with Ankama - item art © Ankama (community-sourced)",
         "Outil de fan non officiel - non affilié à Ankama - visuels © Ankama (communautaires)"
     ),
+    APP_VERSION_LABEL("Version", "Version"),
+    GAME_DATA_LABEL("Game data", "Données de jeu"),
     SLOT_HELMET("Helmet", "Casque"),
     SLOT_AMULET("Amulet", "Amulette"),
     SLOT_EPAULETTES("Epaulettes", "Épaulettes"),

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.PopupPositionProvider
+import me.chosante.autobuilder.genetic.wakfu.WakfuBestBuildFinderAlgorithm
 import me.chosante.common.Equipment
 import me.chosante.common.RuneColor
 import me.chosante.common.RuneType
@@ -71,6 +72,7 @@ import me.chosante.ui.i18n.label
 import me.chosante.ui.i18n.tr
 import me.chosante.ui.state.Phase
 import me.chosante.ui.state.UiState
+import me.chosante.ui.state.WhatsNew
 import me.chosante.ui.state.color
 import me.chosante.ui.state.statColor
 import me.chosante.ui.theme.WColor
@@ -156,16 +158,37 @@ fun PaperdollPanel(
                 )
             }
         }
-        Text(
-            text = tr(Tr.DISCLAIMER),
-            style = WTypography.labelSmall,
-            textAlign = TextAlign.Center,
+        val appVersion = WhatsNew.appVersion
+        val versionPrefix = tr(Tr.APP_VERSION_LABEL)
+        val gameDataPrefix = tr(Tr.GAME_DATA_LABEL)
+        val dataVersion = WakfuBestBuildFinderAlgorithm.dataVersion
+        val versionLine =
+            if (appVersion != null) {
+                "$versionPrefix $appVersion  ·  $gameDataPrefix $dataVersion"
+            } else {
+                "$gameDataPrefix $dataVersion"
+            }
+        Column(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .border(1.dp, WColor.hairline)
-                    .padding(vertical = 10.dp, horizontal = WDimens.pad)
-        )
+                    .padding(vertical = 10.dp, horizontal = WDimens.pad),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(3.dp)
+        ) {
+            Text(
+                text = tr(Tr.DISCLAIMER),
+                style = WTypography.labelSmall,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = versionLine,
+                style = WTypography.labelSmall,
+                color = WColor.muted,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## What

Adds a second line under the disclaimer footer of the **Discovered Build** panel showing the running versions:

> Unofficial fan tool - not affiliated with Ankama - item art © Ankama (community-sourced)
> **Version 1.4.0  ·  Game data 1.91.1.54**

FR: **Version 1.4.0  ·  Données de jeu 1.91.1.54**

## Why

Makes it easy to tell, at a glance, which build of the app and which Wakfu data set a user is running — useful for bug reports and for knowing whether a data bump is needed.

## How

- **App version** comes from the already baked-in `app-version.txt` (generated by `generateVersionResource`, kept in sync by release-please), read via the existing `WhatsNew.appVersion`.
- **Game-data version** comes from `WakfuBestBuildFinderAlgorithm.dataVersion` — the public, lazy-safe const already used to stamp saved builds (no JSON parse triggered).
- The app-version segment is **omitted gracefully** when the resource is absent (IDE/raw test runs), leaving just the game-data line.
- The version line uses `WColor.muted` for a subtle hierarchy below the disclaimer.
- New EN/FR i18n keys: `APP_VERSION_LABEL`, `GAME_DATA_LABEL`.

## Verification

- `./gradlew :gui-compose:ktlintCheck` ✅
- `./gradlew :gui-compose:test` ✅
- Rendered via the screenshot smoke test (`WAKFU_COMPOSE_SCREENSHOT`) — footer shows the two lines correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)