### PR TITLE
feat(damage): bi-element CP-SAT objective (Lot 2 M1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /build/
 **/build/
 
+# Kotlin compiler-daemon working dir (e.g. .kotlin/errors/*.log) — build artifact, never committed
+.kotlin/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
@@ -194,4 +194,27 @@ data class WakfuBestBuildParams(
     // its **parallel** AP probes don't each spawn cores−1 native threads and oversubscribe the CPU. Null =
     // default. Ignored when a deterministic SolverTuning is supplied.
     val solverWorkers: Int? = null,
+    // Max-damage BI-ELEMENT solve (Lot 2): optimize the {first,second} element PAIR with `apSplitOnFirst`
+    // AP on the first element's rotation and (maxDamageApTarget − apSplitOnFirst) on the second, instead of
+    // the single-element max-over-candidateElements. Null ⇒ the unchanged single/boss per-element path.
+    // Requires maxDamageApTarget (the pinned total AP A) to be set. Ignored unless FIND_BUILD_WITH_MAX_DAMAGE.
+    val maxDamageBiElement: BiElementSplit? = null,
 )
+
+/**
+ * A bi-element split for max-damage mode (Lot 2): the element [first] gets [apSplitOnFirst] AP and [second]
+ * gets `maxDamageApTarget − apSplitOnFirst`. The external loop ([MaxDamageSearch]) enumerates these over
+ * `(pair × total-AP × split)`; the objective ([WakfuBuildSolver] `perTurnDamageScoreBiElement`) reads the
+ * split as outer-loop constants, keeping the inner CP-SAT solve linear (no spell-count × mastery product).
+ */
+data class BiElementSplit(
+    val first: me.chosante.autobuilder.domain.SpellElement,
+    val second: me.chosante.autobuilder.domain.SpellElement,
+    val apSplitOnFirst: Int,
+) {
+    init {
+        // A pair must be two distinct elements — a duplicate would collapse the single elementVars fold
+        // (the objective requires this too; fail fast at construction so M2's enumerator can't form e==e).
+        require(first != second) { "bi-element pair must be two distinct elements, got $first twice" }
+    }
+}

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -332,44 +332,102 @@ object WakfuBuildSolver {
     ): Flow<GeneticAlgorithmResult<BuildCombination>> =
         callbackFlow {
             withContext(Dispatchers.IO) {
-                val model = CpModel()
-
-                // Full pool gives the provable *global* optimum and stays tractable for most queries.
-                // Only elemental/resistance targets activate the heavy random-element modelling that
-                // explodes on the full late-game pool, so we prefilter exactly (and only) those cases.
-                val pool =
-                    if (needsItemPrefilter(params.targetStats)) {
-                        prefilterRelevantEquipments(equipmentsByItemType, params)
-                    } else {
-                        equipmentsByItemType
-                    }
-                val allEquips = orderEquipments(pool)
-                val equipVars = model.createEquipmentVariables(allEquips)
-                val skillVars = model.createSkillVariables(params.character.characterSkills)
-                val runeModel = model.createRuneModel(params, allEquips, equipVars, runes)
-                val subModel = model.createSublimationModel(params, allEquips, equipVars, sublimations)
-                model.addNormalSublimationSocketBudget(allEquips, equipVars, runeModel, subModel)
-
-                model.addBuildValidityConstraints(allEquips, equipVars)
-
-                val objective =
-                    when (params.scoreComputationMode) {
-                        ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT ->
-                            model.buildMostMasteriesObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
-
-                        ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT ->
-                            model.buildPrecisionObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
-
-                        ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE ->
-                            model.buildMaxDamageObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
-                    }
-                model.maximize(objective)
-
-                executeSolverAndEmitResults(model, params, allEquips, equipVars, skillVars, runeModel, subModel, this@callbackFlow, tuning)
+                val built = buildModel(params, equipmentsByItemType, runes, sublimations)
+                executeSolverAndEmitResults(
+                    built.model,
+                    params,
+                    built.allEquips,
+                    built.equipVars,
+                    built.skillVars,
+                    built.runeModel,
+                    built.subModel,
+                    this@callbackFlow,
+                    tuning
+                )
             }
             close()
             awaitClose { }
         }
+
+    private class BuiltModel(
+        val model: CpModel,
+        val objective: IntVar,
+        val allEquips: List<Equipment>,
+        val equipVars: Map<Equipment, IntVar>,
+        val skillVars: Map<SkillCharacteristic, IntVar>,
+        val runeModel: RuneModel,
+        val subModel: SublimationModel,
+    )
+
+    /**
+     * Assembles the full CP-SAT model — item / skill / rune / sublimation vars, validity constraints, and the
+     * mode's objective — and calls [CpModel.maximize]. Extracted from [optimize] so the test-only
+     * [maxDamageObjectiveValueForTest] builds a byte-identical model (no drift between the production solve and
+     * the objective-readout used by the bi-element tests).
+     */
+    private fun buildModel(
+        params: WakfuBestBuildParams,
+        equipmentsByItemType: Map<ItemType, List<Equipment>>,
+        runes: List<RuneType>,
+        sublimations: List<Sublimation>,
+    ): BuiltModel {
+        val model = CpModel()
+
+        // Full pool gives the provable *global* optimum and stays tractable for most queries.
+        // Only elemental/resistance targets activate the heavy random-element modelling that
+        // explodes on the full late-game pool, so we prefilter exactly (and only) those cases.
+        val pool =
+            if (needsItemPrefilter(params.targetStats)) {
+                prefilterRelevantEquipments(equipmentsByItemType, params)
+            } else {
+                equipmentsByItemType
+            }
+        val allEquips = orderEquipments(pool)
+        val equipVars = model.createEquipmentVariables(allEquips)
+        val skillVars = model.createSkillVariables(params.character.characterSkills)
+        val runeModel = model.createRuneModel(params, allEquips, equipVars, runes)
+        val subModel = model.createSublimationModel(params, allEquips, equipVars, sublimations)
+        model.addNormalSublimationSocketBudget(allEquips, equipVars, runeModel, subModel)
+
+        model.addBuildValidityConstraints(allEquips, equipVars)
+
+        val objective =
+            when (params.scoreComputationMode) {
+                ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT ->
+                    model.buildMostMasteriesObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
+
+                ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT ->
+                    model.buildPrecisionObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
+
+                ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE ->
+                    model.buildMaxDamageObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
+            }
+        model.maximize(objective)
+
+        return BuiltModel(model, objective, allEquips, equipVars, skillVars, runeModel, subModel)
+    }
+
+    /**
+     * Test-only: assemble the model exactly like [optimize] (via [buildModel]) and return the **maximized
+     * objective value**, requiring a deterministic [SolverTuning] and a proven `OPTIMAL` status. Needed because
+     * the streamed [GeneticAlgorithmResult.matchPercentage] is computed by the single-element scorer and so
+     * cannot read the bi-element objective for an interior split — see the Lot 2 tests in WakfuBuildSolverTest.
+     */
+    internal fun maxDamageObjectiveValueForTest(
+        params: WakfuBestBuildParams,
+        equipmentsByItemType: Map<ItemType, List<Equipment>>,
+        tuning: SolverTuning,
+    ): Long {
+        val built = buildModel(params, equipmentsByItemType, emptyList(), emptyList())
+        val solver = CpSolver()
+        solver.parameters.logSearchProgress = false
+        solver.parameters.numSearchWorkers = tuning.numSearchWorkers
+        solver.parameters.randomSeed = tuning.randomSeed
+        solver.parameters.maxDeterministicTime = tuning.maxDeterministicTime
+        val status = solver.solve(built.model)
+        require(status == com.google.ortools.sat.CpSolverStatus.OPTIMAL) { "expected OPTIMAL, got $status" }
+        return solver.objectiveValue().toLong()
+    }
 
     private fun CpModel.createSkillVariables(characterSkills: CharacterSkills): Map<SkillCharacteristic, IntVar> {
         val skillVars = mutableMapOf<SkillCharacteristic, IntVar>()
@@ -823,7 +881,22 @@ object WakfuBuildSolver {
         statBuilder.applyOutOfCombatCaps()
         // External-loop AP probe: pin the build to exactly N AP so each breakpoint can be evaluated.
         params.maxDamageApTarget?.let { addEquality(statBuilder.actionPointVar(), newConstant(it.toLong())) }
-        val damageScore = statBuilder.perTurnDamageScore(params.damageScenario, params.character.clazz)
+        // Bi-element (Lot 2): when a split is given, optimize the element PAIR (the split + total AP are pinned,
+        // outer-loop constants); otherwise the single/boss per-element objective. Both return a var on the SAME
+        // [DAMAGE_PERTURN_ABS_MAX] domain, so the external max over (mono OR bi, AP, split) is comparable.
+        val damageScore =
+            params.maxDamageBiElement?.let { bi ->
+                val totalAp =
+                    requireNotNull(params.maxDamageApTarget) { "bi-element requires a pinned total AP (maxDamageApTarget)" }
+                statBuilder.perTurnDamageScoreBiElement(
+                    bi.first,
+                    bi.second,
+                    bi.apSplitOnFirst,
+                    totalAp,
+                    params.damageScenario,
+                    params.character.clazz
+                )
+            } ?: statBuilder.perTurnDamageScore(params.damageScenario, params.character.clazz)
         return applyConstraintPenalty(params, statBuilder, damageScore, DAMAGE_PERTURN_ABS_MAX).objective
     }
 
@@ -1477,7 +1550,7 @@ object WakfuBuildSolver {
 
                     // raw = throughput · (perHit ÷ PERHIT_DOWNSCALE) — the per-hit core scaled down to a
                     // modest domain before the multiplication, so the product stays small for CP-SAT.
-                    val perHit = perHitDamageScore(element.masteryCharacteristic, scenario)
+                    val perHit = perHitDamageScore(scenarioElementMasteryVar(element.masteryCharacteristic), element.masteryCharacteristic.name, scenario)
                     val perHitScaled = model.newIntVar(0L, PERHIT_SCALED_MAX, "perHitScaled_${element.name}")
                     model.addDivisionEquality(perHitScaled, perHit, model.newConstant(PERHIT_DOWNSCALE))
                     val raw = model.newIntVar(0L, ROTATION_RAW_MAX, "rotRaw_${element.name}")
@@ -1504,18 +1577,114 @@ object WakfuBuildSolver {
         }
 
         /**
-         * Build-dependent per-hit core `D · Graw` for the spell element [elementMastery] (see
-         * [perTurnDamageScore]). All masteries / DI / crit are clamped into the damage bounds so the two
-         * CP-SAT multiplications stay on small, stable integer domains. Var names are element-suffixed so
-         * the boss-aware path can build one per element without collisions.
+         * Spell/boss-aware per-turn damage for a BI-ELEMENT split (Lot 2): the pair [elementA]+[elementB] with
+         * [apOnA] AP routed to [elementA]'s rotation and `[totalAp] − [apOnA]` to [elementB]'s. The split and total
+         * AP are **outer-loop constants** (from [WakfuBestBuildParams.maxDamageBiElement] + `maxDamageApTarget`),
+         * so each element's throughput `T_e[ap]` is injected as a literal and the objective is
+         * `Σ_e resFactor_e · T_e[ap_e] · perHit_e` — purely **linear** (no spell-count × mastery product; contrast
+         * the mono [perTurnDamageScore], whose `addElement` + `addMultiplicationEquality` IS that bilinear term).
+         *
+         * **Scale-identical to [perTurnDamageScore]**: each element reuses the exact mono pipeline
+         * (perHit → ÷PERHIT_DOWNSCALE → ×T → ×resFactor → ÷FINAL_DOWNSCALE), so at a degenerate split
+         * (`apOnA = 0` or `= totalAp`) the other element's `T` is 0, it drops, and the result reproduces the mono
+         * objective for the surviving element exactly ⇒ bi ≥ mono (domination). The two per-element damages are
+         * summed then **clamped to [DAMAGE_PERTURN_ABS_MAX]**: the sum's natural bound is 2×, but clamping keeps the
+         * objective on the mono domain (so the external `max` over mono/bi is sound) AND keeps the constraint-penalty
+         * multiply overflow-safe (see [applyConstraintPenalty]); the clamp is physically non-binding (the cap is
+         * orders of magnitude above any real per-turn value).
+         *
+         * The **single** [elementVars] call over both mastery characteristics is the double-count fix (Lot 2b):
+         * generic "+all elements" folds in full onto each element's own damage and `*_RANDOM_ELEMENT` lines split
+         * across the pair (`effectiveCount = min(count, 2)`) — two singleton calls would add generic mastery to
+         * both cores and assign a 1-random line in full to each. Crit / DI / range / rear are build-global and
+         * shared by both cores (read inside [perHitDamageScore]) — correctly NOT split.
+         */
+        fun perTurnDamageScoreBiElement(
+            elementA: me.chosante.autobuilder.domain.SpellElement,
+            elementB: me.chosante.autobuilder.domain.SpellElement,
+            apOnA: Int,
+            totalAp: Int,
+            scenario: DamageScenario,
+            clazz: me.chosante.common.CharacterClass,
+        ): IntVar {
+            require(elementA != elementB) { "bi-element requires two distinct elements" }
+            val pair = listOf(elementA, elementB)
+            val resByElement = scenario.candidateElements().toMap()
+            val apByElement = mapOf(elementA to apOnA, elementB to (totalAp - apOnA))
+
+            // (Lot 2b) ONE elementVars call over both elements' masteries — see the KDoc. The cache key
+            // (MASTERY_ELEMENTARY, [eA, eB]) is distinct from the mono singleton keys, and the mono/bi paths are
+            // mutually exclusive within a solve, so there is no cache collision.
+            val masteryVars =
+                elementVars(
+                    wantedElements = pair.map { it.masteryCharacteristic },
+                    genericCharacteristic = Characteristic.MASTERY_ELEMENTARY,
+                    targets = pair.associate { it.masteryCharacteristic to 1 },
+                    randomByCount = MASTERY_RANDOM_BY_COUNT
+                )
+
+            val perElementDamage =
+                pair.mapNotNull { element ->
+                    // A pair element absent from the scenario's resistances degenerates to mono (don't invent a
+                    // neutral resistance — mirrors candidateElements()).
+                    val resistance = resByElement[element] ?: return@mapNotNull null
+                    val ap = apByElement.getValue(element).coerceIn(0, MAX_ROTATION_AP.toInt())
+                    val spells =
+                        SpellCatalog.damageSpells(clazz).filter {
+                            it.element ==
+                                me.chosante.common.SpellElement
+                                    .valueOf(element.name)
+                        }
+                    val table = SpellRotationOptimizer.baseThroughputTable(spells, MAX_ROTATION_AP.toInt())
+                    val throughput = table[ap].coerceAtMost(PER_TURN_THROUGHPUT_MAX) // same clamp as mono clampedTable
+                    if (throughput == 0L) return@mapNotNull null // dead element (no spells) or a=0 slice ⇒ contributes 0
+
+                    val s = "${element.name}_bi"
+                    val perHit = perHitDamageScore(masteryVars.getValue(element.masteryCharacteristic), s, scenario)
+                    val perHitScaled = model.newIntVar(0L, PERHIT_SCALED_MAX, "perHitScaled_$s")
+                    model.addDivisionEquality(perHitScaled, perHit, model.newConstant(PERHIT_DOWNSCALE))
+
+                    // raw = T · perHitScaled — T is an outer-loop CONSTANT, so this is LINEAR (no variable×variable).
+                    val raw = model.newIntVar(0L, ROTATION_RAW_MAX, "rotRaw_$s")
+                    model.addEquality(raw, LinearExpr.term(perHitScaled, throughput))
+
+                    val resFactor = (100L - resistance).coerceIn(RES_FACTOR_MIN, RES_FACTOR_MAX)
+                    val rawWithRes = model.newIntVar(0L, ROTATION_RAW_RES_MAX, "rotRawRes_$s")
+                    model.addEquality(rawWithRes, LinearExpr.term(raw, resFactor))
+                    val damage = model.newIntVar(0L, DAMAGE_PERTURN_ABS_MAX, "rotDamage_$s")
+                    model.addDivisionEquality(damage, rawWithRes, model.newConstant(FINAL_DOWNSCALE))
+                    damage
+                }
+
+            return when (perElementDamage.size) {
+                0 -> model.newConstant(0L)
+                1 -> perElementDamage.single() // a pair with one dead element degenerates to mono (exact, no clamp)
+                else -> {
+                    val sum = model.sumVar("rotBiSum", perElementDamage, 0L, 2L * DAMAGE_PERTURN_ABS_MAX)
+                    val total = model.newIntVar(0L, DAMAGE_PERTURN_ABS_MAX, "rotBiTotal")
+                    model.addMinEquality(total, arrayOf(sum, model.newConstant(DAMAGE_PERTURN_ABS_MAX)))
+                    total
+                }
+            }
+        }
+
+        /**
+         * Build-dependent per-hit core `D · Graw` for an element whose folded elemental-mastery var is
+         * [elementMasteryVar] (see [perTurnDamageScore]). Taking the mastery var as a parameter — rather
+         * than computing it internally — lets the bi-element path feed both cores from a *single*
+         * [elementVars] call over the element pair, so generic "+all elements" and random-element mastery
+         * are folded once per element rather than double-counted. All masteries / DI / crit are clamped
+         * into the damage bounds so the two CP-SAT multiplications stay on small, stable integer domains.
+         * Var names carry [suffix] so per-element cores never collide.
          */
         private fun perHitDamageScore(
-            elementMastery: Characteristic,
+            elementMasteryVar: IntVar,
+            suffix: String,
             scenario: DamageScenario,
         ): IntVar {
-            val s = elementMastery.name
+            val s = suffix
             val masteryTerms = mutableListOf<Term>()
-            masteryTerms.add(Term(scenarioElementMasteryVar(elementMastery), 1L))
+            masteryTerms.add(Term(elementMasteryVar, 1L))
             masteryTerms.add(Term(actualStat(scenario.rangeBand.masteryCharacteristic), 1L))
             if (scenario.orientation.grantsRearMastery) masteryTerms.add(Term(actualStat(Characteristic.MASTERY_BACK), 1L))
             if (scenario.berserk) masteryTerms.add(Term(actualStat(Characteristic.MASTERY_BERSERK), 1L))

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -1286,6 +1286,203 @@ class WakfuBuildSolverTest {
             assertThat(chosen.totalExpectedDamage).isGreaterThan(0.0)
         }
 
+    // ----- Lot 2 M1: bi-element objective -----
+
+    /** Max-damage params pinned to [totalAp] AP; [biElement] non-null selects the bi-element objective. */
+    private fun apPinnedMaxDamageParams(
+        character: Character,
+        scenario: DamageScenario,
+        totalAp: Int,
+        biElement: BiElementSplit? = null,
+    ): WakfuBestBuildParams =
+        WakfuBestBuildParams(
+            character = character,
+            targetStats = TargetStats(emptyList()),
+            searchDuration = 5.seconds,
+            stopWhenBuildMatch = false,
+            maxRarity = Rarity.EPIC,
+            forcedItems = emptyList(),
+            excludedItems = emptyList(),
+            scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE,
+            useRunes = false,
+            damageScenario = scenario,
+            maxDamageApTarget = totalAp,
+            maxDamageBiElement = biElement
+        )
+
+    @Test
+    fun `bi-element degenerate splits reproduce the mono objective exactly`(): Unit =
+        runBlocking {
+            // Level-1 CRA; an AP belt (the only AP source) is forced equipped by the A=12 pin, and a dual
+            // fire+earth amulet so both elements are live and the build is identical across the solves.
+            val character = Character(CharacterClass.CRA, 1, 1, CharacterSkills(1))
+            val dual = equipment(1, ItemType.AMULET, "Dual", mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 100, Characteristic.MASTERY_ELEMENTARY_EARTH to 100))
+            val apBelt = equipment(2, ItemType.BELT, "ApBelt", mapOf(Characteristic.ACTION_POINT to 6))
+            val pool = listOf(dual, apBelt).groupBy { it.itemType }
+            val a = 12
+            val tuning = WakfuBuildSolver.SolverTuning()
+
+            val bi = DamageScenario(rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE, elementResistances = mapOf(SpellElement.FIRE to 0, SpellElement.EARTH to 0))
+            val monoFire =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(
+                        character,
+                        DamageScenario(element = SpellElement.FIRE, targetResistancePercent = 0, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                        a
+                    ),
+                    pool,
+                    tuning
+                )
+            val monoEarth =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(
+                        character,
+                        DamageScenario(element = SpellElement.EARTH, targetResistancePercent = 0, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                        a
+                    ),
+                    pool,
+                    tuning
+                )
+
+            // a=0 ⇒ all AP on the 2nd element ⇒ bi == mono(EARTH); a=A ⇒ all on the 1st ⇒ bi == mono(FIRE). Exact:
+            // bi reduces to the identical integer pipeline as mono at the endpoints (the throughput becomes T[A]).
+            val bi0 =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(character, bi, a, BiElementSplit(SpellElement.FIRE, SpellElement.EARTH, 0)),
+                    pool,
+                    tuning
+                )
+            val biA =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(character, bi, a, BiElementSplit(SpellElement.FIRE, SpellElement.EARTH, a)),
+                    pool,
+                    tuning
+                )
+            assertThat(monoFire).describedAs("sanity: mono FIRE is non-trivial").isGreaterThan(0)
+            assertThat(monoEarth).isGreaterThan(0)
+            assertThat(bi0).describedAs("split 0 ⇒ all AP on EARTH ⇒ reproduces mono EARTH exactly").isEqualTo(monoEarth)
+            assertThat(biA).describedAs("split A ⇒ all AP on FIRE ⇒ reproduces mono FIRE exactly").isEqualTo(monoFire)
+        }
+
+    @Test
+    fun `bi-element sums both element terms rather than taking their max`(): Unit =
+        runBlocking {
+            // FIRE is made dominant (10x EARTH mastery), so a (wrong) MAX objective would always equal the FIRE
+            // term — invariant to EARTH's resistance ⇒ obj(earthRes 0) == obj(earthRes 90). Under the correct SUM,
+            // EARTH's smaller term is still ADDED and scales with (100 − res) ⇒ obj(0) strictly > obj(90). That gap
+            // is precisely what distinguishes "sum the two element terms" from "max over elements".
+            val character = Character(CharacterClass.CRA, 1, 1, CharacterSkills(1))
+            val fireHeavy = equipment(1, ItemType.AMULET, "FireHeavy", mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 1000, Characteristic.MASTERY_ELEMENTARY_EARTH to 100))
+            val apBelt = equipment(2, ItemType.BELT, "ApBelt", mapOf(Characteristic.ACTION_POINT to 6))
+            val pool = listOf(fireHeavy, apBelt).groupBy { it.itemType }
+            val a = 12
+            val split = BiElementSplit(SpellElement.FIRE, SpellElement.EARTH, 6) // FIRE 6 AP, EARTH 6 AP — both live
+            val tuning = WakfuBuildSolver.SolverTuning()
+
+            fun obj(earthRes: Int): Long =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(
+                        character,
+                        DamageScenario(
+                            rangeBand = RangeBand.DISTANCE,
+                            orientation = Orientation.FACE,
+                            elementResistances =
+                                mapOf(
+                                    SpellElement.FIRE to 0,
+                                    SpellElement.EARTH to earthRes
+                                )
+                        ),
+                        a,
+                        split
+                    ),
+                    pool,
+                    tuning
+                )
+
+            val earthOpen = obj(earthRes = 0)
+            val earthResisted = obj(earthRes = 90)
+            assertThat(earthResisted).describedAs("the dominant FIRE term is always present").isGreaterThan(0)
+            assertThat(earthOpen)
+                .describedAs("EARTH's term is summed in and scales with (100 − res); a max objective would ignore the dominated EARTH ⇒ equal")
+                .isGreaterThan(earthResisted)
+        }
+
+    @Test
+    fun `bi-element does not double-count a one-random-element mastery line`(): Unit =
+        runBlocking {
+            // The 2b regression. Generic "+all elements" legitimately boosts BOTH cores; a "1 random element" line
+            // may boost only ONE (the single elementVars call splits it via min(count,2)). So generic > random.
+            // A two-singleton (double-counting) fold would credit the random line to both cores ⇒ generic == random.
+            val character = Character(CharacterClass.CRA, 1, 1, CharacterSkills(1))
+            val apBelt = equipment(2, ItemType.BELT, "ApBelt", mapOf(Characteristic.ACTION_POINT to 6))
+            val a = 12
+            val split = BiElementSplit(SpellElement.FIRE, SpellElement.EARTH, 4)
+            val scenario =
+                DamageScenario(rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE, elementResistances = mapOf(SpellElement.FIRE to 0, SpellElement.EARTH to 0))
+            val tuning = WakfuBuildSolver.SolverTuning()
+
+            fun obj(masteryItem: Equipment): Long =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(apPinnedMaxDamageParams(character, scenario, a, split), listOf(masteryItem, apBelt).groupBy { it.itemType }, tuning)
+
+            val genericObj = obj(equipment(1, ItemType.AMULET, "AllElem", mapOf(Characteristic.MASTERY_ELEMENTARY to 1000)))
+            val randomObj = obj(equipment(1, ItemType.AMULET, "Rand1", mapOf(Characteristic.MASTERY_ELEMENTARY_ONE_RANDOM_ELEMENT to 1000)))
+            assertThat(randomObj).describedAs("a one-random line still helps one element").isGreaterThan(0)
+            assertThat(genericObj)
+                .describedAs("generic boosts BOTH cores, a one-random line only one ⇒ strictly greater (equality would mean the random line was double-counted)")
+                .isGreaterThan(randomObj)
+        }
+
+    @Test
+    fun `bi-element gates out a dead element regardless of its AP or resistance`(): Unit =
+        runBlocking {
+            // CRA has no WATER spells ⇒ all-zero WATER table. Two checks: (1) at the a=A endpoint, bi(FIRE,WATER)
+            // reduces to exactly mono FIRE (no phantom water term); (2) at an INTERIOR split WATER is given 8 of 12
+            // AP and its resistance is swung from a weakness (−100) to 0 — a contributing element would move the
+            // objective, but a properly-gated dead element leaves it invariant. (2) isolates dead-spell gating from
+            // the trivial ap=0 case that (1) alone could be explained by.
+            val character = Character(CharacterClass.CRA, 1, 1, CharacterSkills(1))
+            val fire = equipment(1, ItemType.AMULET, "Fire", mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 100))
+            val apBelt = equipment(2, ItemType.BELT, "ApBelt", mapOf(Characteristic.ACTION_POINT to 6))
+            val pool = listOf(fire, apBelt).groupBy { it.itemType }
+            val a = 12
+            val tuning = WakfuBuildSolver.SolverTuning()
+
+            fun biFireWater(
+                apOnFire: Int,
+                waterRes: Int,
+            ): Long =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(
+                        character,
+                        DamageScenario(
+                            rangeBand = RangeBand.DISTANCE,
+                            orientation = Orientation.FACE,
+                            elementResistances = mapOf(SpellElement.FIRE to 0, SpellElement.WATER to waterRes)
+                        ),
+                        a,
+                        BiElementSplit(SpellElement.FIRE, SpellElement.WATER, apOnFire)
+                    ),
+                    pool,
+                    tuning
+                )
+
+            val monoFire =
+                WakfuBuildSolver.maxDamageObjectiveValueForTest(
+                    apPinnedMaxDamageParams(
+                        character,
+                        DamageScenario(element = SpellElement.FIRE, targetResistancePercent = 0, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                        a
+                    ),
+                    pool,
+                    tuning
+                )
+            assertThat(monoFire).isGreaterThan(0)
+            assertThat(biFireWater(apOnFire = a, waterRes = 0)).describedAs("a=A endpoint ⇒ WATER dropped ⇒ bi == mono FIRE").isEqualTo(monoFire)
+            assertThat(biFireWater(apOnFire = 4, waterRes = -100))
+                .describedAs("dead WATER given 8 AP + a weakness still contributes 0 ⇒ objective invariant to WATER resistance")
+                .isEqualTo(biFireWater(apOnFire = 4, waterRes = 0))
+        }
+
     @Test
     fun `a forced rune is socketed at least once even when it matches no requested stat`(): Unit =
         runBlocking {

--- a/docs/FULL_DAMAGE_PLAN.md
+++ b/docs/FULL_DAMAGE_PLAN.md
@@ -12,9 +12,9 @@ The **global, trackable plan** for the coherent full-damage mode. Multiple agent
 
 | Lot | What it unlocks | Status | Depends on |
 |---|---|---|---|
-| **0** Boss data + selection | "vs a given boss" (auto-element) | 🔶 **CLI ✅ done** (`feat/boss-mode-integration`); **GUI ⬜** (picker + icons) | — |
+| **0** Boss data + selection | "vs a given boss" (auto-element) | ✅ **done** — CLI + GUI boss picker / icons ([#161](https://github.com/CharlyRien/wakfu-autobuilder/pull/161)) | — |
 | **1** Cast limits in the fused table | realistic rotation (no 1-spell spam) | ✅ **done** — per-turn + cooldown caps joined to `Spell` and bounded in both the fused table & display path; WP **cost** extracted too (display-ready), WP **model** deferred (per-fight pool) | — |
-| **2a-b** Bi-element objective + double-count fix | bi-element builds are *searched* | ⬜ todo | — |
+| **2a-b** Bi-element objective + double-count fix | bi-element builds are *searched* | 🔶 **objective done** (`feat/lot2-bi-element`): `perTurnDamageScoreBiElement` — linear, scale-identical to mono, double-count-safe, tested + verified. Not yet driven by the enumeration | — |
 | **2c-d** Enumeration + pruning | bi-element **optimality** | ⬜ todo (loop is currently heuristic) | 2a-b |
 | **2e-f** Scorer lockstep + display | honest `matchPercentage`, UI | ⬜ todo | 2c-d |
 | **3** Sublimations on the damage path | major end-game lever | ⬜ todo (model on `feat/sublimations`, unmerged) | — |


### PR DESCRIPTION
## What

Lot 2 milestone **M1** (full-damage roadmap): a **bi-element** CP-SAT damage objective for max-damage mode — the foundation for searching builds that play an element *pair* against a boss. It's wired behind a new param and **inert in production until M2 wires the enumeration**, so it's safe to merge alone.

## Changes

- `BiElementSplit` + `WakfuBestBuildParams.maxDamageBiElement` — the element pair + AP split (outer-loop constants; construction-guarded distinct elements).
- `StatBuilder.perTurnDamageScoreBiElement` — two per-element cores from **one** `elementVars([e1,e2])` call (the **2b double-count fix**); each element's throughput injected as a **Long constant**, so the objective is `Σ resFactor_e · T_e[split] · perHit_e` — provably **linear** (no spell-count × mastery product, unlike the mono path's `addMultiplicationEquality`). The per-element pipeline is byte-identical to mono; the two terms are summed and clamped to `DAMAGE_PERTURN_ABS_MAX` — overflow-safe under `applyConstraintPenalty` and scale-identical to mono, so the external `max` over (mono, bi, split) stays comparable (the clamp is non-binding for real builds).
- `perHitDamageScore` now takes the folded mastery var (enables the single `elementVars` call over the pair). `buildMaxDamageObjective` branches mono/bi.
- `optimize()`'s model assembly extracted into a shared `buildModel()`; a test-only `maxDamageObjectiveValueForTest()` reads the maximized objective (needed because `matchPercentage` is the single-element scorer and can't read the bi objective for an interior split).

## Verification

- 4 tests: exact endpoint reproduction (bi at split 0/A == mono, bit-for-bit), sum-vs-max discrimination, double-count regression, dead-element gating.
- A **6-lens adversarial-verification workflow** found **no real bug** — linearity, the `buildModel` refactor's equivalence across all three solver modes, overflow/domain bounds, the double-count fold, and edge-case gating all confirmed. Determinism confirmed across reruns.
- `WakfuBuildSolverTest` 50 tests + full `:autobuilder:test` + `:common-lib:test` + `ktlintCheck` green; `gui-compose` compiles.

Independent of [#162](https://github.com/CharlyRien/wakfu-autobuilder/pull/162) (Lot 1) — disjoint regions; they compose at merge. **Next:** M2 (2c-d) extends `MaxDamageSearch` to enumerate `(pair × total-AP × split)` with pruning + proven-`OPTIMAL` inner solves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
