### PR TITLE
feat(runes): a normal sublimation keeps the item's full rune set, and the socket pattern is always drawn

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -54,7 +54,7 @@ object WakfuBuildSolver {
     private const val MAX_POWER_TABLE_INDEX = 2_000
     private const val MAX_PENALTY_MULTIPLIER = 1_000_000L
     private const val MAX_SUBLIMATIONS = 10L // Wakfu: at most 10 sublimations on a build (incl. ≤1 epic, ≤1 relic).
-    private const val NORMAL_SUB_SOCKET_COST = 3L // a normal sublimation occupies 3 sockets on its carrier item.
+    private const val NORMAL_SUB_SOCKET_COST = 3L // a normal sublimation needs a 3-socket carrier for its ordered colour pattern.
 
     // Out-of-combat hardcaps (Wakfu): the equipped sheet can't exceed these. In-combat bonuses — including
     // start-of-combat sublimations — may go beyond, so the cap is on the PRE-sublimation value.
@@ -421,7 +421,11 @@ object WakfuBuildSolver {
         val skillVars = model.createSkillVariables(params.character.characterSkills)
         val runeModel = model.createRuneModel(params, allEquips, equipVars, runes)
         val subModel = model.createSublimationModel(params, allEquips, equipVars, sublimations)
-        model.addNormalSublimationSocketBudget(allEquips, equipVars, runeModel, subModel)
+        // A normal sublimation does NOT reserve rune sockets. Golden runes (colour-agnostic) form its ordered
+        // colour pattern AND still carry their stat — doubling where the item favours that colour — so a carrier
+        // keeps a full set of runes alongside the sub. Carrier eligibility (≥3-socket item) and the
+        // ≤1-normal-sub-per-item cap live in createSublimationModel; rune capacity (Σ runes ≤ sockets) lives in
+        // createRuneModel. The two no longer share a socket budget.
 
         model.addBuildValidityConstraints(allEquips, equipVars)
 
@@ -818,8 +822,9 @@ object WakfuBuildSolver {
     /**
      * Models the chosen/forced sublimations. Each modeled sub gets a [SublimationModel.subVars] boolean.
      * Epic/relic subs are gated to an equipped epic/relic item — their dedicated slot comes from that carrier
-     * ([gateSublimationsOnCarrierItems]); a normal sub is assigned to one ≥3-socket carrier item and consumes
-     * 3 of its sockets ([addNormalSublimationSocketBudget]), so it can't share sockets across items. At most 10
+     * ([gateSublimationsOnCarrierItems]); a normal sub is assigned to one ≥3-socket carrier item (at most one
+     * normal sub per item), but does NOT consume rune sockets — golden runes (colour-agnostic) form its ordered
+     * colour pattern while still carrying their stat, so the carrier keeps a full set of runes. At most 10
      * sublimations per build. Socket colours stay optimistic/re-rollable (no per-item colour data); the chosen
      * carrier + pattern are surfaced in the GUI. Effect contributions fold into the stat term loop by
      * [StatBuilder]; forced subs apply unconditionally (the user takes responsibility).
@@ -869,9 +874,10 @@ object WakfuBuildSolver {
         // Total cap: at most 10 sublimations on a build.
         addLessOrEqual(LinearExpr.sum(subVars.values.toTypedArray()), MAX_SUBLIMATIONS)
 
-        // Tie each NORMAL sub to exactly one carrier item with ≥3 sockets (y[sub,item]=1 ⇒ that item hosts it).
-        // The sub then consumes 3 of that item's sockets (addNormalSublimationSocketBudget) — i.e. it changes
-        // that item's enchantment loadout. Epic/relic subs need no socket carrier (gated on the rarity item above).
+        // Tie each NORMAL sub to exactly one carrier item with ≥3 sockets (y[sub,item]=1 ⇒ that item hosts it):
+        // it needs ≥3 sockets to lay down its ordered 3-colour pattern, but — golden runes being colour-agnostic —
+        // it does NOT take those sockets away from runes, so the carrier keeps a full rune set. Epic/relic subs
+        // need no socket carrier (gated on the rarity item above).
         val normalSubs = subVars.keys.filter { it.rarity == SublimationRarity.NORMAL }
         val carrierItems = allEquips.filter { it.maxShardSlots >= NORMAL_SUB_SOCKET_COST }
         val carrierVars = LinkedHashMap<Sublimation, Map<Equipment, IntVar>>()
@@ -2712,36 +2718,6 @@ object WakfuBuildSolver {
     ) {
         companion object {
             val EMPTY = SublimationModel(emptyMap(), emptySet(), 0)
-        }
-    }
-
-    /**
-     * Best-achievable normal-sublimation ↔ rune socket coupling (research P7): a normal sub reserves 3
-     * socket slots that can no longer hold runes, so `Σ runeCount + 3·Σ normalSubChosen ≤ Σ sockets of
-     * equipped items`. This is a global capacity budget (no per-slot colour / doubling pinning), matching
-     * the engine's existing optimistic re-rollable-colours rune model.
-     */
-    private fun CpModel.addNormalSublimationSocketBudget(
-        allEquips: List<Equipment>,
-        equipVars: Map<Equipment, IntVar>,
-        runeModel: RuneModel,
-        subModel: SublimationModel,
-    ) {
-        val normalSubs = subModel.subVars.keys.filter { it.rarity == SublimationRarity.NORMAL }
-        if (normalSubs.isEmpty()) return
-        // Per item: (runes socketed in it) + 3·(normal subs hosted on it) ≤ its sockets, when equipped. This
-        // ties each sub's 3 sockets to ONE carrier and shares the carrier's sockets with its runes, so hosting
-        // a sub reduces that item's rune capacity (no borrowing sockets across items). A normal sub with no
-        // ≥3-socket carrier is already forced off by the assignment equality in createSublimationModel.
-        for (item in allEquips) {
-            val runeVarsForItem = runeModel.runeVars[item]?.values.orEmpty()
-            val subHostsForItem = normalSubs.mapNotNull { subModel.carrierVars[it]?.get(item) }
-            if (runeVarsForItem.isEmpty() && subHostsForItem.isEmpty()) continue
-            val budget = LinearExpr.newBuilder()
-            runeVarsForItem.forEach { budget.addTerm(it, 1L) }
-            subHostsForItem.forEach { budget.addTerm(it, NORMAL_SUB_SOCKET_COST) }
-            budget.addTerm(equipVars.getValue(item), -item.maxShardSlots.toLong())
-            addLessOrEqual(budget.build(), 0L)
         }
     }
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -1792,7 +1792,7 @@ class WakfuBuildSolverTest {
         }
 
     @Test
-    fun `a normal sublimation is chosen only when enough sockets are free (socket budget)`(): Unit =
+    fun `a normal sublimation needs a carrier item with at least 3 sockets`(): Unit =
         runBlocking {
             val character = Character(CharacterClass.CRA, 1, 1, CharacterSkills(1))
             val normalDi =
@@ -1805,7 +1805,7 @@ class WakfuBuildSolverTest {
                     slotColorPattern = listOf(1, 2, 3)
                 )
 
-            // Carrier with 4 sockets: 3 reserved for the normal sub is fine -> chosen.
+            // Carrier with 4 sockets: enough to lay down the sub's ordered 3-colour pattern -> chosen.
             val bigCarrier = equipment(1, ItemType.AMULET, "Fire4", mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 100), maxShardSlots = 4)
             val chosen =
                 WakfuBuildSolver
@@ -1826,6 +1826,59 @@ class WakfuBuildSolverTest {
                     .toList()
                     .maxByOrNull { it.matchPercentage }!!
             assertThat(declined.individual.sublimations).isEmpty()
+        }
+
+    @Test
+    fun `a normal sublimation does not steal rune sockets from its carrier (golden runes)`(): Unit =
+        runBlocking {
+            val level = 245
+            val character = Character(CharacterClass.CRA, level, level, CharacterSkills(level))
+            // A 4-socket carrier, a beneficial distance rune, and a FORCED normal sub needing a 3-colour pattern.
+            // Golden runes form that pattern while still carrying their stat, so the sub must NOT cost rune sockets:
+            // the carrier keeps all four runes. (The old "reserve 3 sockets" model would cap this at one rune.)
+            val carrier = equipment(1, ItemType.AMULET, "Amu", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4, level = level)
+            val distanceRune =
+                RuneType(27098, I18nText("d", "d", "d", "d"), RuneColor.RED, Characteristic.MASTERY_DISTANCE, listOf(10, 15), 0)
+            val normalSub =
+                sublimation(
+                    10,
+                    SublimationRarity.NORMAL,
+                    SublimationKind.FLAT,
+                    "DistNormal",
+                    effects = listOf(SublimationEffect(Characteristic.MASTERY_DISTANCE, 10)),
+                    slotColorPattern = listOf(1, 2, 3)
+                )
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 1))),
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    forcedSublimations = listOf("DistNormal"),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, listOf(carrier).groupBy { it.itemType }, listOf(distanceRune), listOf(normalSub), WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            // The forced normal sub is hosted on the carrier...
+            assertThat(
+                best.individual.sublimations.values
+                    .flatten()
+                    .map { it.name.en }
+            ).contains("DistNormal")
+            // ...and it does not consume rune sockets: all four sockets still hold the distance rune.
+            val socketed =
+                best.individual.runes.values
+                    .flatten()
+            assertThat(socketed).hasSize(4)
+            assertThat(socketed).allMatch { it.characteristic == Characteristic.MASTERY_DISTANCE }
         }
 
     @Test

--- a/gui-compose/conveyor.conf
+++ b/gui-compose/conveyor.conf
@@ -13,9 +13,9 @@ app {
     // Native installers for all three desktop OSes from a single JVM build.
     // Unsigned builds (no paid certificate): users bypass the OS gatekeeper on first launch.
 
-    // Download site + auto-update feed. Kept here so the Compose app is release-ready; the CI
-    // deploy workflow still targets the JavaFX :gui until the cutover, so this does not publish
-    // automatically.
+    // Download site + auto-update feed. The deploy workflow (.github/workflows/deploy.yml, manual
+    // workflow_dispatch) runs Conveyor against this file: packages + the Sparkle/MSIX/apt update
+    // metadata are uploaded to GitHub Releases, and the download page is published to the gh-pages branch.
     site {
         theme = dark
         github {

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
@@ -646,20 +646,25 @@ private fun ItemTooltip(
                 }
             }
         }
-        if (runes.isNotEmpty()) {
+        val socketRunes = socketLayout(equipment, runes, subs).filter { it.second != null }
+        if (socketRunes.isNotEmpty()) {
             Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
             Text(
                 text = tr(Tr.RUNES),
                 style = WTypography.labelSmall.copy(color = WColor.faint, fontWeight = FontWeight.SemiBold)
             )
-            runes
-                .groupBy { it.characteristic }
-                .forEach { (_, sameStatRunes) ->
+            // Group by (stat, socket colour) so a hosted sublimation's pattern shows in the runes too — e.g. one
+            // green + three red distance runes — exactly matching the card. Enchantment level is gated by the
+            // carrier item's level (Ankama's table).
+            socketRunes
+                .groupBy { (color, rune) -> rune!!.characteristic to color }
+                .forEach { (statColor, cells) ->
+                    val rune = cells.first().second!!
                     TooltipRuneRow(
-                        rune = sameStatRunes.first(),
-                        count = sameStatRunes.size,
-                        // Enchantment level is gated by the carrier item's level (Ankama's table).
-                        level = sameStatRunes.first().maxLevel(equipment.level),
+                        rune = rune,
+                        color = statColor.second,
+                        count = cells.size,
+                        level = rune.maxLevel(equipment.level),
                         lang = lang
                     )
                 }
@@ -707,6 +712,31 @@ private fun RuneColor.displayColor(): Color =
     }
 
 /**
+ * The per-socket display layout for an item's enchantments, as `(socket colour, rune in it)` cells.
+ * A hosted normal sublimation paints its ordered colour pattern on the first sockets — so the pattern is
+ * ALWAYS drawn (that is how the sub is satisfied: users see the green/red/… sockets that host it) — and the
+ * remaining free sockets take the colour of the rune that fills them. Golden runes (colour-agnostic) make this
+ * always reachable: a rune in a pattern socket shows the pattern colour, a rune in a free socket shows its own
+ * (doubling) colour. Capped at the item's socket count; a pattern cell with no rune (more pattern than runes)
+ * carries a null rune. This single source drives both the paperdoll card shards and the hover tooltip so they
+ * always agree.
+ */
+private fun socketLayout(
+    equipment: Equipment,
+    runes: List<RuneType>,
+    subs: List<Sublimation>,
+): List<Pair<RuneColor, RuneType?>> {
+    val pattern = subs.flatMap { it.colors }
+    val slots = equipment.maxShardSlots.coerceAtLeast(0)
+    val cellCount = maxOf(pattern.size, runes.size).coerceAtMost(slots)
+    return (0 until cellCount).map { i ->
+        val rune = runes.getOrNull(i)
+        val color = pattern.getOrNull(i) ?: rune?.color ?: RuneColor.RED
+        color to rune
+    }
+}
+
+/**
  * A socketed rune's "symbol" = its official socket-shape shard, by socket colour: red = square,
  * green = pentagon, blue = triangle. The shard PNGs are extracted from the client's gui.jar
  * (`theme/images/shard{Red,Green,Blue}Full`) into assets/runes/ by `generateAssets`. The stat each rune
@@ -748,6 +778,7 @@ private fun RuneShape(
 @Composable
 private fun TooltipRuneRow(
     rune: RuneType,
+    color: RuneColor,
     count: Int,
     level: Int,
     lang: Lang,
@@ -756,14 +787,16 @@ private fun TooltipRuneRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp)
     ) {
-        RuneShape(color = rune.color, size = 18.dp)
+        // [color] is the SOCKET colour (a sublimation pattern colour, or the rune's own on a free socket), not
+        // necessarily the rune's nominal colour — golden runes take the colour of the socket they sit in.
+        RuneShape(color = color, size = 18.dp)
         Text(
             text = "${count}x",
             style =
                 WTypography.bodySmall.copy(
                     fontFamily = WType.mono,
                     fontWeight = FontWeight.SemiBold,
-                    color = rune.color.displayColor()
+                    color = color.displayColor()
                 )
         )
         Text(
@@ -972,16 +1005,12 @@ private fun SlotMeta(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            // The item's SOCKETS, shown as coloured shards. A rune and a sublimation pattern colour describe the
-            // SAME physical socket (the sub dictates a socket's required colour; the chosen rune sits in it and
-            // already matches), so they are not additive: the solver's CHOSEN RUNES come first and win the socket
-            // budget, and the sublimation's pattern only fills any sockets the runes didn't (capped at the item's
-            // socket count). Ordering runes first stops a 3-colour sub pattern from consuming the whole budget and
-            // hiding the chosen runes. The sublimation is still NAMED to one side on the SAME line (no extra
-            // vertical line, so the shard size stays identical on every card), which surfaces epic/relic subs too
-            // (they carry no pattern). Full per-rune/-sub details stay in the hover tooltip.
-            val socketColors =
-                (runes.map { it.color } + subs.flatMap { it.colors }).take(equipment.maxShardSlots.coerceAtLeast(1))
+            // The item's SOCKETS as coloured shards, from the shared [socketLayout]: a hosted normal sublimation
+            // paints its ordered colour pattern on the first sockets (so it is always visible — golden runes form
+            // it), then the free sockets take their rune's colour. The sublimation is still NAMED to one side on
+            // the SAME line (no extra vertical line, so the shard size stays identical on every card), which
+            // surfaces epic/relic subs too (they carry no pattern). Full per-rune/-sub details stay in the tooltip.
+            val socketColors = socketLayout(equipment, runes, subs).map { it.first }
             val hasSub = subs.isNotEmpty()
             if (socketColors.isNotEmpty() || hasSub) {
                 val gap = 5.dp


### PR DESCRIPTION
## What

Two coupled changes to how a **normal sublimation** interacts with an item's rune sockets.

### Solver — a normal sub no longer costs rune sockets
The previous model ("research P7") enforced `Σ runes + 3·subs ≤ sockets`, so a 4-socket item hosting a
normal sublimation kept only **one** rune (the sub "reserved" three). That under-counts: per
[docs/ENCHANTMENTS_PLAN.md](docs/ENCHANTMENTS_PLAN.md), a normal sub only **pins** three socket *colours*, it
doesn't empty them. Modelling **golden runes** (colour-agnostic) resolves it — they form the sub's ordered
colour pattern *and* carry their stat (doubling where the item favours that colour) — so the carrier keeps a
**full** rune set alongside the sub.

`addNormalSublimationSocketBudget` is removed. Carrier eligibility (≥3 sockets) and the ≤1-normal-sub-per-item
cap were always separate constraints and are unchanged.

### Display — the socket pattern is always drawn
A new shared `socketLayout(equipment, runes, subs)` paints the sublimation's ordered pattern on the first
sockets and fills the rest with the runes' colours. **Both the paperdoll card and the hover tooltip render
from it**, so they agree. A 4-socket amulet with Vélocité II (🟢🟥🟥) now shows **1 green + 3 red** distance
runes in both — making it clear how the sublimation fits (previously the card showed four red shards and the
green pattern socket was hidden). Items without a normal sub (or with epic/relic subs, which carry no pattern)
are unchanged.

## Testing
- New regression test: `a normal sublimation does not steal rune sockets from its carrier (golden runes)`.
- Renamed the now-misnamed `…(socket budget)` test → `…needs a carrier item with at least 3 sockets`.
- Full `:autobuilder:test` green (108 tests); `gui-compose` compiles, ktlint clean.

## Note
Also folds in a small stale-comment refresh in `gui-compose/conveyor.conf`.
