### PR TITLE
feat(rotation): bound spell rotations by real per-turn cast limits + extract WP cost

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/EmbeddedResources.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/EmbeddedResources.kt
@@ -1,0 +1,20 @@
+package me.chosante.autobuilder
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Single source for loading the baked `*-v<VERSION>.json` data artifacts off the classpath. Replaces the
+ * `getResourceAsStream(name)?.readAllBytes()?.let { Json.decodeFromString<List<T>>(String(it)) }` idiom
+ * that was copy-pasted across the equipments / runes / monsters / sublimations loaders in
+ * [WakfuBestBuildFinderAlgorithm] and the spells / cast-limits loaders in
+ * [me.chosante.autobuilder.domain.SpellCatalog] (the copies had already started to drift). Callers decide
+ * the missing-resource policy: `!!` for a required artifact, `?: emptyList()` / `.orEmpty()` for optional.
+ */
+internal object EmbeddedResources {
+    /** Decode classpath resource [name] as a `List<T>`, or null when the resource is absent. */
+    inline fun <reified T> decodeList(name: String): List<T>? =
+        EmbeddedResources::class.java.classLoader
+            .getResourceAsStream(name)
+            ?.readAllBytes()
+            ?.let { Json.decodeFromString<List<T>>(String(it)) }
+}

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellCatalog.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellCatalog.kt
@@ -1,9 +1,10 @@
 package me.chosante.autobuilder.domain
 
-import kotlinx.serialization.json.Json
+import me.chosante.autobuilder.EmbeddedResources
 import me.chosante.autobuilder.VERSION
 import me.chosante.common.CharacterClass
 import me.chosante.common.Spell
+import me.chosante.common.SpellCastLimit
 import me.chosante.common.SpellElement
 
 /**
@@ -19,11 +20,20 @@ import me.chosante.common.SpellElement
  */
 object SpellCatalog {
     val spells: List<Spell> by lazy {
-        this.javaClass.classLoader
-            .getResourceAsStream("spells-v$VERSION.json")
-            ?.readAllBytes()
-            ?.let { Json.decodeFromString<List<Spell>>(String(it)) }
-            ?: emptyList()
+        val base = EmbeddedResources.decodeList<Spell>("spells-v$VERSION.json") ?: emptyList()
+        // Join the baked per-spell cast limits (produced by bdata-extractor, see
+        // docs/SPELL_CAST_LIMITS_EXTRACTION.md) onto each spell by id. The binary id space == the
+        // encyclopedia id space, so the join is direct; a spell with no matching record keeps its null
+        // (unbounded) limits, which the rotation optimizer treats as "no cap" — safe by construction.
+        val castLimitsBySpellId =
+            EmbeddedResources
+                .decodeList<SpellCastLimit>("spell-cast-limits-v$VERSION.json")
+                .orEmpty()
+                .associateBy { it.spellId }
+        base.map { spell ->
+            val limit = castLimitsBySpellId[spell.id] ?: return@map spell
+            spell.copy(maxCastPerTurn = limit.maxCastPerTurn, cooldown = limit.cooldown, wpCost = limit.wpCost)
+        }
     }
 
     private val byClass: Map<CharacterClass, List<Spell>> by lazy { spells.groupBy { it.clazz } }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellRotation.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellRotation.kt
@@ -60,16 +60,20 @@ data class SpellRotation(
  * blow up the constraint model. It reuses the existing [BuildSpellDamage] / [SpellDamage] /
  * [SpellCatalog] helpers, so the maths stays in one place.
  *
- * **Model.** Per-spell AP cost + expected damage are known; **per-turn cast limits and cooldowns are
- * not in the dataset yet** (parsed as null). So the optimum is an **unbounded knapsack** over the AP
- * budget — each spell may repeat — solved exactly by DP. The result is the true optimum *under the
- * known constraints*; when a single spell dominates on damage-per-AP the rotation spams it, which is
- * the honest answer until cast-limit data exists (then pass [maxCastsPerSpell]).
+ * **Model.** Per-spell AP cost + expected damage are known, and each spell's **per-turn cast limit**
+ * ([Spell.maxCastsThisTurn], from the baked cast-limit data joined in [SpellCatalog]) bounds how often
+ * it may repeat. So the optimum is a **bounded knapsack** over the AP budget — each spell repeats up to
+ * its limit (a spell with no limit repeats freely, collapsing to the unbounded knapsack) — solved
+ * exactly by DP. The result is the true optimum under those caps. WP cost is carried ([Spell.wpCost])
+ * but not yet folded in — WP is a per-fight pool, not a per-turn cap; see `docs/FULL_DAMAGE_PLAN.md` "Lot 1".
  */
 object SpellRotationOptimizer {
     /**
-     * Exact best rotation for [apBudget] AP over [scored] (unbounded knapsack DP). [maxCastsPerSpell]
-     * optionally caps how often any one spell is used (for when cast-limit data lands); null = no cap.
+     * Exact best rotation for [apBudget] AP over [scored]. Each spell is capped at its real per-turn
+     * cast limit ([Spell.maxCastsThisTurn], from the baked cast-limit data); [maxCastsPerSpell]
+     * optionally tightens *every* spell further with a uniform cap. When nothing is capped below what
+     * the AP budget would fit, this is the plain unbounded knapsack; otherwise a bounded one. The
+     * result is the true optimum under those caps.
      */
     fun bestRotation(
         scored: List<ScoredSpell>,
@@ -82,11 +86,23 @@ object SpellRotationOptimizer {
             return SpellRotation(element, apBudget.coerceAtLeast(0), 0, emptyList(), 0.0)
         }
 
+        // The most copies of each spell that fit in the AP budget — the single source of truth for both
+        // the cap clamp and the "is anything actually capped?" test below.
+        val maxFits = items.map { apBudget / it.apCost }
+        // Per-spell cap = the spell's own per-turn limit, tightened by the optional uniform override,
+        // and never more copies than fit. A null component (no data cap, no override) means "unbounded".
+        val caps =
+            items.mapIndexed { i, item ->
+                val limit = listOfNotNull(item.spell.maxCastsThisTurn, maxCastsPerSpell).minOrNull()
+                (limit ?: maxFits[i]).coerceIn(0, maxFits[i])
+            }
+
         val counts =
-            if (maxCastsPerSpell == null) {
+            if (caps.indices.none { caps[it] < maxFits[it] }) {
+                // Nothing is capped below what would fit, so the unbounded knapsack is already exact.
                 unboundedKnapsack(items, apBudget)
             } else {
-                boundedKnapsack(items, apBudget, maxCastsPerSpell)
+                boundedKnapsack(items, apBudget, caps)
             }
 
         val casts =
@@ -137,46 +153,48 @@ object SpellRotationOptimizer {
     }
 
     /**
-     * Exact bounded knapsack: each spell may be cast at most [cap] times. Solved as a 0/1 knapsack over
-     * [cap] identical copies per spell, so it yields the **true** capped optimum — not the greedy
-     * single-path approximation the old code used. This is the path the cast-limit data (`maxCastsPerSpell`)
-     * feeds, so it must be exact.
+     * Exact bounded knapsack: spell `i` may be cast at most `caps[i]` times (its real per-turn limit).
+     * Uses the **same item-layered DP as [baseThroughputTable]** — keep the two in lockstep, since they
+     * bound the rotation identically (that one builds the build-independent base-damage table the CP-SAT
+     * objective reads; this one the per-build expected-damage rotation for display/scoring). Each `next`
+     * layer reads the previous `dp`, so a spell is never used past its cap and an uncapped spell
+     * (`caps[i] = budget/cost`) costs nothing extra — no copy expansion. `choice[i][a]` records how many
+     * times spell `i` is cast in the optimum at `a` AP, used to reconstruct the per-spell counts.
      */
     private fun boundedKnapsack(
         items: List<ScoredSpell>,
         apBudget: Int,
-        cap: Int,
+        caps: List<Int>,
     ): Map<Int, Int> {
-        if (cap <= 0) return emptyMap()
-        // Expand to `cap` copies of each spell, keeping the original index so copies aggregate per spell.
-        val idx = ArrayList<Int>()
-        val ap = ArrayList<Int>()
-        val dmg = ArrayList<Double>()
-        items.forEachIndexed { i, item ->
-            repeat(cap) {
-                idx += i
-                ap += item.apCost
-                dmg += item.expectedDamagePerCast
-            }
-        }
-        val n = idx.size
-        // dp[k][a] = max damage using the first k copies within `a` AP (classic 0/1 knapsack).
-        val dp = Array(n + 1) { DoubleArray(apBudget + 1) }
-        for (k in 1..n) {
-            for (a in 0..apBudget) {
-                dp[k][a] = dp[k - 1][a]
-                if (ap[k - 1] <= a) {
-                    val candidate = dp[k - 1][a - ap[k - 1]] + dmg[k - 1]
-                    if (candidate > dp[k][a]) dp[k][a] = candidate
+        val n = items.size
+        var dp = DoubleArray(apBudget + 1)
+        val choice = Array(n) { IntArray(apBudget + 1) }
+        for (i in 0 until n) {
+            val cost = items[i].apCost
+            val value = items[i].expectedDamagePerCast
+            val cap = caps[i].coerceAtLeast(0)
+            val next = dp.copyOf()
+            for (a in cost..apBudget) {
+                var k = 1
+                while (k <= cap && k * cost <= a) {
+                    val candidate = dp[a - k * cost] + k * value
+                    if (candidate > next[a]) {
+                        next[a] = candidate
+                        choice[i][a] = k
+                    }
+                    k++
                 }
             }
+            dp = next
         }
+        // Reconstruct counts by walking the layers back, spending the AP each spell's chosen casts used.
         val counts = HashMap<Int, Int>()
         var a = apBudget
-        for (k in n downTo 1) {
-            if (dp[k][a] != dp[k - 1][a]) { // copy k-1 was taken
-                counts[idx[k - 1]] = (counts[idx[k - 1]] ?: 0) + 1
-                a -= ap[k - 1]
+        for (i in n - 1 downTo 0) {
+            val k = choice[i][a]
+            if (k > 0) {
+                counts[i] = k
+                a -= k * items[i].apCost
             }
         }
         return counts
@@ -360,25 +378,55 @@ object SpellRotationOptimizer {
 
     /**
      * Build-independent per-AP throughput table for [spells]: `table[ap]` = the maximum total **base**
-     * damage castable within `ap` AP (unbounded knapsack on each spell's base damage / AP cost). Index
-     * `0..maxAp`. This is the spell-selection the CP-SAT objective looks up by the build's AP variable —
-     * the per-build mastery multiplier is common to all same-element spells, so it factors out and the
-     * knapsack stays build-independent. Spells without an AP cost or base damage are skipped.
+     * damage castable within `ap` AP, **bounded by each spell's real per-turn cast limit**
+     * ([Spell.maxCastsThisTurn]). Index `0..maxAp`. This is the spell-selection the CP-SAT objective
+     * looks up by the build's AP variable — the per-build mastery multiplier is common to all
+     * same-element spells, so it factors out and the knapsack stays build-independent. Spells without an
+     * AP cost or base damage are skipped.
+     *
+     * **Why bounded.** Without the cap a single high-throughput spell is spammed to fill the AP budget,
+     * which the game disallows; the cap makes the modelled rotation realistic. The DP is the
+     * item-layered bounded knapsack (each spell `s` used at most `c_s` times); a spell with no per-turn
+     * limit gets `c_s = maxAp`, which is `>= maxAp/cost`, so it behaves exactly like the previous
+     * unbounded table. The CP-SAT objective reads this table through the **unchanged**
+     * `addElement(apVar, table, throughput)` call — only the table's *contents* change, so the
+     * optimality argument is intact (see `docs/FULL_DAMAGE_PLAN.md` "Lot 1").
      */
     fun baseThroughputTable(
         spells: List<Spell>,
         maxAp: Int,
     ): LongArray {
-        val items = spells.mapNotNull { s -> s.apCost?.let { ap -> s.baseDamage?.let { base -> ap to base.toLong() } } }
-        val table = LongArray(maxAp + 1)
-        for (ap in 1..maxAp) {
-            var best = table[ap - 1]
-            for ((cost, base) in items) {
-                if (cost in 1..ap) best = maxOf(best, table[ap - cost] + base)
+        // (apCost, baseDamage, perTurnCap). perTurnCap = the spell's per-turn cast limit, or maxAp when
+        // unbounded (no more than maxAp/cost copies fit in maxAp AP anyway).
+        val items =
+            spells.mapNotNull { s ->
+                val cost = s.apCost ?: return@mapNotNull null
+                if (cost < 1) return@mapNotNull null
+                val base = s.baseDamage?.toLong() ?: return@mapNotNull null
+                Triple(cost, base, s.maxCastsThisTurn ?: maxAp)
             }
-            table[ap] = best
+        // Item-layered bounded knapsack (mirrored by [boundedKnapsack], which reconstructs per-spell counts
+        // from the same recurrence — keep the two in lockstep): each `next` layer reads the *previous* `dp`,
+        // so spell `s` is counted at most `cap` times across the whole table — never reused beyond its limit.
+        var dp = LongArray(maxAp + 1)
+        for ((cost, base, cap) in items) {
+            val next = dp.copyOf()
+            for (ap in cost..maxAp) {
+                var k = 1
+                while (k <= cap && k * cost <= ap) {
+                    val candidate = dp[ap - k * cost] + k * base
+                    if (candidate > next[ap]) next[ap] = candidate
+                    k++
+                }
+            }
+            dp = next
         }
-        return table
+        // Enforce the "≤ ap" contract (table[ap] = best castable within *at most* ap AP). The layered DP
+        // above is already monotone non-decreasing, so this pass is normally a no-op; it is kept as a cheap,
+        // explicit guarantee — the CP-SAT objective indexes the table by the AP variable and relies on more
+        // AP never lowering throughput — that stays correct even if the DP recurrence is later changed.
+        for (ap in 1..maxAp) dp[ap] = maxOf(dp[ap], dp[ap - 1])
+        return dp
     }
 
     private fun resolvedActionPoints(

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
@@ -2,7 +2,7 @@ package me.chosante.autobuilder.genetic.wakfu
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.serialization.json.Json
+import me.chosante.autobuilder.EmbeddedResources
 import me.chosante.autobuilder.VERSION
 import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.domain.DamageScenario
@@ -33,9 +33,7 @@ object WakfuBestBuildFinderAlgorithm {
     // paint. Lazy init moves the parse to the first real use (icon preloading / the first search),
     // which always happens on a background thread in the GUI and on the main thread in the CLI.
     val equipments: List<Equipment> by lazy {
-        this.javaClass.classLoader.getResourceAsStream("equipments-v$VERSION.json")?.readAllBytes()!!.let {
-            Json.decodeFromString<List<Equipment>>(String(it))
-        }
+        EmbeddedResources.decodeList<Equipment>("equipments-v$VERSION.json")!!
     }
 
     /**
@@ -43,9 +41,7 @@ object WakfuBestBuildFinderAlgorithm {
      * absent. The OR-Tools solver socket-fills equipped items with these when [WakfuBestBuildParams.useRunes].
      */
     val runes: List<RuneType> by lazy {
-        this.javaClass.classLoader.getResourceAsStream("runes-v$VERSION.json")?.readAllBytes()?.let {
-            Json.decodeFromString<List<RuneType>>(String(it))
-        } ?: emptyList()
+        EmbeddedResources.decodeList<RuneType>("runes-v$VERSION.json") ?: emptyList()
     }
 
     /**
@@ -54,9 +50,7 @@ object WakfuBestBuildFinderAlgorithm {
      * Sorted bosses-first / higher-level-first, as produced by the `monsters-extractor`.
      */
     val monsters: List<Monster> by lazy {
-        this.javaClass.classLoader.getResourceAsStream("monsters-v$VERSION.json")?.readAllBytes()?.let {
-            Json.decodeFromString<List<Monster>>(String(it))
-        } ?: emptyList()
+        EmbeddedResources.decodeList<Monster>("monsters-v$VERSION.json") ?: emptyList()
     }
 
     /**
@@ -86,9 +80,7 @@ object WakfuBestBuildFinderAlgorithm {
      * user [WakfuBestBuildParams.forcedSublimations]; see docs/SUBLIMATIONS_LOT3_RESEARCH.md.
      */
     val sublimations: List<Sublimation> by lazy {
-        this.javaClass.classLoader.getResourceAsStream("sublimations-v$VERSION.json")?.readAllBytes()?.let {
-            Json.decodeFromString<List<Sublimation>>(String(it))
-        } ?: emptyList()
+        EmbeddedResources.decodeList<Sublimation>("sublimations-v$VERSION.json") ?: emptyList()
     }
 
     fun run(params: WakfuBestBuildParams): Flow<GeneticAlgorithmResult<BuildCombination>> {

--- a/autobuilder/src/main/resources/spell-cast-limits-v1.91.1.54.json
+++ b/autobuilder/src/main/resources/spell-cast-limits-v1.91.1.54.json
@@ -6,7 +6,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6968,
@@ -15,7 +16,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6969,
@@ -24,7 +26,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6970,
@@ -33,7 +36,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6971,
@@ -42,7 +46,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6972,
@@ -51,7 +56,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6973,
@@ -60,7 +66,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6974,
@@ -69,7 +76,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6975,
@@ -78,7 +86,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6976,
@@ -87,7 +96,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6977,
@@ -96,7 +106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6978,
@@ -105,7 +116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6979,
@@ -114,7 +126,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6980,
@@ -123,7 +136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6981,
@@ -132,7 +146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6982,
@@ -141,7 +156,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 0
   },
   {
     "spellId": 6983,
@@ -150,7 +166,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 6984,
@@ -159,7 +176,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6985,
@@ -168,7 +186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 6986,
@@ -177,7 +196,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6987,
@@ -186,7 +206,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6988,
@@ -195,7 +216,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6989,
@@ -204,7 +226,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6990,
@@ -213,7 +236,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6991,
@@ -222,7 +246,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6992,
@@ -231,7 +256,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6993,
@@ -240,7 +266,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6994,
@@ -249,7 +276,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6995,
@@ -258,7 +286,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6996,
@@ -267,7 +296,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6997,
@@ -276,7 +306,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6998,
@@ -285,7 +316,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6999,
@@ -294,7 +326,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7000,
@@ -303,7 +336,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7001,
@@ -312,7 +346,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7002,
@@ -321,7 +356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7003,
@@ -330,7 +366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7004,
@@ -339,7 +376,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7005,
@@ -348,7 +386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7307,
@@ -357,7 +396,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7308,
@@ -366,7 +406,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7309,
@@ -375,7 +416,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7310,
@@ -384,7 +426,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7311,
@@ -393,7 +436,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7312,
@@ -402,7 +446,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7313,
@@ -411,7 +456,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7314,
@@ -420,7 +466,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7315,
@@ -429,7 +476,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7316,
@@ -438,7 +486,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7317,
@@ -447,7 +496,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7318,
@@ -456,7 +506,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7319,
@@ -465,7 +516,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7320,
@@ -474,7 +526,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7321,
@@ -483,7 +536,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7322,
@@ -492,7 +546,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 7323,
@@ -501,7 +556,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 3
   },
   {
     "spellId": 7324,
@@ -510,7 +566,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 7325,
@@ -519,7 +576,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7326,
@@ -528,7 +586,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7327,
@@ -537,7 +596,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7328,
@@ -546,7 +606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7329,
@@ -555,7 +616,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7330,
@@ -564,7 +626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7331,
@@ -573,7 +636,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7332,
@@ -582,7 +646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7333,
@@ -591,7 +656,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7334,
@@ -600,7 +666,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7335,
@@ -609,7 +676,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7336,
@@ -618,7 +686,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7337,
@@ -627,7 +696,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7338,
@@ -636,7 +706,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7339,
@@ -645,7 +716,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7340,
@@ -654,7 +726,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7341,
@@ -663,7 +736,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7342,
@@ -672,7 +746,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7343,
@@ -681,7 +756,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7344,
@@ -690,7 +766,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2008,
@@ -699,7 +776,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2009,
@@ -708,7 +786,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2010,
@@ -717,7 +796,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2011,
@@ -726,7 +806,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2012,
@@ -735,7 +816,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2013,
@@ -744,7 +826,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2014,
@@ -753,7 +836,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2015,
@@ -762,7 +846,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2016,
@@ -771,7 +856,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2017,
@@ -780,7 +866,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 2018,
@@ -789,7 +876,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2019,
@@ -798,7 +886,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2021,
@@ -807,7 +896,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2022,
@@ -816,7 +906,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2026,
@@ -825,7 +916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 0
   },
   {
     "spellId": 2028,
@@ -834,7 +926,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2032,
@@ -843,7 +936,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2037,
@@ -852,7 +946,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2039,
@@ -861,7 +956,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2064,
@@ -870,7 +966,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 5059,
@@ -879,7 +976,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5071,
@@ -888,7 +986,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5075,
@@ -897,7 +996,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5076,
@@ -906,7 +1006,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6324,
@@ -915,7 +1016,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6326,
@@ -924,7 +1026,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6337,
@@ -933,7 +1036,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8240,
@@ -942,7 +1046,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8242,
@@ -951,7 +1056,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 1
   },
   {
     "spellId": 8272,
@@ -960,7 +1066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8273,
@@ -969,7 +1076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8274,
@@ -978,7 +1086,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8275,
@@ -987,7 +1096,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8276,
@@ -996,7 +1106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8277,
@@ -1005,7 +1116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8278,
@@ -1014,7 +1126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8279,
@@ -1023,7 +1136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8280,
@@ -1032,7 +1146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4579,
@@ -1041,7 +1156,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4581,
@@ -1050,7 +1166,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4583,
@@ -1059,7 +1176,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4584,
@@ -1068,7 +1186,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4585,
@@ -1077,7 +1196,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4586,
@@ -1086,7 +1206,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4587,
@@ -1095,7 +1216,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4588,
@@ -1104,7 +1226,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4589,
@@ -1113,7 +1236,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4590,
@@ -1122,7 +1246,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4592,
@@ -1131,7 +1256,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4593,
@@ -1140,7 +1266,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4594,
@@ -1149,7 +1276,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4595,
@@ -1158,7 +1286,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4596,
@@ -1167,7 +1296,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4597,
@@ -1176,7 +1306,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 4601,
@@ -1185,7 +1316,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4602,
@@ -1194,7 +1326,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 4606,
@@ -1203,7 +1336,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4607,
@@ -1212,7 +1346,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4608,
@@ -1221,7 +1356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4609,
@@ -1230,7 +1366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4610,
@@ -1239,7 +1376,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5122,
@@ -1248,7 +1386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5124,
@@ -1257,7 +1396,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5126,
@@ -1266,7 +1406,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6850,
@@ -1275,7 +1416,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 2
   },
   {
     "spellId": 8479,
@@ -1284,7 +1426,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8481,
@@ -1293,7 +1436,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 8503,
@@ -1302,7 +1446,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8504,
@@ -1311,7 +1456,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8508,
@@ -1320,7 +1466,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8510,
@@ -1329,7 +1476,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8511,
@@ -1338,7 +1486,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8512,
@@ -1347,7 +1496,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8513,
@@ -1356,7 +1506,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 749,
@@ -1365,7 +1516,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 750,
@@ -1374,7 +1526,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 751,
@@ -1383,7 +1536,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 752,
@@ -1392,7 +1546,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 753,
@@ -1401,7 +1556,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 754,
@@ -1410,7 +1566,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 756,
@@ -1419,7 +1576,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 757,
@@ -1428,7 +1586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 758,
@@ -1437,7 +1596,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 761,
@@ -1446,7 +1606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 763,
@@ -1455,7 +1616,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 764,
@@ -1464,7 +1626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 765,
@@ -1473,7 +1636,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 766,
@@ -1482,7 +1646,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 767,
@@ -1491,7 +1656,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 771,
@@ -1500,7 +1666,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 772,
@@ -1509,7 +1676,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 775,
@@ -1518,7 +1686,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 776,
@@ -1527,7 +1696,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 777,
@@ -1536,7 +1706,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 783,
@@ -1545,7 +1716,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 785,
@@ -1554,7 +1726,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1417,
@@ -1563,7 +1736,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1418,
@@ -1572,7 +1746,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2839,
@@ -1581,7 +1756,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 4
   },
   {
     "spellId": 5344,
@@ -1590,7 +1766,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 3
   },
   {
     "spellId": 5351,
@@ -1599,7 +1776,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5352,
@@ -1608,7 +1786,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5353,
@@ -1617,7 +1796,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7184,
@@ -1626,7 +1806,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7185,
@@ -1635,7 +1816,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7186,
@@ -1644,7 +1826,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7187,
@@ -1653,7 +1836,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7188,
@@ -1662,7 +1846,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7189,
@@ -1671,7 +1856,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7190,
@@ -1680,7 +1866,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7191,
@@ -1689,7 +1876,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7192,
@@ -1698,7 +1886,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7193,
@@ -1707,7 +1896,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7195,
@@ -1716,7 +1906,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7196,
@@ -1725,7 +1916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2041,
@@ -1734,7 +1926,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2042,
@@ -1743,7 +1936,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2043,
@@ -1752,7 +1946,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2044,
@@ -1761,7 +1956,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2045,
@@ -1770,7 +1966,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2046,
@@ -1779,7 +1976,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2047,
@@ -1788,7 +1986,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2048,
@@ -1797,7 +1996,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2049,
@@ -1806,7 +2006,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 2050,
@@ -1815,7 +2016,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2059,
@@ -1824,7 +2026,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2060,
@@ -1833,7 +2036,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 2061,
@@ -1842,7 +2046,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 2062,
@@ -1851,7 +2056,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2065,
@@ -1860,7 +2066,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2066,
@@ -1869,7 +2076,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2067,
@@ -1878,7 +2086,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2068,
@@ -1887,7 +2096,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2072,
@@ -1896,7 +2106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2073,
@@ -1905,7 +2116,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2075,
@@ -1914,7 +2126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 2076,
@@ -1923,7 +2136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 2078,
@@ -1932,7 +2146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 2079,
@@ -1941,7 +2156,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 2080,
@@ -1950,7 +2166,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5246,
@@ -1959,7 +2176,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5249,
@@ -1968,7 +2186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5250,
@@ -1977,7 +2196,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5251,
@@ -1986,7 +2206,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7225,
@@ -1995,7 +2216,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7954,
@@ -2004,7 +2226,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7955,
@@ -2013,7 +2236,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7956,
@@ -2022,7 +2246,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7957,
@@ -2031,7 +2256,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7958,
@@ -2040,7 +2266,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7959,
@@ -2049,7 +2276,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7960,
@@ -2058,7 +2286,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7961,
@@ -2067,7 +2296,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7999,
@@ -2076,7 +2306,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8000,
@@ -2085,7 +2316,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8001,
@@ -2094,7 +2326,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 623,
@@ -2103,7 +2336,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 625,
@@ -2112,7 +2346,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 627,
@@ -2121,7 +2356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 2
   },
   {
     "spellId": 628,
@@ -2130,7 +2366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 630,
@@ -2139,7 +2376,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 636,
@@ -2148,7 +2386,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 638,
@@ -2157,7 +2396,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 644,
@@ -2166,7 +2406,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 645,
@@ -2175,7 +2416,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 779,
@@ -2184,7 +2426,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 780,
@@ -2193,7 +2436,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 781,
@@ -2202,7 +2446,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 782,
@@ -2211,7 +2456,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 1415,
@@ -2220,7 +2466,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1532,
@@ -2229,7 +2476,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1533,
@@ -2238,7 +2486,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1534,
@@ -2247,7 +2496,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1535,
@@ -2256,7 +2506,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 1536,
@@ -2265,7 +2516,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1537,
@@ -2274,7 +2526,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1538,
@@ -2283,7 +2536,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1539,
@@ -2292,7 +2546,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1540,
@@ -2301,7 +2556,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 1541,
@@ -2310,7 +2566,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 1542,
@@ -2319,7 +2576,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 5451,
@@ -2328,7 +2586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5453,
@@ -2337,7 +2596,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5454,
@@ -2346,7 +2606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5455,
@@ -2355,7 +2616,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5463,
@@ -2364,7 +2626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7985,
@@ -2373,7 +2636,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 2
   },
   {
     "spellId": 7987,
@@ -2382,7 +2646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7990,
@@ -2391,7 +2656,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7991,
@@ -2400,7 +2666,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7992,
@@ -2409,7 +2676,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7993,
@@ -2418,7 +2686,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7994,
@@ -2427,7 +2696,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7995,
@@ -2436,7 +2706,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7996,
@@ -2445,7 +2716,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7997,
@@ -2454,7 +2726,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7998,
@@ -2463,7 +2736,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4775,
@@ -2472,7 +2746,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4776,
@@ -2481,7 +2756,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4777,
@@ -2490,7 +2766,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4778,
@@ -2499,7 +2776,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4779,
@@ -2508,7 +2786,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4780,
@@ -2517,7 +2796,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4781,
@@ -2526,7 +2806,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4782,
@@ -2535,7 +2816,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4783,
@@ -2544,7 +2826,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4784,
@@ -2553,7 +2836,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4785,
@@ -2562,7 +2846,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4786,
@@ -2571,7 +2856,8 @@
     "maxCastPerTurn": 6,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4787,
@@ -2580,7 +2866,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4788,
@@ -2589,7 +2876,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4789,
@@ -2598,7 +2886,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4790,
@@ -2607,7 +2896,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 4791,
@@ -2616,7 +2906,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4792,
@@ -2625,7 +2916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4793,
@@ -2634,7 +2926,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 2
   },
   {
     "spellId": 4794,
@@ -2643,7 +2936,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4795,
@@ -2652,7 +2946,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4796,
@@ -2661,7 +2956,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4797,
@@ -2670,7 +2966,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4798,
@@ -2679,7 +2976,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4799,
@@ -2688,7 +2986,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5100,
@@ -2697,7 +2996,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5101,
@@ -2706,7 +3006,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5102,
@@ -2715,7 +3016,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5103,
@@ -2724,7 +3026,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5104,
@@ -2733,7 +3036,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5130,
@@ -2742,7 +3046,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 8413,
@@ -2751,7 +3056,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8414,
@@ -2760,7 +3066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8415,
@@ -2769,7 +3076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8416,
@@ -2778,7 +3086,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8417,
@@ -2787,7 +3096,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8418,
@@ -2796,7 +3106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8419,
@@ -2805,7 +3116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8420,
@@ -2814,7 +3126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8421,
@@ -2823,7 +3136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8422,
@@ -2832,7 +3146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4769,
@@ -2841,7 +3156,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4774,
@@ -2850,7 +3166,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 4805,
@@ -2859,7 +3176,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 4806,
@@ -2868,7 +3186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 4808,
@@ -2877,7 +3196,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 4809,
@@ -2886,7 +3206,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4810,
@@ -2895,7 +3216,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4811,
@@ -2904,7 +3226,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4812,
@@ -2913,7 +3236,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4813,
@@ -2922,7 +3246,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4814,
@@ -2931,7 +3256,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4815,
@@ -2940,7 +3266,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4816,
@@ -2949,7 +3276,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4817,
@@ -2958,7 +3286,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4818,
@@ -2967,7 +3296,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4819,
@@ -2976,7 +3306,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4820,
@@ -2985,7 +3316,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4821,
@@ -2994,7 +3326,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4822,
@@ -3003,7 +3336,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6842,
@@ -3012,7 +3346,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 6945,
@@ -3021,7 +3356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6946,
@@ -3030,7 +3366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6947,
@@ -3039,7 +3376,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6948,
@@ -3048,7 +3386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6949,
@@ -3057,7 +3396,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6950,
@@ -3066,7 +3406,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6951,
@@ -3075,7 +3416,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6952,
@@ -3084,7 +3426,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6953,
@@ -3093,7 +3436,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6955,
@@ -3102,7 +3446,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6956,
@@ -3111,7 +3456,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6957,
@@ -3120,7 +3466,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6958,
@@ -3129,7 +3476,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6959,
@@ -3138,7 +3486,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6960,
@@ -3147,7 +3496,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6961,
@@ -3156,7 +3506,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6962,
@@ -3165,7 +3516,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6963,
@@ -3174,7 +3526,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7753,
@@ -3183,7 +3536,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 7795,
@@ -3192,7 +3546,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 912,
@@ -3201,7 +3556,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 913,
@@ -3210,7 +3566,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 914,
@@ -3219,7 +3576,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 915,
@@ -3228,7 +3586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 916,
@@ -3237,7 +3596,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 917,
@@ -3246,7 +3606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 918,
@@ -3255,7 +3616,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 919,
@@ -3264,7 +3626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 2
   },
   {
     "spellId": 920,
@@ -3273,7 +3636,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 921,
@@ -3282,7 +3646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 922,
@@ -3291,7 +3656,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 925,
@@ -3300,7 +3666,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 927,
@@ -3309,7 +3676,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 928,
@@ -3318,7 +3686,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 929,
@@ -3327,7 +3696,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 930,
@@ -3336,7 +3706,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 931,
@@ -3345,7 +3716,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 932,
@@ -3354,7 +3726,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 933,
@@ -3363,7 +3736,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 934,
@@ -3372,7 +3746,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 935,
@@ -3381,7 +3756,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 937,
@@ -3390,7 +3766,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 938,
@@ -3399,7 +3776,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4959,
@@ -3408,7 +3786,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5055,
@@ -3417,7 +3796,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5057,
@@ -3426,7 +3806,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 5058,
@@ -3435,7 +3816,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5234,
@@ -3444,7 +3826,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7053,
@@ -3453,7 +3836,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7054,
@@ -3462,7 +3846,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 8139,
@@ -3471,7 +3856,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 1
   },
   {
     "spellId": 8149,
@@ -3480,7 +3866,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8150,
@@ -3489,7 +3876,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8151,
@@ -3498,7 +3886,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8152,
@@ -3507,7 +3896,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8153,
@@ -3516,7 +3906,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8154,
@@ -3525,7 +3916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8155,
@@ -3534,7 +3926,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8156,
@@ -3543,7 +3936,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8157,
@@ -3552,7 +3946,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 8158,
@@ -3561,7 +3956,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5028,
@@ -3570,7 +3966,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5029,
@@ -3579,7 +3976,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5030,
@@ -3588,7 +3986,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5031,
@@ -3597,7 +3996,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5032,
@@ -3606,7 +4006,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 3
   },
   {
     "spellId": 5033,
@@ -3615,7 +4016,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5034,
@@ -3624,7 +4026,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5035,
@@ -3633,7 +4036,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 5036,
@@ -3642,7 +4046,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5037,
@@ -3651,7 +4056,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5038,
@@ -3660,7 +4066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5039,
@@ -3669,7 +4076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5040,
@@ -3678,7 +4086,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 5041,
@@ -3687,7 +4096,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5042,
@@ -3696,7 +4106,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 5043,
@@ -3705,7 +4116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 5044,
@@ -3714,7 +4126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 5045,
@@ -3723,7 +4136,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5047,
@@ -3732,7 +4146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 5049,
@@ -3741,7 +4156,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5050,
@@ -3750,7 +4166,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5051,
@@ -3759,7 +4176,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5052,
@@ -3768,7 +4186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5053,
@@ -3777,7 +4196,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5054,
@@ -3786,7 +4206,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5192,
@@ -3795,7 +4216,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5193,
@@ -3804,7 +4226,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5194,
@@ -3813,7 +4236,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5195,
@@ -3822,7 +4246,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7211,
@@ -3831,7 +4256,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7212,
@@ -3840,7 +4266,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7213,
@@ -3849,7 +4276,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7214,
@@ -3858,7 +4286,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7215,
@@ -3867,7 +4296,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7216,
@@ -3876,7 +4306,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7217,
@@ -3885,7 +4316,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7218,
@@ -3894,7 +4326,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7219,
@@ -3903,7 +4336,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7220,
@@ -3912,7 +4346,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7224,
@@ -3921,7 +4356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7830,
@@ -3930,7 +4366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4702,
@@ -3939,7 +4376,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4703,
@@ -3948,7 +4386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4704,
@@ -3957,7 +4396,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4705,
@@ -3966,7 +4406,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4706,
@@ -3975,7 +4416,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4707,
@@ -3984,7 +4426,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4708,
@@ -3993,7 +4436,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4709,
@@ -4002,7 +4446,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4710,
@@ -4011,7 +4456,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4711,
@@ -4020,7 +4466,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4712,
@@ -4029,7 +4476,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4713,
@@ -4038,7 +4486,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4714,
@@ -4047,7 +4496,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4715,
@@ -4056,7 +4506,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4716,
@@ -4065,7 +4516,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4717,
@@ -4074,7 +4526,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4719,
@@ -4083,7 +4536,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4720,
@@ -4092,7 +4546,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 4721,
@@ -4101,7 +4556,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4722,
@@ -4110,7 +4566,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4723,
@@ -4119,7 +4576,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4724,
@@ -4128,7 +4586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4725,
@@ -4137,7 +4596,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4726,
@@ -4146,7 +4606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5148,
@@ -4155,7 +4616,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5149,
@@ -4164,7 +4626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5150,
@@ -4173,7 +4636,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5151,
@@ -4182,7 +4646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6844,
@@ -4191,7 +4656,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 6845,
@@ -4200,7 +4666,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 6846,
@@ -4209,7 +4676,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6463,
@@ -4218,7 +4686,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6464,
@@ -4227,7 +4696,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6465,
@@ -4236,7 +4706,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6466,
@@ -4245,7 +4716,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6467,
@@ -4254,7 +4726,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6468,
@@ -4263,7 +4736,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6469,
@@ -4272,7 +4746,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6470,
@@ -4281,7 +4756,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6471,
@@ -4290,7 +4766,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6472,
@@ -4299,7 +4776,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6473,
@@ -4308,7 +4786,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6474,
@@ -4317,7 +4796,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6475,
@@ -4326,7 +4806,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6476,
@@ -4335,7 +4816,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6478,
@@ -4344,7 +4826,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6479,
@@ -4353,7 +4836,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6480,
@@ -4362,7 +4846,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6481,
@@ -4371,7 +4856,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6482,
@@ -4380,7 +4866,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6483,
@@ -4389,7 +4876,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6484,
@@ -4398,7 +4886,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6485,
@@ -4407,7 +4896,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6486,
@@ -4416,7 +4906,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6487,
@@ -4425,7 +4916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6488,
@@ -4434,7 +4926,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6489,
@@ -4443,7 +4936,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 6490,
@@ -4452,7 +4946,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6491,
@@ -4461,7 +4956,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 6492,
@@ -4470,7 +4966,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6493,
@@ -4479,7 +4976,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 6494,
@@ -4488,7 +4986,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 7062,
@@ -4497,7 +4996,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7063,
@@ -4506,7 +5006,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7064,
@@ -4515,7 +5016,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7065,
@@ -4524,7 +5026,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7090,
@@ -4533,7 +5036,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7091,
@@ -4542,7 +5046,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7092,
@@ -4551,7 +5056,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7982,
@@ -4560,7 +5066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7983,
@@ -4569,7 +5076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7984,
@@ -4578,7 +5086,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7066,
@@ -4587,7 +5096,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7067,
@@ -4596,7 +5106,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7068,
@@ -4605,7 +5116,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7069,
@@ -4614,7 +5126,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7070,
@@ -4623,7 +5136,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7071,
@@ -4632,7 +5146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7072,
@@ -4641,7 +5156,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7073,
@@ -4650,7 +5166,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7074,
@@ -4659,7 +5176,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7075,
@@ -4668,7 +5186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7076,
@@ -4677,7 +5196,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7077,
@@ -4686,7 +5206,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7078,
@@ -4695,7 +5216,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7079,
@@ -4704,7 +5226,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7080,
@@ -4713,7 +5236,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7084,
@@ -4722,7 +5246,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 5
+    "cooldown": 5,
+    "wpCost": 1
   },
   {
     "spellId": 7085,
@@ -4731,7 +5256,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 4
+    "cooldown": 4,
+    "wpCost": 0
   },
   {
     "spellId": 7086,
@@ -4740,7 +5266,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 7087,
@@ -4749,7 +5276,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7088,
@@ -4758,7 +5286,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 7089,
@@ -4767,7 +5296,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 7093,
@@ -4776,7 +5306,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7094,
@@ -4785,7 +5316,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7095,
@@ -4794,7 +5326,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7096,
@@ -4803,7 +5336,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7097,
@@ -4812,7 +5346,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7098,
@@ -4821,7 +5356,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7099,
@@ -4830,7 +5366,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7100,
@@ -4839,7 +5376,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7101,
@@ -4848,7 +5386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7102,
@@ -4857,7 +5396,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7103,
@@ -4866,7 +5406,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7104,
@@ -4875,7 +5416,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7105,
@@ -4884,7 +5426,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7106,
@@ -4893,7 +5436,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7107,
@@ -4902,7 +5446,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7108,
@@ -4911,7 +5456,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7111,
@@ -4920,7 +5466,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7112,
@@ -4929,7 +5476,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7113,
@@ -4938,7 +5486,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6256,
@@ -4947,7 +5496,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6257,
@@ -4956,7 +5506,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6258,
@@ -4965,7 +5516,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6259,
@@ -4974,7 +5526,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6260,
@@ -4983,7 +5536,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6261,
@@ -4992,7 +5546,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6262,
@@ -5001,7 +5556,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6263,
@@ -5010,7 +5566,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6264,
@@ -5019,7 +5576,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6265,
@@ -5028,7 +5586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6266,
@@ -5037,7 +5596,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6267,
@@ -5046,7 +5606,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6268,
@@ -5055,7 +5616,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6269,
@@ -5064,7 +5626,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6270,
@@ -5073,7 +5636,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6271,
@@ -5082,7 +5646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6272,
@@ -5091,7 +5656,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6273,
@@ -5100,7 +5666,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6274,
@@ -5109,7 +5676,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6275,
@@ -5118,7 +5686,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6276,
@@ -5127,7 +5696,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6277,
@@ -5136,7 +5706,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6278,
@@ -5145,7 +5716,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6279,
@@ -5154,7 +5726,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6280,
@@ -5163,7 +5736,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6281,
@@ -5172,7 +5746,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6282,
@@ -5181,7 +5756,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6284,
@@ -5190,7 +5766,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6285,
@@ -5199,7 +5776,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 6287,
@@ -5208,7 +5786,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6288,
@@ -5217,7 +5796,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 1
   },
   {
     "spellId": 7551,
@@ -5226,7 +5806,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 1
   },
   {
     "spellId": 7552,
@@ -5235,7 +5816,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7553,
@@ -5244,7 +5826,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7554,
@@ -5253,7 +5836,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7555,
@@ -5262,7 +5846,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7556,
@@ -5271,7 +5856,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7557,
@@ -5280,7 +5866,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7558,
@@ -5289,7 +5876,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7596,
@@ -5298,7 +5886,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6902,
@@ -5307,7 +5896,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6903,
@@ -5316,7 +5906,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6904,
@@ -5325,7 +5916,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6905,
@@ -5334,7 +5926,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6906,
@@ -5343,7 +5936,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6907,
@@ -5352,7 +5946,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6908,
@@ -5361,7 +5956,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6909,
@@ -5370,7 +5966,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6910,
@@ -5379,7 +5976,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6911,
@@ -5388,7 +5986,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6912,
@@ -5397,7 +5996,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6913,
@@ -5406,7 +6006,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6914,
@@ -5415,7 +6016,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6915,
@@ -5424,7 +6026,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6916,
@@ -5433,7 +6036,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6917,
@@ -5442,7 +6046,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 2
   },
   {
     "spellId": 6918,
@@ -5451,7 +6056,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6919,
@@ -5460,7 +6066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 2
   },
   {
     "spellId": 6920,
@@ -5469,7 +6076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 6921,
@@ -5478,7 +6086,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 6922,
@@ -5487,7 +6096,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6925,
@@ -5496,7 +6106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6926,
@@ -5505,7 +6116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6927,
@@ -5514,7 +6126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6928,
@@ -5523,7 +6136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6929,
@@ -5532,7 +6146,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6930,
@@ -5541,7 +6156,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6931,
@@ -5550,7 +6166,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6932,
@@ -5559,7 +6176,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6933,
@@ -5568,7 +6186,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6934,
@@ -5577,7 +6196,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6935,
@@ -5586,7 +6206,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6936,
@@ -5595,7 +6216,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6937,
@@ -5604,7 +6226,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6938,
@@ -5613,7 +6236,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6939,
@@ -5622,7 +6246,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6940,
@@ -5631,7 +6256,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6941,
@@ -5640,7 +6266,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6942,
@@ -5649,7 +6276,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 6943,
@@ -5658,7 +6286,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7810,
@@ -5667,7 +6296,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4668,
@@ -5676,7 +6306,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4669,
@@ -5685,7 +6316,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4670,
@@ -5694,7 +6326,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4671,
@@ -5703,7 +6336,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4680,
@@ -5712,7 +6346,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4683,
@@ -5721,7 +6356,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4684,
@@ -5730,7 +6366,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 4685,
@@ -5739,7 +6376,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 4686,
@@ -5748,7 +6386,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4687,
@@ -5757,7 +6396,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4688,
@@ -5766,7 +6406,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4689,
@@ -5775,7 +6416,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4690,
@@ -5784,7 +6426,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4691,
@@ -5793,7 +6436,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4692,
@@ -5802,7 +6446,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4693,
@@ -5811,7 +6456,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4694,
@@ -5820,7 +6466,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 4695,
@@ -5829,7 +6476,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4697,
@@ -5838,7 +6486,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4698,
@@ -5847,7 +6496,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4699,
@@ -5856,7 +6506,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4700,
@@ -5865,7 +6516,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 4701,
@@ -5874,7 +6526,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5056,
@@ -5883,7 +6536,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5131,
@@ -5892,7 +6546,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5132,
@@ -5901,7 +6556,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5143,
@@ -5910,7 +6566,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7198,
@@ -5919,7 +6576,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 2
   },
   {
     "spellId": 7199,
@@ -5928,7 +6586,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7200,
@@ -5937,7 +6596,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 1
   },
   {
     "spellId": 7202,
@@ -5946,7 +6606,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7203,
@@ -5955,7 +6616,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7204,
@@ -5964,7 +6626,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7205,
@@ -5973,7 +6636,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7206,
@@ -5982,7 +6646,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7207,
@@ -5991,7 +6656,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7208,
@@ -6000,7 +6666,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7209,
@@ -6009,7 +6676,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7210,
@@ -6018,7 +6686,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7720,
@@ -6027,7 +6696,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7814,
@@ -6036,7 +6706,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5561,
@@ -6045,7 +6716,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5562,
@@ -6054,7 +6726,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5563,
@@ -6063,7 +6736,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5564,
@@ -6072,7 +6746,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5565,
@@ -6081,7 +6756,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5566,
@@ -6090,7 +6766,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5567,
@@ -6099,7 +6776,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5568,
@@ -6108,7 +6786,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5569,
@@ -6117,7 +6796,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5570,
@@ -6126,7 +6806,8 @@
     "maxCastPerTurn": 4,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 3,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5571,
@@ -6135,7 +6816,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5572,
@@ -6144,7 +6826,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5575,
@@ -6153,7 +6836,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 3
+    "cooldown": 3,
+    "wpCost": 0
   },
   {
     "spellId": 5576,
@@ -6162,7 +6846,8 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5577,
@@ -6171,7 +6856,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 5579,
@@ -6180,7 +6866,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5580,
@@ -6189,7 +6876,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5581,
@@ -6198,7 +6886,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5582,
@@ -6207,7 +6896,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5583,
@@ -6216,7 +6906,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5584,
@@ -6225,7 +6916,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5585,
@@ -6234,7 +6926,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5586,
@@ -6243,7 +6936,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5587,
@@ -6252,7 +6946,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5588,
@@ -6261,7 +6956,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5590,
@@ -6270,7 +6966,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5591,
@@ -6279,7 +6976,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5592,
@@ -6288,7 +6986,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5593,
@@ -6297,7 +6996,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 2,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5594,
@@ -6306,7 +7006,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 5595,
@@ -6315,7 +7016,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5596,
@@ -6324,7 +7026,8 @@
     "maxCastPerTurn": 3,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 5597,
@@ -6333,7 +7036,8 @@
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7754,
@@ -6342,7 +7046,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7755,
@@ -6351,7 +7056,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 2
+    "cooldown": 2,
+    "wpCost": 0
   },
   {
     "spellId": 7797,
@@ -6360,7 +7066,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7798,
@@ -6369,7 +7076,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7800,
@@ -6378,7 +7086,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7801,
@@ -6387,7 +7096,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7802,
@@ -6396,7 +7106,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7803,
@@ -6405,7 +7116,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7804,
@@ -6414,7 +7126,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7805,
@@ -6423,7 +7136,8 @@
     "maxCastPerTurn": 0,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   },
   {
     "spellId": 7809,
@@ -6432,6 +7146,7 @@
     "maxCastPerTurn": 1,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 0,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   }
 ]

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellCatalogTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellCatalogTest.kt
@@ -29,6 +29,34 @@ class SpellCatalogTest {
     }
 
     @Test
+    fun `joins the baked per-spell cast limits onto the catalog`() {
+        // Anchor on oracle-verified spells (docs/SPELL_CAST_LIMITS_EXTRACTION.md §8). The ids are pinned to
+        // the current Wakfu data version; firstOrNull + isNotNull turns a future data bump that removes one
+        // into a clear "update the anchor" message instead of a raw NoSuchElementException.
+        // Cra "Flèche ardente" (Blazing Arrow, 4769) reads "3 uses per turn" in-game.
+        val blazingArrow = SpellCatalog.forClass(CharacterClass.CRA).firstOrNull { it.id == 4769 }
+        assertThat(blazingArrow).describedAs("oracle anchor 'Flèche ardente' (4769) — update if the data version changed").isNotNull
+        assertThat(blazingArrow!!.maxCastPerTurn).isEqualTo(3)
+        assertThat(blazingArrow.maxCastsThisTurn).isEqualTo(3)
+        assertThat(blazingArrow.wpCost).describedAs("a normal AP arrow costs no WP").isEqualTo(0)
+
+        // WP cost is joined too (for display + future modelling): Cra "Flèche destructrice" (4814) is a
+        // WP-gated arrow ("Points Wakfu" / pw_base = 1). It is NOT folded into the per-turn cap.
+        val destructiveArrow = SpellCatalog.forClass(CharacterClass.CRA).firstOrNull { it.id == 4814 }
+        assertThat(destructiveArrow).describedAs("oracle anchor 'Flèche destructrice' (4814) — update if the data version changed").isNotNull
+        assertThat(destructiveArrow!!.wpCost).isEqualTo(1)
+
+        // Guard against a silent join failure: if the cast-limit resource didn't deserialize, the join
+        // would leave every spell unbounded. A real join caps a substantial share of the kit.
+        assertThat(SpellCatalog.spells.count { it.maxCastsThisTurn != null })
+            .describedAs("spells carrying a real per-turn cast limit")
+            .isGreaterThan(50)
+        assertThat(SpellCatalog.spells.count { (it.wpCost ?: 0) > 0 })
+            .describedAs("spells carrying a WP cost")
+            .isGreaterThan(50)
+    }
+
+    @Test
     fun `a spell's expected damage rises with the build's elemental mastery`() {
         val character = Character(clazz = CharacterClass.CRA, level = 230, minLevel = 1)
         val emptyBuild = BuildCombination(equipments = emptyList(), characterSkills = CharacterSkills(230))

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellRotationTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellRotationTest.kt
@@ -148,6 +148,89 @@ class SpellRotationTest {
         assertThat(debuffAware(a)).describedAs("debuff-aware prefers the 13-AP build — the breakpoint").isGreaterThan(debuffAware(c))
     }
 
+    private fun damageSpell(
+        ap: Int,
+        base: Int,
+        maxCastPerTurn: Int? = null,
+        cooldown: Int? = null,
+        id: Int = 1,
+    ) = Spell(
+        id = id,
+        clazz = CharacterClass.CRA,
+        name = I18nText("s", "s", "s", "s"),
+        element = SpellElement.FIRE,
+        apCost = ap,
+        baseDamage = base,
+        maxCastPerTurn = maxCastPerTurn,
+        cooldown = cooldown
+    )
+
+    @Test
+    fun `baseThroughputTable caps a spell at its per-turn limit instead of spamming it`() {
+        // 2 AP / 100 base, castable at most twice per turn. With 10 AP the unbounded table would stack
+        // 5 casts (500); the cap pins it at 2 casts (200), then the extra AP sits idle.
+        val table = SpellRotationOptimizer.baseThroughputTable(listOf(damageSpell(ap = 2, base = 100, maxCastPerTurn = 2)), maxAp = 10)
+        assertThat(table[10]).isEqualTo(200L)
+        assertThat(table[4]).describedAs("2 casts already fit in 4 AP").isEqualTo(200L)
+        assertThat(table[2]).describedAs("1 cast in 2 AP").isEqualTo(100L)
+    }
+
+    @Test
+    fun `baseThroughputTable caps a cooldown spell at a single cast per turn`() {
+        // cooldown > 0 ⇒ at most one cast this turn, even though maxCastPerTurn = 0 ("unlimited").
+        val table = SpellRotationOptimizer.baseThroughputTable(listOf(damageSpell(ap = 3, base = 100, maxCastPerTurn = 0, cooldown = 2)), maxAp = 12)
+        assertThat(table[12]).isEqualTo(100L)
+    }
+
+    @Test
+    fun `baseThroughputTable leaves an uncapped spell unbounded`() {
+        // maxCastPerTurn = 0 / cooldown absent ⇒ no per-turn limit: the budget fills with casts.
+        val table = SpellRotationOptimizer.baseThroughputTable(listOf(damageSpell(ap = 2, base = 100, maxCastPerTurn = 0)), maxAp = 10)
+        assertThat(table[10]).describedAs("5 casts, no per-turn limit").isEqualTo(500L)
+    }
+
+    @Test
+    fun `baseThroughputTable bounds each spell by its own cap when several compete`() {
+        // A: 2 AP / 100 base, cap 1; B: 3 AP / 120 base, cap 2. Unbounded at 12 AP would spam A (×6 = 600);
+        // capped, the best is A×1 + B×2 = 340 (8 AP, rest idle) — each spell honoured its OWN per-turn cap,
+        // not a shared/uniform one. This is the multi-spell aggregation the fused CP-SAT objective relies on.
+        val table =
+            SpellRotationOptimizer.baseThroughputTable(
+                listOf(
+                    damageSpell(id = 1, ap = 2, base = 100, maxCastPerTurn = 1),
+                    damageSpell(id = 2, ap = 3, base = 120, maxCastPerTurn = 2)
+                ),
+                maxAp = 12
+            )
+        assertThat(table[12]).describedAs("A×1 + B×2, both caps binding").isEqualTo(340L)
+        assertThat(table[6]).describedAs("B×2").isEqualTo(240L)
+        assertThat(table[5]).describedAs("one of each").isEqualTo(220L)
+    }
+
+    @Test
+    fun `bestRotation honours distinct per-spell caps across several spells`() {
+        // Same shape via the display path: A capped at 1, B at 2 ⇒ A×1 + B×2 = 340 (8 AP); neither spell
+        // spammed past its own cap, and the caps don't bleed across spells (per-spell, not uniform).
+        val a = ScoredSpell(damageSpell(id = 1, ap = 2, base = 1, maxCastPerTurn = 1), apCost = 2, expectedDamagePerCast = 100.0)
+        val b = ScoredSpell(damageSpell(id = 2, ap = 3, base = 1, maxCastPerTurn = 2), apCost = 3, expectedDamagePerCast = 120.0)
+        val rotation = SpellRotationOptimizer.bestRotation(listOf(a, b), apBudget = 12)
+        assertThat(rotation.totalExpectedDamage).isEqualTo(340.0)
+        assertThat(rotation.apUsed).isEqualTo(8)
+        assertThat(rotation.casts.single { it.spell.id == 1 }.count).describedAs("A capped at 1").isEqualTo(1)
+        assertThat(rotation.casts.single { it.spell.id == 2 }.count).describedAs("B capped at 2").isEqualTo(2)
+    }
+
+    @Test
+    fun `bestRotation caps a spell by its own per-turn limit without a uniform override`() {
+        // The display path must honour the spell's joined cast limit on its own (no maxCastsPerSpell):
+        // castable twice/turn, 2 AP, budget 10 ⇒ 2 casts (200), not the unbounded 5 (500).
+        val scored = listOf(ScoredSpell(damageSpell(ap = 2, base = 1, maxCastPerTurn = 2), apCost = 2, expectedDamagePerCast = 100.0))
+        val rotation = SpellRotationOptimizer.bestRotation(scored, apBudget = 10)
+        assertThat(rotation.casts.single().count).isEqualTo(2)
+        assertThat(rotation.apUsed).isEqualTo(4)
+        assertThat(rotation.totalExpectedDamage).isEqualTo(200.0)
+    }
+
     @Test
     fun `forBuild gates the rotation to the class's playable element — Cra has no Water spells`() {
         val character = Character(clazz = CharacterClass.CRA, level = 230, minLevel = 1)

--- a/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Extract.kt
+++ b/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Extract.kt
@@ -57,6 +57,9 @@ data class CastLimit(
     val maxCastPerTurnIncr: Int,
     val maxCastPerTarget: Int,
     val cooldown: Int,
+    /** WP (Wakfu Point) base cost — Ankama's `pw_base`. `0` = no WP cost. Carried for display + future
+     *  rotation modelling; WP is a per-fight pool, see `docs/FULL_DAMAGE_PLAN.md` "Lot 1". */
+    val wpCost: Int,
 )
 
 @Serializable
@@ -115,7 +118,8 @@ fun buildCastLimits(
                 maxCastPerTurn = (r["cast_max_per_turn"] as Float).toInt(),
                 maxCastPerTurnIncr = (r["cast_max_per_turn_incr"] as Float).toInt(),
                 maxCastPerTarget = r["cast_max_per_target"] as Int,
-                cooldown = r["cast_min_interval"] as Int
+                cooldown = r["cast_min_interval"] as Int,
+                wpCost = (r["pw_base"] as Float).toInt()
             )
         }
 

--- a/common-lib/src/main/kotlin/me/chosante/common/Spell.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/Spell.kt
@@ -61,6 +61,13 @@ data class Spell(
     val element: SpellElement? = null,
     val category: SpellCategory = SpellCategory.ACTIVE,
     val apCost: Int? = null,
+    /**
+     * WP (Wakfu Point) base cost (Ankama's `pw_base`), or null when unknown. `0` = free. Sourced from the
+     * baked cast-limit data (`spell-cast-limits-v<VERSION>.json`, joined by [id] in `SpellCatalog`), **not**
+     * the encyclopedia. Carried for display and future rotation modelling — WP is a per-fight pool, not a
+     * per-turn cap, so it is deliberately **not** folded into [maxCastsThisTurn] yet (see
+     * `docs/FULL_DAMAGE_PLAN.md` "Lot 1").
+     */
     val wpCost: Int? = null,
     val rangeMin: Int? = null,
     val rangeMax: Int? = null,
@@ -69,7 +76,21 @@ data class Spell(
     val area: SpellArea? = null,
     val requiresLineOfSight: Boolean? = null,
     val levelRequired: Int? = null,
+    /**
+     * Minimum number of turns between two casts of this spell (Ankama's `cast_min_interval`), or null
+     * when unknown. Sourced from the baked cast-limit data (`spell-cast-limits-v<VERSION>.json`, joined
+     * by [id] in `SpellCatalog`), **not** the encyclopedia. `0`/null means "no cooldown"; any value
+     * `> 0` means the spell can be cast at most once this turn (see [maxCastsThisTurn]).
+     */
     val cooldown: Int? = null,
+    /**
+     * Maximum number of times this spell may be cast in a single turn (Ankama's `cast_max_per_turn`),
+     * or null when unknown. Sourced from the baked cast-limit data (`spell-cast-limits-v<VERSION>.json`,
+     * joined by [id] in `SpellCatalog`), **not** the encyclopedia. Per that data's convention `0` means
+     * "no per-turn limit" (unlimited), which [maxCastsThisTurn] treats the same as null. See
+     * `docs/SPELL_CAST_LIMITS_EXTRACTION.md`.
+     */
+    val maxCastPerTurn: Int? = null,
     val iconId: Int? = null,
     val description: I18nText? = null,
     /**
@@ -86,6 +107,26 @@ data class Spell(
 ) {
     /** True when the spell carries a readable base hit, i.e. it can be fed to [SpellDamage]. */
     val hasDamage: Boolean get() = element != null && baseDamage != null
+
+    /**
+     * How many times this spell can be cast at a single target in one turn, or `null` when it is
+     * effectively unbounded (limited only by the AP budget). Folds the two per-turn limits in the baked
+     * cast-limit data:
+     *  - [cooldown] `> 0` (a minimum-interval spell) ⇒ at most **one** cast this turn;
+     *  - otherwise [maxCastPerTurn] (`0`/null in the data means "no per-turn limit").
+     *
+     * Per-spell **WP** cost ([wpCost]) is deliberately **not** folded in: WP is a per-*fight* pool (not a
+     * per-turn allowance), so bounding a single turn by it needs a separate amortized WP-budget model —
+     * see `docs/FULL_DAMAGE_PLAN.md` "Lot 1". Per-target limits are likewise out of scope here
+     * (single-target damage only).
+     */
+    val maxCastsThisTurn: Int?
+        get() =
+            when {
+                (cooldown ?: 0) > 0 -> 1
+                (maxCastPerTurn ?: 0) > 0 -> maxCastPerTurn
+                else -> null
+            }
 
     /** True when this active spell removes resistance from the target (usable as a rotation-opening debuff). */
     val isResistanceDebuff: Boolean get() = (targetResistanceReductionFlat ?: 0) > 0

--- a/common-lib/src/main/kotlin/me/chosante/common/SpellCastLimit.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/SpellCastLimit.kt
@@ -1,0 +1,30 @@
+package me.chosante.common
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-spell cast limits decoded from the local game client by the `bdata-extractor` module and baked
+ * into `autobuilder/src/main/resources/spell-cast-limits-v<VERSION>.json` (see
+ * `docs/SPELL_CAST_LIMITS_EXTRACTION.md`). Joined onto [Spell] by [spellId] at catalog load
+ * (`SpellCatalog`) so the spell-rotation optimizer can bound how often a spell is cast per turn.
+ *
+ * Convention from the extraction: values are the **raw decoded integers** — **`0` means "no limit" /
+ * "no cooldown"** (unlimited), *not* a finite cap of zero. [Spell.maxCastsThisTurn] applies that
+ * convention. Every field is nullable so a partial/absent record degrades to "unknown" (= no cap)
+ * rather than inventing a value.
+ *
+ * @property maxCastPerTarget single-target caps are out of scope for the single-target damage path;
+ *   carried for completeness / the future multi-target lot but not propagated to [Spell].
+ */
+@Serializable
+data class SpellCastLimit(
+    val spellId: Int,
+    val name: String? = null,
+    val breedId: Int? = null,
+    val maxCastPerTurn: Int? = null,
+    val maxCastPerTurnIncr: Int? = null,
+    val maxCastPerTarget: Int? = null,
+    val cooldown: Int? = null,
+    /** WP (Wakfu Point) base cost (`0` = free). Joined onto [Spell.wpCost]. */
+    val wpCost: Int? = null,
+)

--- a/docs/FULL_DAMAGE_PLAN.md
+++ b/docs/FULL_DAMAGE_PLAN.md
@@ -13,7 +13,7 @@ The **global, trackable plan** for the coherent full-damage mode. Multiple agent
 | Lot | What it unlocks | Status | Depends on |
 |---|---|---|---|
 | **0** Boss data + selection | "vs a given boss" (auto-element) | 🔶 **CLI ✅ done** (`feat/boss-mode-integration`); **GUI ⬜** (picker + icons) | — |
-| **1** Cast limits in the fused table | realistic rotation (no 1-spell spam) | 🔶 data on `main`, **unwired**; display-path bounded DP exists | — |
+| **1** Cast limits in the fused table | realistic rotation (no 1-spell spam) | ✅ **done** — per-turn + cooldown caps joined to `Spell` and bounded in both the fused table & display path; WP **cost** extracted too (display-ready), WP **model** deferred (per-fight pool) | — |
 | **2a-b** Bi-element objective + double-count fix | bi-element builds are *searched* | ⬜ todo | — |
 | **2c-d** Enumeration + pruning | bi-element **optimality** | ⬜ todo (loop is currently heuristic) | 2a-b |
 | **2e-f** Scorer lockstep + display | honest `matchPercentage`, UI | ⬜ todo | 2c-d |
@@ -76,37 +76,35 @@ dungeon-boss id, not `gfx` — unused.)
 
 **Goal.** Bound the rotation so it stops spamming one spell. No structural solver change.
 
-**Reality on `main` (reconciled):**
-- The cast-limit data **already exists**: `autobuilder/src/main/resources/spell-cast-limits-v1.91.1.54.json`
-  (produced by the `bdata-extractor` module — decodes the local game binary; see `SPELL_CAST_LIMITS_EXTRACTION.md`).
-- A **bounded-knapsack DP already exists in the display path**: `SpellRotationOptimizer.bestRotation` picks
-  `unboundedKnapsack` vs `boundedKnapsack(items, apBudget, maxCastsPerSpell)` [SpellRotation.kt:86-89, :145].
-- **But it's unwired**: the json is not loaded/joined to `Spell`, `maxCastsPerSpell` is `null` everywhere in
-  the live path, and the **fused** `baseThroughputTable` [SpellRotation.kt:368] is still **unbounded** (the
-  objective calls it with no cap [WakfuBuildSolver.kt:1180]).
+**What landed (done):**
+1. ✅ **Load + join.** `SpellCatalog.spells` joins `spell-cast-limits-v<VERSION>.json`
+   (deserialized as the new `common-lib SpellCastLimit`) onto each `Spell` by `id`, populating
+   `Spell.maxCastPerTurn` (new field) and `Spell.cooldown`. A new `Spell.maxCastsThisTurn` computed
+   property folds those into a single per-turn cap (`cooldown > 0` ⇒ 1; `maxCastPerTurn` `0`/null ⇒
+   unbounded), applying the data's "`0` = unlimited" convention.
+2. ✅ **Bound `baseThroughputTable`** — now the item-layered bounded knapsack (each spell `s` capped at
+   `c_s = maxCastsThisTurn ?: maxAp`); a spell with no limit gets `c_s = maxAp ≥ maxAp/cost`, so it
+   reproduces the old unbounded table exactly. `model.addElement(apVar, table, throughput)` is
+   **unchanged** — only the table's contents change, so the optimality proof holds. The display path
+   (`bestRotation` → generalized `boundedKnapsack(items, apBudget, caps: List<Int>)`) uses the **same**
+   per-spell caps, keeping the objective and the re-scorer (`bestSequencedRotation`/`bestAcrossElements`,
+   the lockstep guard in `WakfuBuildSolverTest`) consistent.
+3. ✅ **Cooldown** (`cooldown > 0` ⇒ cap = 1) folded into `maxCastsThisTurn`. **Per-target** skipped
+   (single-target only; `SpellCastLimit.maxCastPerTarget` is parsed but not propagated).
 
-**Remaining work:**
-1. **Load + join** the cast-limits json to `Spell` by `spellId` at load (mirror equipments/runes;
-   `Spell.cooldown`/`Spell.wpCost` fields exist but are null today).
-2. **Bound `baseThroughputTable`** — add a per-spell cap arg and reuse the existing `boundedKnapsack` item-layered
-   DP (each spell `s` capped at `c_s`; trivial at AP ≤ 20, ~12 spells, cap ≤ 3):
-   ```kotlin
-   for ((cost, base, cap) in items) {
-       val next = dp.copyOf()
-       for (ap in cost..maxAp) for (k in 1..cap) if (k*cost <= ap)
-           next[ap] = maxOf(next[ap], dp[ap - k*cost] + k*base)
-       dp = next
-   }
-   for (ap in 1..maxAp) dp[ap] = maxOf(dp[ap], dp[ap-1]) // ≤ ap
-   ```
-   `model.addElement(apVar, table, throughput)` [WakfuBuildSolver.kt:1192] is **unchanged** — only the table's
-   *contents* change. Optimality proof intact.
-3. **Cooldown / WP / per-target.** `cooldown > 0` ⇒ cap = 1 this turn. WP: **1-D amortized budget**
-   (`WP_pool / n_turns` constant pre-filter), no 2-D `(ap, wp)` table for now. `maxCastPerTarget` is for the
-   future AoE/multi-target lot, not single-target boss DPS.
-
-> Quick interim guard (optional, before full wiring): pass a conservative placeholder `maxCastsPerSpell`
-> (2–3) so the most obviously-fake "cast X ×4" rotations disappear in the display.
+**Deferred — model only (data now present):** WP cost is extracted (`pw_base` → `SpellCastLimit.wpCost`
+→ `Spell.wpCost`, joined in `SpellCatalog`; 103/715 player spells cost WP) and carried for display, but
+**not yet folded into the rotation**. WP is a per-*fight* pool, so bounding a single turn needs the 1-D
+amortized `WP_pool / n_turns` model — with the pool kept a **constant** (not the build's `WAKFU_POINT`
+variable) to preserve the build-independence of `baseThroughputTable` (a build-dependent WP cap would
+reintroduce the bilinear blow-up). Pure-WP (0-AP) damage spells additionally need a flat **additive**
+throughput term — they can't be AP-knapsack items. Open knob: where `n_turns` comes from (boss
+turns-to-kill vs. a fixed assumption). **Per-class regen:** the scarce-pool assumption is most wrong for
+**Xelor** — base WP is already doubled (12, `Character.kt`) *and* it regenerates WP in-fight
+(`Horlogerie`/`Cours du temps` passives, ~+1 WP/turn). That regen is conditional/triggered/scripted in
+the passive data (the "state assumed up" bucket Lot 4 defers), so it can't be derived — model WP budget
+as a **per-class** policy (`amortized-pool` for most classes; `renewable` / near-unbounded for Xelor and
+the niche Eni-Tridelta / Foggernaut-stasis cases) under a documented assumption.
 
 ---
 
@@ -246,7 +244,7 @@ Lot 3 (merge subs) ─┐
 Lot 4 (passives)   ─┴─► class-real damage ceiling (consume Lot 2's scenario gating)
 ```
 
-**Recommended next:** finish **Lot 0 GUI** (boss picker + icons — unblocks the visible "pick a boss" UX) and/or
-**Lot 1** (wire the cast-limit json into the fused `baseThroughputTable`) — both small, independent, data already
-present. **Lot 2** is the headline feature; the architecture (external loop + per-element `perHit` cores +
-build-independent tables) is already the right one — it's an extension, not a rewrite.
+**Recommended next:** finish **Lot 0 GUI** (boss picker + icons — unblocks the visible "pick a boss" UX) —
+small, independent, data already present (**Lot 1** is now done). **Lot 2** is the headline feature; the
+architecture (external loop + per-element `perHit` cores + build-independent tables) is already the right one
+— it's an extension, not a rewrite.

--- a/docs/SPELL_CAST_LIMITS_EXTRACTION.md
+++ b/docs/SPELL_CAST_LIMITS_EXTRACTION.md
@@ -138,7 +138,8 @@ Emit a single JSON file: an **array of spell objects, one per spell id**. Use `n
     "maxCastPerTurn": 2,
     "maxCastPerTurnIncr": 0,
     "maxCastPerTarget": 1,
-    "cooldown": 0
+    "cooldown": 0,
+    "wpCost": 0
   }
 ]
 ```
@@ -147,14 +148,20 @@ Field semantics:
 - `spellId` (int, required) — the binary `id`, the JSON key for the optimizer.
 - `name` (string|null) — French name if resolvable (`equipment`-style French matching is the project convention), else `null`.
 - `breedId` (int|null) — class id (1–18ish); use to filter to player classes.
-- `maxCastPerTurn` (int|null) — `cast_max_per_turn`. The value `SpellRotationOptimizer.maxCastsPerSpell` consumes. `null` = unconfirmed/unlimited-unknown.
+- `maxCastPerTurn` (int|null) — `cast_max_per_turn`. Joined onto `Spell.maxCastPerTurn` and folded (with
+  `cooldown`) into the rotation cap `Spell.maxCastsThisTurn` the optimizer reads. `null` = unconfirmed/unlimited-unknown.
 - `maxCastPerTurnIncr` (number|null, optional) — per-level increment; carry it so per-level resolution stays possible.
 - `maxCastPerTarget` (int|null) — `cast_max_per_target`.
-- `cooldown` (int|null, optional) — `cast_min_interval` (turns between casts). Omit or `null` if 0/absent.
+- `cooldown` (int|null) — `cast_min_interval` (turns between casts); `0` = no cooldown. (The in-repo Kotlin
+  extractor emits it verbatim — `0` included — rather than omitting it.)
+- `wpCost` (int|null) — `pw_base`, the spell's WP (Wakfu Point) base cost; `0` = free (emitted verbatim).
+  WP is a per-*fight* pool (not refilled each turn), so unlike the per-turn caps this is **not** a per-turn
+  limit — it is joined onto `Spell.wpCost` for display + a future amortized WP-budget model (see
+  `docs/FULL_DAMAGE_PLAN.md` "Lot 1").
 
 Notes:
 - A `castMaxPerTurn` of 0/absent in the binary commonly means **unlimited per turn** — decide and document the convention; do **not** silently coerce to a finite number.
-- Key the final baked artifact by `spellId` (object map or array — match what `SpellRotationOptimizer`'s `maxCastsPerSpell` hook expects on the Kotlin side; the optimizer already has the hook, so this JSON only has to feed it).
+- Key the final baked artifact by `spellId`. `SpellCatalog` joins it onto `Spell` by `spellId` at load, so the engine reads `Spell.maxCastsThisTurn` / `Spell.wpCost` — never this JSON directly. (`SpellRotationOptimizer.bestRotation` also takes an optional uniform `maxCastsPerSpell` override, distinct from the per-spell data caps.)
 - This is an **offline, baked** artifact (parallel to the existing baked `equipments-v<version>.json` and class-spells JSON) — the Rust tool runs once to produce it; the Kotlin app does not parse the binary at runtime.
 
 ---
@@ -164,7 +171,7 @@ Notes:
 ```
 GOAL
 Produce a JSON file of per-spell cast limits for Wakfu, keyed by spell id, to feed an existing
-Kotlin build-optimizer that already has a `maxCastsPerSpell` hook in `SpellRotationOptimizer`.
+Kotlin build-optimizer; `SpellCatalog` joins it onto `Spell` by id, read via `Spell.maxCastsThisTurn`.
 Target fields per spell: maxCastPerTurn, maxCastPerTurnIncr (optional), maxCastPerTarget,
 cooldown (= min interval between casts, optional), plus breedId (class) and name. This is an
 OFFLINE, baked artifact — produce the JSON once; the Kotlin app reads the JSON, never the binary.
@@ -216,7 +223,7 @@ Array (or id-keyed map) of:
     "maxCastPerTarget": int|null, "cooldown": int|null }
 Rules: NEVER invent a value. Use null for anything unconfirmed or not yet oracle-validated. Do NOT
 coerce missing/0 to a finite cap — a 0/absent maxCastPerTurn likely means "unlimited"; document the
-convention rather than guessing. Match the key shape SpellRotationOptimizer.maxCastsPerSpell expects.
+convention rather than guessing. Match the array-keyed-by-spellId shape SpellCatalog joins onto Spell.
 
 DELIVERABLE
 The baked JSON file (offline artifact, parallel to the existing equipments-v<version>.json), plus a
@@ -228,9 +235,10 @@ short note on which path produced it and which spells you oracle-validated.
 ## 8. Extraction results (run 2026-06-15, Wakfu data `1.91.1.54`)
 
 **Produced:** `autobuilder/src/main/resources/spell-cast-limits-v1.91.1.54.json`
-(715 spells, ~126 KB, JSON array sorted by `breedId` then `spellId`). This is the baked, offline
-artifact — parallel to `equipments-v1.91.1.54.json` / `spells-v1.91.1.54.json`. **Not** wired into
-the Kotlin engine; the `SpellRotationOptimizer.maxCastsPerSpell` integration is a separate step.
+(715 spells, ~135 KB, JSON array sorted by `breedId` then `spellId`). This is the baked, offline
+artifact — parallel to `equipments-v1.91.1.54.json` / `spells-v1.91.1.54.json`. It is now joined onto
+`Spell` in `SpellCatalog` (`maxCastPerTurn`/`cooldown` → the per-turn cap `Spell.maxCastsThisTurn` used
+by the rotation optimizer; `wpCost` carried for display) — see `docs/FULL_DAMAGE_PLAN.md` "Lot 1".
 
 > **Canonical reproduction is now in-repo and pure-JVM:** `./gradlew :bdata-extractor:run`. That Kotlin
 > module (clean-room decoder, `bdata-extractor/`) decodes the same binaries and **regenerates this exact
@@ -258,6 +266,7 @@ from `spells-v1.91.1.54.json`, emit the §6 contract.
 ### Field mapping (binary → output)
 `cast_max_per_turn` (f32) → `maxCastPerTurn`; `cast_max_per_turn_incr` (f32) → `maxCastPerTurnIncr`;
 `cast_max_per_target` (i16) → `maxCastPerTarget`; `cast_min_interval` (i16) → `cooldown`;
+`pw_base` (f32) → `wpCost` (the WP base cost; `pa`/`pm`/`pw` = AP/MP/WP, so it sits right after `pa_base`);
 `breed_id` (i16) → `breedId`; `id` → `spellId`. `name` = French name from the scraped catalog.
 
 ### Convention (decided & applied)


### PR DESCRIPTION
## What

Lot 1 of the full-damage roadmap (`docs/FULL_DAMAGE_PLAN.md`): bound the spell-rotation throughput by each spell's **real per-turn cast limit**, so max-damage mode stops over-rewarding spamming a single spell. Also extracts per-spell **WP cost** for display + future modelling.

## Changes

- **Cast-limit join.** `Spell` gains `maxCastPerTurn` + a computed `maxCastsThisTurn` cap (`cooldown > 0 ⇒ 1`; `maxCastPerTurn` `0`/null ⇒ unbounded). `SpellCatalog` joins `spell-cast-limits-v*.json` onto each `Spell` by id via the new `SpellCastLimit` DTO.
- **Bounded throughput.** `baseThroughputTable` (the CP-SAT objective table) and `bestRotation` (display/scorer) both use one item-layered bounded knapsack with per-spell caps. The `addElement(apVar, table, throughput)` call is unchanged — only the table's *contents* change — so the optimality proof and the solver↔scorer lockstep are intact.
- **WP cost.** `bdata-extractor` now surfaces `pw_base` → `SpellCastLimit.wpCost` → `Spell.wpCost` (regenerated artifact is additive-only). WP *modelling* is deferred: WP is a per-fight pool with per-class in-fight regen (Xelor especially) — see the plan doc.
- **Cleanups (self-review + max-effort review):** shared `EmbeddedResources.decodeList<T>` loader (was 6 copy-pasted blocks); `boundedKnapsack` rewritten to the same item-layered DP as `baseThroughputTable`; multi-spell test coverage; doc accuracy.

## Verification

`./gradlew :autobuilder:test :bdata-extractor:test :common-lib:test ktlintCheck` — green (incl. 46 OR-Tools solver tests + the lockstep assertion). `gui-compose` compiles. A 9-angle max-effort review found **no correctness bugs**; all surfaced findings (cleanup / coverage / docs) are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
