### PR TITLE
fix(cli): graceful message when search emits no build

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
@@ -35,7 +35,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.flow.lastOrNull
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
@@ -650,7 +650,7 @@ HUPPERMAGE"""
 
         runBlocking {
             val progressBar = progressBar(terminal)
-            val bestCombination =
+            val bestResult =
                 WakfuBestBuildFinderAlgorithm
                     .run(
                         WakfuBestBuildParams(
@@ -680,7 +680,19 @@ HUPPERMAGE"""
                         delay(1000L)
                     }.onCompletion {
                         progressBar.stop()
-                    }.last()
+                    }.lastOrNull()
+            // A short --duration on a cold JVM can let OR-Tools' native cold start consume the whole
+            // time budget (most often in max-damage mode) so the flow emits nothing; .lastOrNull()
+            // then yields null. Fail with a clear hint instead of letting NoSuchElementException crash
+            // the CLI with a stack trace.
+            if (bestResult == null) {
+                throw PrintMessage(
+                    message = "No build found within the time budget — try a longer --duration.",
+                    printError = true
+                )
+            }
+            val bestCombination =
+                bestResult
                     .individual
                     .also {
                         terminal.println("Research result")


### PR DESCRIPTION
## Problem

In `autobuilder`'s `Main.kt`, `run()` collects the build-search flow with `.last()`. In `FIND_BUILD_WITH_MAX_DAMAGE` mode, if the search emits nothing — e.g. a very short `--duration` on a cold JVM where the OR-Tools native cold start consumes the whole budget — `.last()` throws `java.util.NoSuchElementException: Expected at least one element`, crashing the CLI with a stack trace instead of a helpful message.

**Reproduce** (cold build, first OR-Tools run):
```sh
./gradlew :autobuilder:run --args='--class cra --max-level 165 --computation-mode max-damage --duration 3'
```
With `--duration 20` it works. This affects all max-damage searches, not just boss mode.

## Fix

Replace the unguarded `.last()` with `.lastOrNull()` and, when the result is `null`, throw `PrintMessage(printError = true)` with a clear hint — the same graceful-error pattern the file already uses for bad input:

> No build found within the time budget — try a longer --duration.

Behavior is unchanged when at least one result is emitted. The progress bar is already stopped via the flow's `onCompletion` before the message prints.

## Verification

`./gradlew :autobuilder:test ktlintCheck` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)