### PR TITLE
feat: per-spell damage, multi-build comparison, translations, and provable max-damage with runes/sublimations

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/Main.kt
@@ -1055,7 +1055,7 @@ private fun List<me.chosante.common.Passive>.asPassivesASCIITable() =
                     passive.flatStats.entries
                         .joinToString(", ") { "+${it.value} ${it.key.name}" }
                         .ifBlank { "—" }
-                row(passive.name ?: passive.spellId.toString(), flat, passive.description ?: "")
+                row(passive.name?.fr ?: passive.spellId.toString(), flat, passive.description?.fr ?: "")
             }
         }
     }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/BuildSpellDamage.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/BuildSpellDamage.kt
@@ -2,6 +2,7 @@ package me.chosante.autobuilder.domain
 
 import me.chosante.autobuilder.genetic.wakfu.computeCharacteristicsValues
 import me.chosante.common.Character
+import me.chosante.common.Characteristic
 import me.chosante.common.Spell
 import me.chosante.common.SpellDamage
 
@@ -27,22 +28,11 @@ object BuildSpellDamage {
         rangeBand: SpellDamage.RangeBand? = null,
         rearMastery: Boolean = false,
         berserkMastery: Boolean = false,
+        orientationMultiplierPercent: Int = 100,
         targetResistancePercent: Int = 0,
         critCapPercent: Int = 100,
     ): SpellDamage.Result? {
-        val element = spell.element ?: return null
-        val stats =
-            computeCharacteristicsValues(
-                buildCombination = build,
-                characterBaseCharacteristics = character.baseCharacteristicValues,
-                // Fold generic elemental mastery into the spell's element, exactly like the scorers.
-                masteryElementsWanted = mapOf(element.masteryCharacteristic to 1),
-                resistanceElementsWanted = emptyMap()
-            )
-                // The generic "+all elements" mastery is now folded into the element key above, so drop
-                // the standalone entry — otherwise SpellDamage (which also adds it) would count it twice.
-                .toMutableMap()
-                .apply { remove(me.chosante.common.Characteristic.MASTERY_ELEMENTARY) }
+        val stats = resolveStats(spell, build, character) ?: return null
         return SpellDamage.expectedDamage(
             spell = spell,
             stats = stats,
@@ -50,8 +40,34 @@ object BuildSpellDamage {
             rangeBand = rangeBand,
             rearMastery = rearMastery,
             berserkMastery = berserkMastery,
+            orientationMultiplierPercent = orientationMultiplierPercent,
             targetResistancePercent = targetResistancePercent,
             critCapPercent = critCapPercent
         )
+    }
+
+    /**
+     * The build's resolved characteristic totals as [SpellDamage] reads them for [spell]'s element — the
+     * generic "+all elements" mastery folded into the element key, then the standalone entry dropped so
+     * [SpellDamage.expectedDamage] (which re-adds it) doesn't double-count. `null` when the spell has no element.
+     *
+     * Resolving a build's stats is the expensive part; expose it so a caller showing several scenarios of the
+     * SAME spell (e.g. face / back / berserk) can resolve **once** and call [SpellDamage.expectedDamage] per
+     * scenario, instead of paying a full re-resolution for each via [expectedDamage].
+     */
+    fun resolveStats(
+        spell: Spell,
+        build: BuildCombination,
+        character: Character,
+    ): Map<Characteristic, Int>? {
+        val element = spell.element ?: return null
+        return computeCharacteristicsValues(
+            buildCombination = build,
+            characterBaseCharacteristics = character.baseCharacteristicValues,
+            // Fold generic elemental mastery into the spell's element, exactly like the scorers.
+            masteryElementsWanted = mapOf(element.masteryCharacteristic to 1),
+            resistanceElementsWanted = emptyMap()
+        ).toMutableMap()
+            .apply { remove(Characteristic.MASTERY_ELEMENTARY) }
     }
 }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/DamageScenario.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/DamageScenario.kt
@@ -1,6 +1,7 @@
 package me.chosante.autobuilder.domain
 
 import me.chosante.common.Characteristic
+import me.chosante.common.SpellDamage
 
 /** Spell element of the attack being optimized; maps to the matching elemental mastery. */
 enum class SpellElement(
@@ -19,6 +20,17 @@ enum class RangeBand(
     MELEE(Characteristic.MASTERY_MELEE),
     DISTANCE(Characteristic.MASTERY_DISTANCE),
 }
+
+/**
+ * Maps a scenario's [RangeBand] onto the calculator's [SpellDamage.RangeBand] (same MELEE/DISTANCE split)
+ * so [SpellDamage.expectedDamage] / [BuildSpellDamage] credit the build's distance or melee mastery. Shared
+ * by the spell-rotation scorer and the GUI's spell-damage views so both fold in the same secondary mastery.
+ */
+fun RangeBand.toSpellDamageRangeBand(): SpellDamage.RangeBand =
+    when (this) {
+        RangeBand.MELEE -> SpellDamage.RangeBand.MELEE
+        RangeBand.DISTANCE -> SpellDamage.RangeBand.DISTANCE
+    }
 
 /**
  * Attack orientation: the positional damage multiplier, and whether rear ("back") mastery applies.

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/PassiveCatalog.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/PassiveCatalog.kt
@@ -25,11 +25,14 @@ object PassiveCatalog {
     /** The passives of [clazz] the solver may auto-pick — fully declarative with a flat stat bonus. */
     fun choosable(clazz: CharacterClass): List<Passive> = forClass(clazz).filter { it.solverChoosable }
 
-    /** Resolve a forced passive by (case-insensitive) French name within [clazz]; null if no match. */
+    /** Resolve a forced passive by (case-insensitive) name in **any** language within [clazz]; null if no match. */
     fun findByName(
         clazz: CharacterClass,
         name: String,
-    ): Passive? = forClass(clazz).firstOrNull { it.name?.equals(name, ignoreCase = true) == true }
+    ): Passive? =
+        forClass(clazz).firstOrNull { passive ->
+            passive.name?.let { n -> listOf(n.fr, n.en, n.es, n.pt).any { it.equals(name, ignoreCase = true) } } == true
+        }
 
     /**
      * Passive slots unlocked at [level]. Wakfu grants a new slot at levels 10 / 30 / 50 / 100 / 150 / 200,

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellCatalog.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellCatalog.kt
@@ -6,6 +6,7 @@ import me.chosante.common.Spell
 import me.chosante.common.SpellCastLimit
 import me.chosante.common.SpellDamageScaling
 import me.chosante.common.SpellElement
+import me.chosante.common.SpellLocalization
 
 /**
  * The embedded class-spell dataset (`spells.json`, produced by the `spells-extractor` module from the
@@ -41,11 +42,22 @@ object SpellCatalog {
                 .decodeList<SpellDamageScaling>("spell-damage.json")
                 .orEmpty()
                 .associateBy { it.spellId }
+        // Join the per-spell localized name + description (bdata i18n, all four languages) so the GUI shows
+        // translated spell text; the encyclopedia scrape only carried English descriptions. A spell with no
+        // record keeps its encyclopedia text — safe by construction.
+        val localizationBySpellId =
+            EmbeddedResources
+                .decodeList<SpellLocalization>("spell-i18n.json")
+                .orEmpty()
+                .associateBy { it.spellId }
         base.map { spell ->
             val limit = castLimitsBySpellId[spell.id]
             val scaling = damageScalingBySpellId[spell.id]
-            if (limit == null && scaling == null) return@map spell
+            val localization = localizationBySpellId[spell.id]
+            if (limit == null && scaling == null && localization == null) return@map spell
             spell.copy(
+                name = localization?.name ?: spell.name,
+                description = localization?.description ?: spell.description,
                 maxCastPerTurn = limit?.maxCastPerTurn,
                 maxCastPerTarget = limit?.maxCastPerTarget,
                 cooldown = limit?.cooldown,

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellRotation.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/domain/SpellRotation.kt
@@ -16,6 +16,17 @@ data class ScoredSpell(
     val expectedDamagePerCast: Double,
 )
 
+/**
+ * Per-turn expected damage of the discovered build under one attack scenario variant ([orientation] + the
+ * optional [berserk] low-HP bonus). The max-damage result lists these so the player can read off how much
+ * positioning / berserk play is worth — exactly the levers the mode optimizes — instead of a single number.
+ */
+data class ScenarioDamage(
+    val orientation: Orientation,
+    val berserk: Boolean,
+    val totalExpectedDamage: Double,
+)
+
 /** A spell cast [count] times in the rotation, with its per-cast and total expected damage. */
 data class SpellCast(
     val spell: Spell,
@@ -239,6 +250,11 @@ object SpellRotationOptimizer {
                         rangeBand = scenario.rangeBand.toSpellDamageRangeBand(),
                         rearMastery = scenario.orientation.grantsRearMastery,
                         berserkMastery = scenario.berserk,
+                        // The positional multiplier (face 1.0 / side 1.10 / back 1.25) the displayed rotation
+                        // was missing: only rear MASTERY was applied, so a back-hit scenario under-showed by
+                        // ×1.25. A uniform constant per search, so it scales every build/element equally — it
+                        // never changes which build the engine picks, only the (now precise) shown number.
+                        orientationMultiplierPercent = scenario.orientation.multiplierPercent,
                         targetResistancePercent = resistancePercent,
                         critCapPercent = scenario.critCapPercent
                     )?.expected ?: return@mapNotNull null
@@ -377,6 +393,53 @@ object SpellRotationOptimizer {
             ?: SpellRotation(null, apBudget ?: 0, 0, emptyList(), 0.0)
 
     /**
+     * Per-turn expected damage of [build] under each attack-position variant, for the result breakdown:
+     * **face**, **side** and **back** (each at no berserk), plus a **back + berserk** entry when [includeBerserk]
+     * (the build actually carries berserk mastery, else it'd duplicate the back number), and ALWAYS the
+     * configured `(scenario.orientation, scenario.berserk)` combo so the row matching the headline rotation is
+     * present and can be highlighted — even for off-grid combos like side+berserk. Each entry re-runs the full
+     * debuff-aware rotation under that orientation, so the entry matching the configured scenario equals the
+     * headline rotation total. Orientation is the one lever the per-turn objective drops (a uniform factor), so
+     * this is the cheapest honest way to surface "what the other positions are worth".
+     */
+    fun scenarioBreakdown(
+        build: BuildCombination,
+        character: Character,
+        clazz: CharacterClass,
+        scenario: DamageScenario,
+        includeBerserk: Boolean,
+        // The already-computed headline rotation total for the CONFIGURED (scenario.orientation, scenario.berserk)
+        // combo, if the caller has it — reused instead of re-running that one rotation (the rest still compute).
+        configuredRotationTotal: Double? = null,
+    ): List<ScenarioDamage> {
+        // Dedup so the configured combo (added last) doesn't repeat a base row it already equals.
+        val combos = LinkedHashSet<Pair<Orientation, Boolean>>()
+        combos.add(Orientation.FACE to false)
+        combos.add(Orientation.SIDE to false)
+        combos.add(Orientation.BACK to false)
+        if (includeBerserk) combos.add(Orientation.BACK to true)
+        combos.add(scenario.orientation to scenario.berserk)
+        return combos.map { (orientation, berserk) ->
+            val isConfigured = orientation == scenario.orientation && berserk == scenario.berserk
+            ScenarioDamage(
+                orientation = orientation,
+                berserk = berserk,
+                totalExpectedDamage =
+                    if (isConfigured && configuredRotationTotal != null) {
+                        configuredRotationTotal
+                    } else {
+                        bestSequencedRotation(
+                            build,
+                            character,
+                            clazz,
+                            scenario.copy(orientation = orientation, berserk = berserk)
+                        ).totalExpectedDamage
+                    }
+            )
+        }
+    }
+
+    /**
      * Build-independent per-AP throughput table for [spells]: `table[ap]` = the maximum total **base**
      * damage castable within `ap` AP, **bounded by each spell's real per-turn cast limit**
      * ([Spell.maxCastsThisTurn]). Index `0..maxAp`. This is the spell-selection the CP-SAT objective
@@ -440,10 +503,4 @@ object SpellRotationOptimizer {
             masteryElementsWanted = mapOf(scenario.element.masteryCharacteristic to 1),
             resistanceElementsWanted = emptyMap()
         )[Characteristic.ACTION_POINT] ?: 0
-
-    private fun RangeBand.toSpellDamageRangeBand(): SpellDamage.RangeBand =
-        when (this) {
-            RangeBand.MELEE -> SpellDamage.RangeBand.MELEE
-            RangeBand.DISTANCE -> SpellDamage.RangeBand.DISTANCE
-        }
 }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindMaxDamageScoring.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindMaxDamageScoring.kt
@@ -66,7 +66,7 @@ object FindMaxDamageScoring {
         if (scenario.healing) masteryBase += value(Characteristic.MASTERY_HEALING)
 
         val critMastery = value(Characteristic.MASTERY_CRITICAL)
-        val damageInflicted = max(value(Characteristic.DAMAGE_INFLICTED), -DAMAGE_INFLICTED_FLOOR)
+        val damageInflicted = max(value(Characteristic.DAMAGE_INFLICTED), -DAMAGE_DI_FLOOR.toInt())
         val critRate = value(Characteristic.CRITICAL_HIT).coerceIn(0, 100).coerceAtMost(scenario.critCapPercent) / 100.0
 
         val constantFactor =
@@ -120,6 +120,4 @@ object FindMaxDamageScoring {
                 .coerceAtMost(BigDecimal(100))
         return (BigDecimal(100).setScale(4) / successPercentage.coerceAtLeast(BigDecimal.ONE)).pow(6)
     }
-
-    private const val DAMAGE_INFLICTED_FLOOR = 50
 }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindMostMasteriesFromInputScoring.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/FindMostMasteriesFromInputScoring.kt
@@ -99,6 +99,17 @@ object FindMostMasteriesFromInputScoring {
         // Combine sums and adjust for negative mastery penalties
         val finalMasteryScore = sumOfMasteriesWithoutElementary + lowestWantedElementaryMasteryValue + removeNegativeMasteries
 
-        return (finalMasteryScore.toBigDecimal() / penaltyFactor)
+        // Fold the global % Damage Inflicted multiplier in exactly as the CP-SAT objective does
+        // (StatBuilder.diAdjustedMasteryScore): maximize mastery × (1 + DI/100) so the proxy is damage-faithful
+        // and a −DI choice only pays off when its mastery gain outweighs it. The mastery is clamped to ≥ 0
+        // BEFORE the multiply (mirroring the objective, which clamps via clampVar) so a negative-mastery build
+        // can never invert the DI incentive; DI is clamped to [−FLOOR, MAX] and the product is floored back onto
+        // the objective's domain. Integer truncation mirrors CP-SAT's addDivisionEquality so the two never drift.
+        val damageInflicted = (actualCharacteristicsValues[Characteristic.DAMAGE_INFLICTED] ?: 0).coerceIn(-DAMAGE_DI_FLOOR.toInt(), DAMAGE_DI_MAX.toInt())
+        val diAdjustedScore =
+            (maxOf(finalMasteryScore.toLong(), 0L) * (100L + damageInflicted) / 100L)
+                .coerceIn(-MASTERY_SCORE_ABS_MAX, MASTERY_SCORE_ABS_MAX)
+
+        return (diAdjustedScore.toBigDecimal() / penaltyFactor)
     }
 }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageSearch.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageSearch.kt
@@ -122,6 +122,12 @@ object MaxDamageSearch {
             // phase, so we never re-derive it with another bestSequencedRotation pass.
             var bestSolvedScenario: DamageScenario? = null
             var phase1Optimal = false
+            // [consider] is called CONCURRENTLY by the parallel per-element probe collectors (a boss /
+            // multi-candidate search streams each probe's best-so-far live), so the read-modify-write of
+            // [best] and the streamed progress must be serialized. The expensive re-score runs OUTSIDE the
+            // lock. The lock is uncontended on the single-element path (one collector).
+            val considerLock = Any()
+            var lastProgressSent = 0
 
             fun consider(
                 result: GeneticAlgorithmResult<BuildCombination>,
@@ -133,19 +139,23 @@ object MaxDamageSearch {
                 // overrides the solver's own (proxy, debuff-blind) score: [sequencedScore] is the debuff-aware
                 // rotation the CLI/GUI also display, so ranking by it keeps the shown damage == the scored damage.
                 val score = sequencedScore(baseParams, result.individual)
-                val current = best
-                // Highest score; on a tie prefer the PROVEN result so [best].isOptimal reflects the proof — the
-                // solver emits the optimum un-proven first, then proven (same build, same score), and a plain
-                // strict `>` would keep the earlier un-proven copy and under-report the proof at the final emit.
-                if (current == null ||
-                    score > current.matchPercentage ||
-                    (score.compareTo(current.matchPercentage) == 0 && result.isOptimal && !current.isOptimal)
-                ) {
-                    best = result.copy(matchPercentage = score)
-                    bestSolvedScenario = solvedScenario
+                synchronized(considerLock) {
+                    val current = best
+                    // Highest score; on a tie prefer the PROVEN result so [best].isOptimal reflects the proof — the
+                    // solver emits the optimum un-proven first, then proven (same build, same score), and a plain
+                    // strict `>` would keep the earlier un-proven copy and under-report the proof at the final emit.
+                    if (current == null ||
+                        score > current.matchPercentage ||
+                        (score.compareTo(current.matchPercentage) == 0 && result.isOptimal && !current.isOptimal)
+                    ) {
+                        best = result.copy(matchPercentage = score)
+                        bestSolvedScenario = solvedScenario
+                    }
+                    // Improvements from parallel probes can arrive out of order — keep the streamed bar monotonic.
+                    lastProgressSent = maxOf(lastProgressSent, progress)
+                    // Streamed best-so-far is never "proven" — optimality is decided once at the final emit.
+                    best?.let { trySend(it.copy(progressPercentage = lastProgressSent, isOptimal = false)) }
                 }
-                // Streamed best-so-far is never "proven" — optimality is decided once at the final emit.
-                best?.let { trySend(it.copy(progressPercentage = progress, isOptimal = false)) }
             }
 
             val producer =
@@ -168,14 +178,16 @@ object MaxDamageSearch {
                         // so this repeats the (single-threaded) model construction N times; that is deliberate: a
                         // shared model would force the N solves to run SEQUENTIALLY (CP-SAT mutates solver state),
                         // and N parallel solves with N model builds beat one shared model solved N times in a row.
-                        val elementResults =
-                            runProbeBatch(elementParams.map { it.copy(searchDuration = phaseBudget) }, equipmentsByItemType, runes, sublimations, phaseBudget, tuning)
-                        phase1Optimal = elementResults.isNotEmpty() && elementResults.all { (_, r) -> r != null && r.isOptimal }
-                        elementResults.forEachIndexed { index, (probeParams, probe) ->
-                            if (probe != null) {
-                                consider(probe, probeParams.damageScenario, ((index + 1) * phase1Ceiling / elementResults.size).coerceIn(0, phase1Ceiling))
+                        //
+                        // Each probe STREAMS its improving solutions into [consider] as they arrive (not awaited
+                        // as a batch), so a build appears within seconds. Awaiting the whole batch first left the
+                        // GUI on the "Preparing OR-Tools model" overlay (build == null) for the ENTIRE budget,
+                        // which on a long boss search looked like an infinite hang that never found a build.
+                        val probesProved =
+                            streamProbeBatch(elementParams, equipmentsByItemType, runes, sublimations, phaseBudget, phase1Ceiling, tuning) { probeParams, probe, progress ->
+                                consider(probe, probeParams.damageScenario, progress)
                             }
-                        }
+                        phase1Optimal = probesProved.isNotEmpty() && probesProved.all { it }
                     }
 
                     // Phase 1's best score, snapshotted before the heuristic debuff phase can move it.
@@ -289,6 +301,64 @@ object MaxDamageSearch {
                 .map { base ->
                     val p = base.copy(searchDuration = plan.perProbeBudget, solverWorkers = plan.workersPerProbe)
                     async(dispatcher) { p to solveProbe(p, equipmentsByItemType, runes, sublimations, tuning) }
+                }.awaitAll()
+        }
+    }
+
+    /**
+     * Like [runProbeBatch] but STREAMS each probe's improving solutions to [onResult] as they are found,
+     * instead of awaiting every probe and returning the batch. This lets the caller surface a best-so-far
+     * build within seconds of the search starting — the boss / multi-element path used to await the whole
+     * batch, leaving the GUI's "Preparing OR-Tools model" overlay up (no build) for the entire budget.
+     *
+     * Returns, per probe, whether its CP-SAT solve PROVED optimality — the boss optimum is proven iff every
+     * element's solve proved. Core budgeting is identical to [runProbeBatch] (the concurrent native workers
+     * never exceed host−1, and the batch fits [phaseBudget]). [progressCeiling] scales each probe's 0–100
+     * progress into the bar's phase-1 ceiling. [onResult] is invoked concurrently from the probe collectors,
+     * so it MUST be thread-safe (see [consider], which guards its shared state).
+     */
+    private suspend fun streamProbeBatch(
+        probeParams: List<WakfuBestBuildParams>,
+        equipmentsByItemType: Map<ItemType, List<Equipment>>,
+        runes: List<RuneType>,
+        sublimations: List<Sublimation>,
+        phaseBudget: Duration,
+        progressCeiling: Int,
+        tuning: WakfuBuildSolver.SolverTuning?,
+        onResult: (WakfuBestBuildParams, GeneticAlgorithmResult<BuildCombination>, Int) -> Unit,
+    ): List<Boolean> {
+        if (probeParams.isEmpty()) return emptyList()
+
+        suspend fun collectProbe(params: WakfuBestBuildParams): Boolean {
+            var proved = false
+            WakfuBuildSolver
+                .optimize(params, equipmentsByItemType, runes, sublimations, tuning)
+                .collect { result ->
+                    // CP-SAT declares optimality once, on this element's final emission; its best emission is
+                    // proven iff that happened, so OR-ing over the stream matches the old per-probe `isOptimal`.
+                    if (result.isOptimal) proved = true
+                    onResult(params, result, (result.progressPercentage * progressCeiling / 100).coerceIn(0, progressCeiling))
+                }
+            return proved
+        }
+
+        // Test path ([tuning] != null): det-time solves are reproducible regardless of parallelism, so run
+        // them straight on IO with the tuning's own worker count (mirrors [runProbeBatch]).
+        if (tuning != null) {
+            return coroutineScope {
+                probeParams
+                    .map { base -> async(Dispatchers.IO) { collectProbe(base.copy(searchDuration = phaseBudget)) } }
+                    .awaitAll()
+            }
+        }
+
+        val host = (Runtime.getRuntime().availableProcessors() - 1).coerceAtLeast(1)
+        val plan = probePlan(probeParams.size, host, phaseBudget)
+        val dispatcher = Dispatchers.IO.limitedParallelism(plan.concurrency)
+        return coroutineScope {
+            probeParams
+                .map { base ->
+                    async(dispatcher) { collectProbe(base.copy(searchDuration = plan.perProbeBudget, solverWorkers = plan.workersPerProbe)) }
                 }.awaitAll()
         }
     }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/ScoreComputationMode.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/ScoreComputationMode.kt
@@ -15,6 +15,23 @@ enum class ScoreComputationMode(
     }
 }
 
+/**
+ * % Damage Inflicted clamp bounds, shared by the CP-SAT objective ([me.chosante.autobuilder.genetic.wakfu.WakfuBuildSolver])
+ * and the re-scorers ([FindMostMasteriesFromInputScoring], [FindMaxDamageScoring]) so the damage-faithful score
+ * stays in lockstep. [DAMAGE_DI_FLOOR] is Wakfu's −50% damage floor (DI can't reduce a hit below ×0.5);
+ * [DAMAGE_DI_MAX] is a CP-SAT domain safety bound far above any real build. (common-lib's [me.chosante.common.SpellDamage]
+ * keeps its own copy of the floor — it cannot depend on this module.)
+ */
+internal const val DAMAGE_DI_FLOOR = 50L
+internal const val DAMAGE_DI_MAX = 5_000L
+
+/**
+ * Absolute bound of the "most-masteries" mastery-score domain, shared by the CP-SAT objective and the
+ * re-scorer so the DI-folded score is clamped onto the same range on both sides (a no-op for any real build,
+ * whose mastery sums are ≤ ~1e5).
+ */
+internal const val MASTERY_SCORE_ABS_MAX = 100_000_000L
+
 fun Characteristic.isMaximizableMastery(): Boolean =
     this in
         setOf(

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -404,6 +404,9 @@ object WakfuBuildSolver {
         tightDomains: Boolean = true,
         // Benchmark/test seam: bypass the prefilter so the full pool is solved regardless of the gate.
         forceFullPool: Boolean = false,
+        // Test seam: force the per-stat rune COUNT model even where the single-type fold would apply, so a
+        // test can assert the fold preserves the optimum (fold == count optimum on a rune pool).
+        forceRuneCountModel: Boolean = false,
     ): BuiltModel {
         val model = CpModel()
 
@@ -419,7 +422,21 @@ object WakfuBuildSolver {
         val allEquips = orderEquipments(pool)
         val equipVars = model.createEquipmentVariables(allEquips)
         val skillVars = model.createSkillVariables(params.character.characterSkills)
-        val runeModel = model.createRuneModel(params, allEquips, equipVars, runes)
+        // The single-type rune fold (createRuneModel) is sound unless a sublimation IN PLAY requires a
+        // POSITIVE secondary-mastery cap (`secondary ≤ N`, N>0): there an intra-item secondary/elemental
+        // MIX can be optimal, which the fold can't express. Every solver-choosable secondary-cap sub has
+        // N=0 (⇒ all-elemental, no mix), so the default search folds; this guard future-proofs the data and
+        // a forced sub with N>0.
+        val forcedSubNames = params.forcedSublimations.map { it.lowercase() }.toSet()
+        val secondaryCapMixSubInPlay =
+            sublimations.any { sub ->
+                val inPlay = (sub.solverChoosable && params.useSublimations) || sub.name.fr.lowercase() in forcedSubNames || sub.name.en.lowercase() in forcedSubNames
+                inPlay &&
+                    sub.condition?.type == SublimationConditionType.SECONDARY_MASTERIES_AT_MOST &&
+                    (sub.condition?.value ?: 0) > 0
+            }
+        val allowRuneFold = !forceRuneCountModel && !secondaryCapMixSubInPlay
+        val runeModel = model.createRuneModel(params, allEquips, equipVars, runes, allowRuneFold)
         val subModel = model.createSublimationModel(params, allEquips, equipVars, sublimations)
         // A normal sublimation does NOT reserve rune sockets. Golden runes (colour-agnostic) form its ordered
         // colour pattern AND still carry their stat — doubling where the item favours that colour — so a carrier
@@ -497,8 +514,11 @@ object WakfuBuildSolver {
         equipmentsByItemType: Map<ItemType, List<Equipment>>,
         tuning: SolverTuning,
         tightDomains: Boolean,
+        runes: List<RuneType> = emptyList(),
+        sublimations: List<Sublimation> = emptyList(),
+        forceRuneCountModel: Boolean = false,
     ): MaxDamageSolveOutcome {
-        val built = buildModel(params, equipmentsByItemType, emptyList(), emptyList(), tightDomains)
+        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains, forceRuneCountModel = forceRuneCountModel)
         val solver = deterministicMaxDamageSolver(tuning)
         val status = solver.solve(built.model)
         val hasSolution =
@@ -533,8 +553,10 @@ object WakfuBuildSolver {
         params: WakfuBestBuildParams,
         equipmentsByItemType: Map<ItemType, List<Equipment>>,
         tuning: SolverTuning,
+        runes: List<RuneType> = emptyList(),
+        sublimations: List<Sublimation> = emptyList(),
     ): List<MaxDamageVarBound> {
-        val built = buildModel(params, equipmentsByItemType, emptyList(), emptyList(), tightDomains = false)
+        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains = false)
         val solver = deterministicMaxDamageSolver(tuning)
         val status = solver.solve(built.model)
         require(status == com.google.ortools.sat.CpSolverStatus.OPTIMAL || status == com.google.ortools.sat.CpSolverStatus.FEASIBLE) {
@@ -649,6 +671,7 @@ object WakfuBuildSolver {
         allEquips: List<Equipment>,
         equipVars: Map<Equipment, IntVar>,
         runes: List<RuneType>,
+        allowRuneFold: Boolean,
     ): RuneModel {
         if (runes.isEmpty()) return RuneModel.EMPTY
         val runeById = runes.associateBy { it.id }
@@ -684,17 +707,51 @@ object WakfuBuildSolver {
             (if (params.useRunes) relevantRuneStats(params, runeByCharacteristic.keys) else emptySet()) + forcedRuneStats
         if (runeStats.isEmpty()) return RuneModel.EMPTY
 
+        // Max-damage can fill every socket "for free": the generic elemental-mastery rune is NOT a
+        // secondary mastery and only ever raises the damage objective, so it backfills any socket without
+        // tripping a secondary-mastery / AP / crit / range "at most" sub condition, and overshooting a
+        // required target is never penalised (the max-damage score caps actual at target — coerceAtMost in
+        // FindMaxDamageScoring.requiredConstraintPenaltyFactor). So the proven optimum ALWAYS fills its
+        // sockets (an empty one could take one more elemental rune for strictly more mastery), and pinning
+        // Σ runeCount = slots·selected (instead of ≤) removes every provably-suboptimal "underfill"
+        // assignment from the integer search WITHOUT changing the optimum — a pure search-space cut that
+        // helps the proof close. Gated on a real elemental filler being modelled; the other modes keep ≤
+        // (there a rune feeds a *requested exact* stat where full fill is not free).
+        val fillSocketsForMaxDamage =
+            params.scoreComputationMode == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE &&
+                Characteristic.MASTERY_ELEMENTARY in runeStats
+        // Single-type-per-item rune FOLD (max-damage, no forced runes, no secondary-cap>0 sub in play —
+        // [allowRuneFold]): because a rune's value is uniform across an item's sockets (doubling is per item
+        // SLOT, not per socket — see RuneType.valueOn), filling an item entirely with its single best-value
+        // type is ≥ any mix, so mixing types within ONE item is freedom the optimum never uses. Modelling each
+        // item's choice as ONE boolean pick per type (Σ pick = selected) instead of an integer count 0..slots
+        // collapses the rune search to binary decisions — far easier for CP-SAT to PROVE — with the SAME
+        // reachable stat contributions (a pick contributes slots·coeff; see baseTermsFor + the 0..1 leaf seed).
+        // The solver still chooses the type per item (build-dependent: mastery vs crit-mastery, elemental vs a
+        // secondary for the secondary=0 subs) and items still differ — only the never-optimal intra-item mix is
+        // dropped. Gated to where it is provably sound; forced runes / secondary-cap>0 subs keep the count model.
+        val singleTypePerItem = allowRuneFold && fillSocketsForMaxDamage && forcedRuneStats.isEmpty()
         val runeVars = mutableMapOf<Equipment, Map<Characteristic, IntVar>>()
         for (equip in allEquips) {
             val slots = equip.maxShardSlots
             if (slots <= 0) continue
-            val perStat = runeStats.associateWith { stat -> newIntVar(0, slots.toLong(), "rune_${equip.equipmentId}_${stat.name}") }
-            // Sockets only count when the item is equipped: Σ runeCount ≤ slots · selected (linear).
-            val capExpr = LinearExpr.newBuilder()
-            perStat.values.forEach { capExpr.addTerm(it, 1L) }
-            capExpr.addTerm(equipVars.getValue(equip), -slots.toLong())
-            addLessOrEqual(capExpr.build(), 0L)
-            runeVars[equip] = perStat
+            if (singleTypePerItem) {
+                // One boolean per type; exactly one type fills all the item's sockets when equipped, none otherwise.
+                val perStat = runeStats.associateWith { stat -> newBoolVar("runePick_${equip.equipmentId}_${stat.name}") }
+                val pickExpr = LinearExpr.newBuilder()
+                perStat.values.forEach { pickExpr.addTerm(it, 1L) }
+                pickExpr.addTerm(equipVars.getValue(equip), -1L)
+                addEquality(pickExpr.build(), 0L)
+                runeVars[equip] = perStat
+            } else {
+                val perStat = runeStats.associateWith { stat -> newIntVar(0, slots.toLong(), "rune_${equip.equipmentId}_${stat.name}") }
+                // Sockets only count when the item is equipped: Σ runeCount {= max-damage | ≤ other modes} slots·selected.
+                val capExpr = LinearExpr.newBuilder()
+                perStat.values.forEach { capExpr.addTerm(it, 1L) }
+                capExpr.addTerm(equipVars.getValue(equip), -slots.toLong())
+                if (fillSocketsForMaxDamage) addEquality(capExpr.build(), 0L) else addLessOrEqual(capExpr.build(), 0L)
+                runeVars[equip] = perStat
+            }
         }
         // Global forced runes must be socketed at least once across the build.
         for (stat in globalForcedRuneStats) {
@@ -727,7 +784,7 @@ object WakfuBuildSolver {
                 if (any) addGreaterOrEqual(countExpr.build(), count.toLong())
             }
         }
-        return RuneModel(runeByCharacteristic, runeVars)
+        return RuneModel(runeByCharacteristic, runeVars, singleTypePerItem)
     }
 
     /**
@@ -1412,7 +1469,13 @@ object WakfuBuildSolver {
             equippedItems
                 .associateWith { equip ->
                     runeModel.runeVars[equip].orEmpty().flatMap { (stat, runeVar) ->
-                        val count = valueOf(runeVar).toInt()
+                        // Fold model: runeVar is a boolean pick ⇒ that one type fills ALL of the item's sockets.
+                        val count =
+                            if (runeModel.singleTypePerItem) {
+                                if (valueOf(runeVar) > 0L) equip.maxShardSlots else 0
+                            } else {
+                                valueOf(runeVar).toInt()
+                            }
                         val rune = runeModel.runeByCharacteristic[stat]
                         if (count > 0 && rune != null) List(count) { rune } else emptyList()
                     }
@@ -1540,7 +1603,9 @@ object WakfuBuildSolver {
             equipVars.forEach { (equip, v) -> tracker.seed(v, 0L..1L, "equip_${equip.equipmentId}") }
             skillVars.forEach { (skill, v) -> tracker.seed(v, 0L..skill.maxPointsAssignable.toLong(), "skill_${skill.name}") }
             runeModel.runeVars.forEach { (equip, perStat) ->
-                perStat.forEach { (stat, v) -> tracker.seed(v, 0L..equip.maxShardSlots.toLong(), "rune_${equip.equipmentId}_${stat.name}") }
+                // Fold ⇒ each var is a boolean PICK (0..1, contributes slots·coeff); count model ⇒ 0..slots.
+                val runeHi = if (runeModel.singleTypePerItem) 1L else equip.maxShardSlots.toLong()
+                perStat.forEach { (stat, v) -> tracker.seed(v, 0L..runeHi, "rune_${equip.equipmentId}_${stat.name}") }
             }
             subModel.subVars.forEach { (sub, v) -> tracker.seed(v, 0L..1L, "sub_${sub.stateId}") }
         }
@@ -2187,7 +2252,37 @@ object WakfuBuildSolver {
             // M = clamp(100 + ΣMastery, 0, MAX); criticalMastery and DI clamped likewise. The clamps inherit
             // their inputs' reachable ranges, so M / criticalMastery / DI land on their true ~6k / ~1k domains
             // (not the safe-huge caps), which is what shrinks the two multiplication envelopes below.
-            val preM = tSumNaive("dmgPreM_$s", masteryTerms, 100L, -CLAMP_INTERMEDIATE_MAX, CLAMP_INTERMEDIATE_MAX)
+            //
+            // The naive sum over the per-stat mastery vars DOUBLE-COUNTS runes across those stats: each stat's
+            // reach independently assumes its rune fills every socket, but a socket holds ONE rune, so the rune
+            // mastery feeding M is ≤ Σ_slot best(item.slots × best mastery-rune coeff) — a sound, socket-aware
+            // bound. Subtracting that provable over-count keeps M's declared range tight WITH runes on (the
+            // inflation is what stalled the proof once runes were modelled); the over-count is 0 when runes are
+            // off, so every non-rune path stays byte-identical. Items/skills/subs keep their per-slot auto bound.
+            val masteryRuneStats =
+                buildList {
+                    add(Characteristic.MASTERY_ELEMENTARY)
+                    add(scenario.rangeBand.masteryCharacteristic)
+                    if (scenario.orientation.grantsRearMastery) add(Characteristic.MASTERY_BACK)
+                    if (scenario.berserk) add(Characteristic.MASTERY_BERSERK)
+                    if (scenario.healing) add(Characteristic.MASTERY_HEALING)
+                }
+            var preMLo = 100L
+            var preMHi = 100L
+            for (t in masteryTerms) {
+                val d = tracker.of(t.variable)
+                preMLo += d.first * t.coefficient
+                preMHi += d.last * t.coefficient
+            }
+            val preM =
+                tSum(
+                    "dmgPreM_$s",
+                    masteryTerms,
+                    100L,
+                    preMLo..(preMHi - runeMasteryOverCount(masteryRuneStats)),
+                    -CLAMP_INTERMEDIATE_MAX,
+                    CLAMP_INTERMEDIATE_MAX
+                )
             val m = tClamp(preM, 0L, DAMAGE_MASTERY_MAX, "dmgM_$s")
             val criticalMastery = tClamp(actualStat(Characteristic.MASTERY_CRITICAL), 0L, DAMAGE_MASTERY_MAX, "dmgCriticalMastery_$s")
             val critCap = scenario.critCapPercent.toLong().coerceIn(0L, 100L)
@@ -2201,6 +2296,38 @@ object WakfuBuildSolver {
             val graw = tSumNaive("dmgGraw_$s", listOf(Term(m, 400L), Term(term, 1L)), 0L, 0L, DAMAGE_GRAW_MAX)
 
             return tMul("dmgScore_$s", d, graw, 0L, DAMAGE_SCORE_ABS_MAX)
+        }
+
+        /**
+         * How much the naive [perHitDamageScore] mastery sum over-counts RUNE mastery across the scenario's
+         * mastery stats: each per-stat mastery var's reach independently assumes its rune fills every socket,
+         * but a socket holds ONE rune and only ONE item is equipped per slot, so the rune mastery feeding M is
+         * ≤ Σ_slot best(item.slots × best mastery-rune coeff). Returns `naiveRuneSum − socketAwareMax` (≥ 0)
+         * over [masteryRuneStats] — exactly the per-stat rune total the naive reach added minus that tight
+         * socket-aware bound — so subtracting it from the naive reach yields a SOUND, tighter upper bound on
+         * M's rune portion (never an under-estimate; the optimum's own M still fits). 0 when runes are off.
+         */
+        private fun runeMasteryOverCount(masteryRuneStats: List<Characteristic>): Long {
+            if (runeModel.runeVars.isEmpty()) return 0L
+
+            fun coeff(
+                equip: Equipment,
+                stat: Characteristic,
+            ): Long = runeModel.runeByCharacteristic[stat]?.valueOn(equip.itemType, equip.level)?.toLong() ?: 0L
+            val socketable = allEquips.filter { runeModel.runeVars.containsKey(it) }
+            if (socketable.isEmpty()) return 0L
+            val naive =
+                socketable.sumOf { equip ->
+                    val slots = equip.maxShardSlots.toLong()
+                    masteryRuneStats.sumOf { stat -> slots * coeff(equip, stat) }
+                }
+            val socketAware =
+                socketable.groupBy { it.itemType }.entries.sumOf { (type, items) ->
+                    val limit = if (type == ItemType.RING) 2L else 1L
+                    val best = items.maxOf { equip -> equip.maxShardSlots.toLong() * (masteryRuneStats.maxOfOrNull { coeff(equip, it) } ?: 0L) }
+                    limit * best.coerceAtLeast(0L)
+                }
+            return (naive - socketAware).coerceAtLeast(0L)
         }
 
         /**
@@ -2489,8 +2616,11 @@ object WakfuBuildSolver {
                     val runeVar = perStat[char] ?: continue
                     // Rune level is capped by the carrier ITEM's level, not the character's (fix 36918746).
                     val coefficient = rune.valueOn(equip.itemType, equip.level).toLong()
+                    // Fold model: runeVar is a boolean PICK — one pick fills all `slots` sockets, so it
+                    // contributes slots·coeff. Count model: runeVar is the count and contributes coeff each.
+                    val multiplier = if (runeModel.singleTypePerItem) equip.maxShardSlots.toLong() else 1L
                     if (coefficient != 0L) {
-                        terms.add(Term(runeVar, coefficient))
+                        terms.add(Term(runeVar, coefficient * multiplier))
                     }
                 }
             }
@@ -2699,6 +2829,12 @@ object WakfuBuildSolver {
     private class RuneModel(
         val runeByCharacteristic: Map<Characteristic, RuneType>,
         val runeVars: Map<Equipment, Map<Characteristic, IntVar>>,
+        /**
+         * True ⇒ [runeVars] are boolean single-type PICKS (one chosen type fills every socket of the item)
+         * rather than per-stat counts, so a pick contributes `slots·coeff` and its leaf domain is 0..1. See
+         * the rune fold in [createRuneModel].
+         */
+        val singleTypePerItem: Boolean = false,
     ) {
         companion object {
             val EMPTY = RuneModel(emptyMap(), emptyMap())

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -50,7 +50,8 @@ object WakfuBuildSolver {
     private const val PERCENT_ABS_MAX = 10_000L
     private const val PRODUCT_ABS_MAX = STAT_ABS_MAX * PERCENT_ABS_MAX
     private const val STAT_WITH_PERCENT_ABS_MAX = STAT_ABS_MAX + (PRODUCT_ABS_MAX / 100) + 10
-    private const val MASTERY_SCORE_ABS_MAX = 100_000_000L
+
+    // MASTERY_SCORE_ABS_MAX is shared with the re-scorer — see ScoreComputationMode.kt.
     private const val MAX_POWER_TABLE_INDEX = 2_000
     private const val MAX_PENALTY_MULTIPLIER = 1_000_000L
     private const val MAX_SUBLIMATIONS = 10L // Wakfu: at most 10 sublimations on a build (incl. ≤1 epic, ≤1 relic).
@@ -65,9 +66,8 @@ object WakfuBuildSolver {
 
     // Bounds for the max-damage objective's nonlinear terms. Masteries / DI are clamped into these
     // (well above any real build) so the CP-SAT multiplication variables keep small, stable domains.
+    // DAMAGE_DI_FLOOR / DAMAGE_DI_MAX are shared with the re-scorers — see ScoreComputationMode.kt.
     private const val DAMAGE_MASTERY_MAX = 100_000L
-    private const val DAMAGE_DI_MAX = 5_000L
-    private const val DAMAGE_DI_FLOOR = 50L
     private const val CLAMP_INTERMEDIATE_MAX = 8_000_000_000L
     private const val DAMAGE_GRAW_MAX = 400L * DAMAGE_MASTERY_MAX + 100L * (DAMAGE_MASTERY_MAX * 6)
     private const val DAMAGE_SCORE_ABS_MAX = (100L + DAMAGE_DI_MAX) * DAMAGE_GRAW_MAX
@@ -850,9 +850,32 @@ object WakfuBuildSolver {
             SublimationKind.FLAT -> {}
             SublimationKind.COMBAT_CONDITIONAL -> return false
         }
+        // Backstop for the degenerate most-masteries/precision request with NO maximizable mastery to protect
+        // (only AP/MP/HP/range targets). There the DI fold `mastery × (1 + DI/100)` is structurally 0 — nothing
+        // for the DI factor to multiply — so a damage-reducing sub would otherwise be free for the overshoot
+        // tie-breaker to grab (the old Enutrof failure mode for required-only requests). When ANY maximizable
+        // mastery is requested the fold governs DI on merit, so this never fires. Max-damage models DI directly.
+        if (dropsDamageWithNoMasteryToProtect(sub, params)) return false
         // It must be able to contribute *something* in this mode/scenario.
         val hasUsableEffect = sub.effects.any { scenarioGateMatches(it.scenarioGate, params) }
         return hasUsableEffect || sub.conversion != null
+    }
+
+    /**
+     * True when [sub] reduces % Damage Inflicted in a non-max-damage request that maximizes **no** mastery,
+     * so the DI fold can't weigh it and it must not be auto-chosen (it could only ever cut real damage). When a
+     * maximizable mastery IS requested, [StatBuilder.diAdjustedMasteryScore] already prices DI in, so a −DI sub
+     * is taken only when its mastery gain outweighs the loss — and this returns false.
+     */
+    private fun dropsDamageWithNoMasteryToProtect(
+        sub: Sublimation,
+        params: WakfuBestBuildParams,
+    ): Boolean {
+        if (params.scoreComputationMode == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE) return false
+        if (params.targetStats.any { it.characteristic.isMaximizableMastery() }) return false
+        val netDamageInflicted =
+            sub.effects.filter { it.characteristic == Characteristic.DAMAGE_INFLICTED }.sumOf { it.value }
+        return netDamageInflicted < 0
     }
 
     /**
@@ -1050,10 +1073,11 @@ object WakfuBuildSolver {
     }
 
     /**
-     * Objective for "most masteries" mode: maximize only the *requested* masteries under the
-     * required-stat constraints. There is deliberately no tie-breaker that fills otherwise-empty
-     * slots, so a slot whose items cannot improve any requested stat is left empty in the proven
-     * optimum. This is why, e.g., an item set asking only for distance mastery + AP/MP/HP comes
+     * Objective for "most masteries" mode: maximize the *requested* masteries — scaled by the build's global
+     * **% Damage Inflicted** so the proxy is damage-faithful (see [StatBuilder.diAdjustedMasteryScore]) —
+     * under the required-stat constraints. There is deliberately no tie-breaker that fills otherwise-empty
+     * slots, so a slot whose items cannot improve any requested stat (nor the DI factor) is left empty in the
+     * proven optimum. This is why, e.g., an item set asking only for distance mastery + AP/MP/HP comes
      * back with no mount: every mount in the data carries only [Characteristic.MASTERY_ELEMENTARY],
      * which contributes to none of those targets, so adding one cannot raise the objective and the
      * proven optimum leaves the slot empty. (Decision: keep as-is; see the engine discussion in
@@ -1072,7 +1096,9 @@ object WakfuBuildSolver {
         val targetStats = params.targetStats
         val targetCharacteristics = targetStats.map { it.characteristic }.toSet()
 
-        val masteryScore = statBuilder.finalMasteryScore(targetStats, targetCharacteristics)
+        // Damage-faithful proxy: maximized mastery sum × (1 + DI/100). Mirrored exactly by the re-scorer
+        // (FindMostMasteriesFromInputScoring) so the solver optimum and the scored optimum stay in lockstep.
+        val masteryScore = statBuilder.diAdjustedMasteryScore(statBuilder.finalMasteryScore(targetStats, targetCharacteristics))
 
         val requiredTargets = targetStats.filter { it.characteristic.isRequiredMostMasteriesTarget() }
         val penalized = applyConstraintPenalty(params, statBuilder, masteryScore, MASTERY_SCORE_ABS_MAX)
@@ -1303,6 +1329,9 @@ object WakfuBuildSolver {
      * — divided by the same required-target shortfall penalty as [FindMaxDamageScoring]. Kept in lockstep
      * with [buildMaxDamageObjective]: both compute `max_e (throughput_e × perHit_e × resFactor_e)` and
      * apply the AP/MP/range penalty, so the build the objective maximizes is the one the solver emits.
+     * The rotation also folds in the scenario's positional ×multiplier (face/side/back) — a uniform constant
+     * the objective deliberately drops since it scales every build equally, so it sharpens the *displayed*
+     * per-turn damage without changing which build (or element) ranks highest.
      */
     private fun maxDamageRotationScore(
         params: WakfuBestBuildParams,
@@ -2102,6 +2131,37 @@ object WakfuBuildSolver {
                     .build()
             model.addEquality(total, sumExpr)
             return total
+        }
+
+        /**
+         * Folds the global **% Damage Inflicted** multiplier into [masteryScore] so most-masteries maximizes a
+         * DAMAGE-FAITHFUL proxy `masteryScore × (1 + DI/100)` (the same DI factor the max-damage objective and
+         * the real hit formula use) instead of the raw mastery sum. So a `+DI` choice now raises the objective
+         * in proportion to the mastery already invested, and a `−DI` choice (e.g. a −20% DI sublimation grabbed
+         * to over-satisfy an AP/MP target) is taken **only** when its mastery gain outweighs the damage it
+         * costs — the engine no longer trades real damage for a hollow mastery point. DI is clamped to
+         * `[−DAMAGE_DI_FLOOR, DAMAGE_DI_MAX]` exactly as the max-damage objective and the re-scorer do.
+         *
+         * [masteryScore] is first clamped to `≥ 0` (mirroring the max-damage objective's `m = tClamp(preM, 0, …)`):
+         * the factor `100 + DI` is always positive, so multiplying a *negative* mastery by it would INVERT the DI
+         * incentive (a higher DI making the product more negative) — clamping at 0 keeps "+DI is always better"
+         * monotone. The product is then divided by 100 and clamped back onto `[0, MASTERY_SCORE_ABS_MAX]` — a
+         * no-op for any real build (mastery sums are ≤ ~1e5, far below the bound) — so the result keeps the same
+         * domain as the raw [masteryScore] and **every downstream penalty / overshoot bound is unchanged**.
+         * When the build carries no DI the factor is exactly 100, so the whole fold is the identity (×1) and
+         * DI-free requests are byte-identical to the old objective.
+         */
+        fun diAdjustedMasteryScore(masteryScore: IntVar): IntVar {
+            val nonNegativeMastery = model.clampVar(masteryScore, 0L, MASTERY_SCORE_ABS_MAX, "mmMasteryNonNeg")
+            val di = model.clampVar(actualStat(Characteristic.DAMAGE_INFLICTED), -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDI")
+            // factor = 100 + DI ∈ [100 − FLOOR, 100 + MAX]; (1 + DI/100) scaled by 100 to stay integer.
+            val factor = model.sumVar("mmDiFactor", listOf(Term(di, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
+            val productBound = MASTERY_SCORE_ABS_MAX * (100L + DAMAGE_DI_MAX)
+            val product = model.newIntVar(0L, productBound, "mmDiProduct")
+            model.addMultiplicationEquality(product, arrayOf(nonNegativeMastery, factor))
+            val scaled = model.newIntVar(0L, productBound / 100L, "mmDiScaled")
+            model.addDivisionEquality(scaled, product, model.newConstant(100L))
+            return model.clampVar(scaled, 0L, MASTERY_SCORE_ABS_MAX, "mmDiAdjusted")
         }
 
         // The build's resolved Action Points variable (base + gear + skills), for the external-loop AP probe.

--- a/autobuilder/src/main/resources/spell-i18n.json
+++ b/autobuilder/src/main/resources/spell-i18n.json
@@ -1,0 +1,5747 @@
+[
+  {
+    "spellId": 6967,
+    "name": {
+      "fr": "Fécalistofedes",
+      "en": "Fecastopheles",
+      "es": "Fecalistófedes",
+      "pt": "Fecalistófedes"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Ce sort coûteux a une puissance importante pour compenser son manque de maniabilité.",
+      "en": "Inflicts Fire damage. This costly spell is difficult to wield but compensates for that with its power.",
+      "es": "Causa daños de fuego. Este costoso hechizo tiene una potencia importante para compensar su falta de manejabilidad.",
+      "pt": "Inflige danos de fogo. Este feitiço oneroso tem uma potência considerável que compensa sua falta de maneabilidade."
+    }
+  },
+  {
+    "spellId": 6968,
+    "name": {
+      "fr": "Météorite",
+      "en": "Meteorite",
+      "es": "Meteorito",
+      "pt": "Meteorito"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Lancé sur un allié, lui applique un bouclier Feu qui déclenchera un bonus en fin de tour du porteur.",
+      "en": "Inflicts Fire damage. When cast on an ally, applies a Fire shield that triggers a bonus at the end of the bearer's turn.",
+      "es": "Causa daños de fuego. Lanzado sobre un aliado, le aplica un escudo de fuego que activará un bonus al final del turno del portador.",
+      "pt": "Inflige danos de fogo. Quando lançado em um aliado, aplica nele um escudo de fogo que aciona um bônus no fim do turno do portador."
+    }
+  },
+  {
+    "spellId": 6969,
+    "name": {
+      "fr": "Attaque naturelle",
+      "en": "Natural Attack",
+      "es": "Ataque Natural",
+      "pt": "Ataque Natural"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Lancé sur un ennemi, lui vole de l'Esquive. L'esquive volée peut ensuite être donnée à un allié avec ce même sort.",
+      "en": "Inflicts Fire damage. If cast on an enemy, steals Dodge from them. The stolen Dodge can then be given to an ally by using the same spell.",
+      "es": "Causa daños de fuego. Lanzado sobre un enemigo, le roba esquiva. La esquiva robada puede luego darse a un aliado usando este mismo hechizo.",
+      "pt": "Inflige danos de fogo. Quando lançado em um inimigo, rouba Esquiva dele. Em seguida, a Esquiva roubada pode ser dada a um aliado com este mesmo feitiço."
+    }
+  },
+  {
+    "spellId": 6970,
+    "name": {
+      "fr": "Magma",
+      "en": "Magma",
+      "es": "Magma",
+      "pt": "Magma"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Lancé sur un allié, lui applique un bouclier Feu qui déclenchera des dommages en fin de tour du porteur.",
+      "en": "Inflicts Fire damage. When cast on an ally, applies a Fire shield that inflicts damage at the end of the bearer's turn.",
+      "es": "Causa daños de fuego. Lanzado sobre un aliado, le aplica un escudo de fuego que activará daños al final del turno del portador.",
+      "pt": "Inflige danos de fogo. Quando lançado em um aliado, aplica nele um escudo de fogo que aciona danos no fim do turno do portador."
+    }
+  },
+  {
+    "spellId": 6971,
+    "name": {
+      "fr": "Volcan",
+      "en": "Volcano",
+      "es": "Volcán",
+      "pt": "Vulcão"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Lancé sur un allié, lui applique un bouclier Feu qui déclenchera un bonus en fin de tour du porteur.",
+      "en": "Inflicts Fire damage. When cast on an ally, applies a Fire shield that triggers a bonus at the end of the bearer's turn.",
+      "es": "Causa daños de fuego. Lanzado sobre un aliado, le aplica un escudo de fuego que activará un bonus al final del turno del portador.",
+      "pt": "Inflige danos de fogo. Quando lançado em um aliado, aplica nele um escudo de fogo que aciona um bônus no fim do turno do portador."
+    }
+  },
+  {
+    "spellId": 6972,
+    "name": {
+      "fr": "Goutte",
+      "en": "Drip",
+      "es": "Gota",
+      "pt": "Gota"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau. Lancé sur un allié, lui applique un bouclier Eau qui réduit la prochaine entrave ennemie reçue.",
+      "en": "Inflicts Water damage. When cast on an ally, applies a Water shield that reduces the next enemy hindering received.",
+      "es": "Causa daños de agua. Lanzado sobre un aliado, le aplica un escudo de agua que reduce la próxima traba enemiga recibida.",
+      "pt": "Inflige danos de água. Quando lançado em um aliado, aplica nele um escudo de água que reduz o próximo entrave inimigo recebido."
+    }
+  },
+  {
+    "spellId": 6973,
+    "name": {
+      "fr": "Onde",
+      "en": "Wave",
+      "es": "Onda",
+      "pt": "Onda"
+    },
+    "description": {
+      "fr": "Applique un peu d'Armure sur un allié.",
+      "en": "Applies a small amount of armor on an ally.",
+      "es": "Aplica un poco de armadura en un aliado.",
+      "pt": "Aplica um pouco de Armadura a um aliado."
+    }
+  },
+  {
+    "spellId": 6974,
+    "name": {
+      "fr": "Avalanche",
+      "en": "Avalanche",
+      "es": "Avalancha",
+      "pt": "Avalanche"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau. Lancé sur une cible, la téléporte sur le centre du glyphe le plus proche. Si la case centrale est occupée par un obstacle, les deux cibles échangent de position.",
+      "en": "Inflicts Water damage. When cast on a target, it teleports them to the center of the nearest glyph. If the center cell is occupied by an obstacle, the two targets switch places.",
+      "es": "Causa daños de agua. Lanzado sobre un objetivo, lo teletransporta al centro del glifo más cercano. Si un obstáculo ocupa la casilla central, los dos objetivos intercambian la posición.",
+      "pt": "Inflige danos de água. Quando lançado em um alvo, o teletransporta para o centro do glifo mais próximo. Se a célula central estiver ocupada por um obstáculo, os dois alvos trocam de lugar."
+    }
+  },
+  {
+    "spellId": 6975,
+    "name": {
+      "fr": "Orage",
+      "en": "Storm",
+      "es": "Tormenta",
+      "pt": "Tormenta"
+    },
+    "description": {
+      "fr": "Lancé sur un allié, ce sort inflige des dommages conséquents tout autour de celui-ci. Sur un ennemi, celui-ci est déplacé vers le Féca.",
+      "en": "When cast on an ally, this spell inflicts considerable damage all around the ally. When cast on an enemy, the enemy is moved toward the Feca.",
+      "es": "Lanzado sobre un aliado, este hechizo inflige daños consecuentes alrededor de este. Sobre un enemigo, este es desplazado hacia el feca.",
+      "pt": "Quando lançado em um aliado, este feitiço inflige danos consideráveis ao redor dele. Se for lançado em um inimigo, ele é deslocado na direção do Feca."
+    }
+  },
+  {
+    "spellId": 6976,
+    "name": {
+      "fr": "Lame de fond",
+      "en": "Crashing Wave",
+      "es": "Filo Abisal",
+      "pt": "Lâmina Profunda"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau. Lancé sur un allié, lui applique un bouclier Eau qui déclenchera un bonus défensif en cas d'attaque ennemie reçue.",
+      "en": "Inflicts Water damage. When cast on an ally, applies a Water shield that triggers a defensive bonus when receiving an enemy attack.",
+      "es": "Causa daños de agua. Lanzado sobre un aliado, le aplica un escudo de agua que activará un bonus defensivo en caso de ataque enemigo recibido.",
+      "pt": "Inflige danos de água. Quando lançado em um aliado, aplica nele um escudo de água que aciona um bônus defensivo em caso de ataque inimigo."
+    }
+  },
+  {
+    "spellId": 6977,
+    "name": {
+      "fr": "Frappe tellurique",
+      "en": "Telluric Whack",
+      "es": "Golpe Telúrico",
+      "pt": "Golpe Telúrico"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Lancé sur un allié, lui applique un bouclier Terre qui déclenchera un échange de position en début de tour du porteur.",
+      "en": "Inflicts Earth damage. When cast on an ally, applies an Earth shield that triggers a position swap at the start of the bearer's turn.",
+      "es": "Causa daños de tierra. Lanzado sobre un aliado, le aplica un escudo de tierra que activará un cambio de posición al principio del turno del portador.",
+      "pt": "Inflige danos de terra. Quando lançado em um aliado, aplica nele um escudo de terra que aciona uma troca de posição no começo do turno do portador."
+    }
+  },
+  {
+    "spellId": 6978,
+    "name": {
+      "fr": "Orbe défensif",
+      "en": "Defensive Orb",
+      "es": "Orbe Defensivo",
+      "pt": "Orbe Defensivo"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Lancé sur un allié, lui applique un bouclier Terre qui déclenchera un bonus défensif au début du prochain tour du Féca.",
+      "en": "Inflicts Earth damage. When cast on an ally, applies an Earth shield on that ally that triggers a defensive bonus at the start of the Feca's next turn.",
+      "es": "Causa daños de tierra. Lanzado sobre un aliado, le aplica un escudo de tierra que activará un bonus defensivo al principio del próximo turno del feca.",
+      "pt": "Inflige danos de terra. Quando lançado em um aliado, aplica nele um escudo de terra que aciona um bônus defensivo no começo do próximo turno do Feca."
+    }
+  },
+  {
+    "spellId": 6979,
+    "name": {
+      "fr": "Bastion",
+      "en": "Bastion",
+      "es": "Bastión",
+      "pt": "Bastião"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Lancé sur un allié, le Féca prendra 25 % de ses dommages subis à sa place.",
+      "en": "Inflicts Earth damage. When cast on an ally, the Feca suffers 25% of the ally's damage suffered instead of the ally.",
+      "es": "Inflige daños de tierra. Lanzado sobre un aliado, el feca recibirá un 25% de sus daños sufridos en su lugar.",
+      "pt": "Inflige danos de terra. Quando é lançado em um aliado, o Feca leva 25% dos danos sofridos no lugar dele."
+    }
+  },
+  {
+    "spellId": 6980,
+    "name": {
+      "fr": "Rempart",
+      "en": "Rampart",
+      "es": "Muralla",
+      "pt": "Muralha"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Lancé sur un allié, lui applique un bouclier Terre qui déclenchera un bonus défensif en début de tour du porteur.",
+      "en": "Inflicts Earth damage. When cast on an ally, applies an Earth shield that triggers a defensive bonus at the start of the bearer's turn.",
+      "es": "Causa daños de tierra. Lanzado sobre un aliado, le aplica un escudo de tierra que activará un bonus defensivo al principio del turno del portador.",
+      "pt": "Inflige danos de terra. Quando lançado em um aliado, aplica nele um escudo de terra que aciona um bônus defensivo no começo do turno do portador."
+    }
+  },
+  {
+    "spellId": 6981,
+    "name": {
+      "fr": "Bâton",
+      "en": "Staff",
+      "es": "Bastón",
+      "pt": "Bastão"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Lancé sur un allié, lui applique un bouclier Terre qui déclenchera un bonus offensif en début de tour du porteur.",
+      "en": "Inflicts Earth damage. When cast on an ally, applies an Earth shield that triggers an offensive bonus at the start of the bearer's turn.",
+      "es": "Causa daños de tierra. Lanzado sobre un aliado, le aplica un escudo de tierra que activará un bonus ofensivo al principio del turno del portador.",
+      "pt": "Inflige danos de terra. Quando lançado em um aliado, aplica nele um escudo de terra que aciona um bônus ofensivo no começo do turno do portador."
+    }
+  },
+  {
+    "spellId": 6982,
+    "name": {
+      "fr": "Immunité",
+      "en": "Immunity",
+      "es": "Inmune",
+      "pt": "Imunidade"
+    },
+    "description": {
+      "fr": "Ce sort immunise complètement l'allié aux dommages reçus pendant un tour.",
+      "en": "This spell makes an ally completely immune to damage received for one turn.",
+      "es": "Este hechizo inmuniza completamente al aliado contra los daños recibidos durante un turno.",
+      "pt": "Este feitiço imuniza completamente o aliado contra os danos recebidos durante um turno."
+    }
+  },
+  {
+    "spellId": 6983,
+    "name": {
+      "fr": "Trêve",
+      "en": "Truce",
+      "es": "Tregua",
+      "pt": "Trégua"
+    },
+    "description": {
+      "fr": "Pendant un tour, toutes les entités présentes en combat sont plus résistantes, les alliés comme les ennemis. Ce sort permet de temporiser en cas de situation difficile.",
+      "en": "For one turn, all entities in the fight are more resistant, allies and enemies alike. This spell helps buy time when the going gets rough.",
+      "es": "Durante un turno, todas las entidades presentes en combate son más resistentes, tanto los aliados como los enemigos. Este hechizo sirve para ganar tiempo si la situación se complica.",
+      "pt": "Durante um turno, todas as entidades presentes no combate ficam mais resistentes, tanto os aliados quanto os inimigos. Este feitiço permite ganhar tempo se a situação estiver difícil."
+    }
+  },
+  {
+    "spellId": 6984,
+    "name": {
+      "fr": "Pacification",
+      "en": "Pacification",
+      "es": "Pacificación",
+      "pt": "Pacificação"
+    },
+    "description": {
+      "fr": "Ce sort fixe les dommages infligés de la cible à 30 %. Cela peut augmenter ses capacités offensives ou bien les diminuer, selon la situation.",
+      "en": "This spell sets the target's damage inflicted to 30%. This can increase or decrease their offensive ability depending on the situation.",
+      "es": "Este hechizo fija los daños infligidos del objetivo al 30%. Esto permite aumentar sus capacidades ofensivas o reducirlas, según la situación.",
+      "pt": "Fixa em 30% os danos infligidos do alvo. Isto pode aumentar ou diminuir suas habilidades ofensivas, dependendo da situação."
+    }
+  },
+  {
+    "spellId": 6985,
+    "name": {
+      "fr": "Provocation",
+      "en": "Provocation",
+      "es": "Provocación",
+      "pt": "Provocação"
+    },
+    "description": {
+      "fr": "Le Féca provoque sa cible. Ils deviennent tous deux stabilisés et perdent en mobilité, ce qui pousse la cible à rester sur place et l'attaquer.",
+      "en": "The Feca taunts their target. Both of them become stabilized and lose mobility, causing the target to remain in place and attack.",
+      "es": "El feca provoca a su objetivo. Ambos se estabilizan y pierden movilidad, lo que obliga al objetivo a quedarse quieto y a atacarlo.",
+      "pt": "O Feca provoca o alvo. Os dois ficam estabilizados e perdem mobilidade, o que leva o alvo a ficar no lugar e atacá-lo."
+    }
+  },
+  {
+    "spellId": 6986,
+    "name": {
+      "fr": "Égide",
+      "en": "Aegis",
+      "es": "Égida",
+      "pt": "Égide"
+    },
+    "description": {
+      "fr": "Ce sort renforce significativement les défenses de l'allié ciblé. En revanche, il devient de plus en plus coûteux en fonction du nombre d'alliés ciblés par ce sort dans un même tour.",
+      "en": "This spell significantly increases the targeted ally's defenses. However, it becomes more and more costly based on the number of allies targeted by this spell within the same turn.",
+      "es": "Este hechizo refuerza significativamente las defensas del aliado seleccionado. Sin embargo, se vuelve cada vez más costoso según el número de aliados seleccionados con este hechizo en un mismo turno.",
+      "pt": "Este feitiço reforça consideravelmente as defesas do aliado visado. Por outro lado, ele se torna cada vez mais oneroso em função da quantidade de aliados visados pelo feitiço no mesmo turno."
+    }
+  },
+  {
+    "spellId": 6987,
+    "name": {
+      "fr": "Magnétisme",
+      "en": "Magnetism",
+      "es": "Magnetismo",
+      "pt": "Magnetismo"
+    },
+    "description": {
+      "fr": "Le Féca utilise ses outils pour créer un puissant champ magnétique qui permet de contrôler le placement des entités.",
+      "en": "The Feca uses their tools to create a powerful magnetic field that lets them control entities' positions.",
+      "es": "El feca usa herramientas para crear un potente campo magnético que permite controlar el posicionamiento de las entidades.",
+      "pt": "O Feca usa suas ferramentas para criar um poderoso campo magnético que permite controlar o posicionamento das entidades."
+    }
+  },
+  {
+    "spellId": 7307,
+    "name": {
+      "fr": "Corbeau incendiaire",
+      "en": "Incendiary Crow",
+      "es": "Cuervo Incendiario",
+      "pt": "Corvo Incendiário"
+    },
+    "description": {
+      "fr": "Ce sort peut taper à travers les obstacles. Il inflige des dommages élevés si la cible n'est pas dans la ligne de vue du lanceur.",
+      "en": "This spell can strike through obstacles. It inflicts high damage if the target isn't in the caster's line of sight.",
+      "es": "Este hechizo puede golpear a través de los obstáculos. Inflige daños elevados si el objetivo no está en la línea de visión del lanzador.",
+      "pt": "Este feitiço pode bater através dos obstáculos. Inflige danos elevados se o alvo não estiver na linha de visão do lançador."
+    }
+  },
+  {
+    "spellId": 7308,
+    "name": {
+      "fr": "Fouet enflammé",
+      "en": "Flaming Whip",
+      "es": "Látigo Flamígero",
+      "pt": "Chicote Flamejante"
+    },
+    "description": {
+      "fr": "Échaude la cible. Cette dernière subira plus de dommages indirects. Les dommages dits \"indirects\" sont toutes les sources de dommages causés en dehors des effets d'un sort ou d'une arme. Exemple : glyphes, poisons, auras...",
+      "en": "Scalds the target. The target will suffer more indirect damage. \"Indirect\" damage is any damage caused by anything other than the effects of a spell or weapon. For example: glyphs, poisons, auras, etc.",
+      "es": "Escalda al objetivo. Este sufrirá más daños indirectos. Los daños \"indirectos\" son todas las fuentes de daños causados aparte de los efectos de un hechizo o de un arma. Ejemplo: glifos, venenos, auras...",
+      "pt": "Escalda o alvo. Assim, ele sofrerá mais danos indiretos. Os danos chamados \"indiretos\" são todos os danos que não são causados por um feitiço ou uma arma. Por exemplo: glifo, veneno, auras..."
+    }
+  },
+  {
+    "spellId": 7309,
+    "name": {
+      "fr": "Tornade de flammes",
+      "en": "Flame Tornado",
+      "es": "Tornado de Llamas",
+      "pt": "Tornado de Chamas"
+    },
+    "description": {
+      "fr": "Lancé sur un ennemi, celui-ci subit plus de dommages de la part de l'invocation de l'Osamodas. S'il s'agit d'un allié, il reçoit plus de soins de la part de l'invocation.",
+      "en": "Cast on an enemy, the enemy suffers more damage from the Osamodas's summons. If it is an ally, they receive more healing from the summons.",
+      "es": "Lanzado sobre un enemigo, este sufre más daños de parte de la invocación del osamodas. Si se trata de un aliado, recibe más curas de parte de la invocación.",
+      "pt": "Lançado em um inimigo, ele sofre mais danos da invocação do Osamodas. Caso se trate de um aliado, ele recebe mais curas da invocação."
+    }
+  },
+  {
+    "spellId": 7310,
+    "name": {
+      "fr": "Attisement",
+      "en": "Fanning",
+      "es": "Atizamiento",
+      "pt": "Atiçamento"
+    },
+    "description": {
+      "fr": "Soigne l'invocation de l'Osamodas en fonction des dommages qu'il inflige. Lancé sur un allié, celui-ci est soigné en début de tour pendant plusieurs tours.",
+      "en": "Heals the Osamodas's summons based on the damage it inflicts. Cast on an ally, the ally is healed at the start of the turn for several turns.",
+      "es": "Cura a la invocación del osamodas en función de los daños que este inflige. Lanzado sobre un aliado, este se cura al principio del turno durante varios turnos.",
+      "pt": "Cura a invocação do Osamodas em função dos danos que ele inflige. Lançado em um aliado, ele é curado no começo do turno durante vários turnos."
+    }
+  },
+  {
+    "spellId": 7311,
+    "name": {
+      "fr": "Souffle du dragon",
+      "en": "Dragon's Breath",
+      "es": "Soplido del Dragón",
+      "pt": "Sopro do Dragão"
+    },
+    "description": {
+      "fr": "Inflige des dommages élevés en zone. En forme draconique, la cible du sort est blessée mais les dommages infligés autour de celle-ci sont augmentés.",
+      "en": "Inflicts high damage in an area of effect. In dragon form, the spell's target is injured but the damage inflicted around the target are higher.",
+      "es": "Inflige daños elevados en zona. En forma dracónica, el objetivo del hechizo resulta herido, pero los daños infligidos alrededor de él aumentan.",
+      "pt": "Inflige danos elevados em zona. Na forma dragontina, o alvo do feitiço é ferido, mas os danos infligidos ao redor dele são aumentados."
+    }
+  },
+  {
+    "spellId": 7312,
+    "name": {
+      "fr": "Tempête de sable",
+      "en": "Sandstorm",
+      "es": "Tormenta de Arena",
+      "pt": "Tempestade de Areia"
+    },
+    "description": {
+      "fr": "L'invocation de l'Osamodas devient plus résistante si elle est au contact de la cible.",
+      "en": "The Osamodas's summons becomes more resistant if it is adjacent to the target.",
+      "es": "La invocación del osamodas se vuelve más resistente si está en contacto con el objetivo.",
+      "pt": "A invocação do Osamodas torna-se mais resistente quando está em contato com o alvo."
+    }
+  },
+  {
+    "spellId": 7313,
+    "name": {
+      "fr": "Pesanteur",
+      "en": "Gravity",
+      "es": "Pesante",
+      "pt": "Gravidade"
+    },
+    "description": {
+      "fr": "Retire du tacle et de l'esquive à la cible.",
+      "en": "Reduces the target's Lock and Dodge.",
+      "es": "Retira placaje y esquiva al objetivo.",
+      "pt": "Reduz o Bloqueio e a Esquiva do alvo."
+    }
+  },
+  {
+    "spellId": 7314,
+    "name": {
+      "fr": "Empalement",
+      "en": "Impalement",
+      "es": "Empalamiento",
+      "pt": "Empalamento"
+    },
+    "description": {
+      "fr": "Inflige des dommages élevés au corps-à-corps.",
+      "en": "Inflicts high damage in close combat.",
+      "es": "Inflige daños elevados en cuerpo a cuerpo.",
+      "pt": "Inflige danos elevados de corpo a corpo."
+    }
+  },
+  {
+    "spellId": 7315,
+    "name": {
+      "fr": "Gambade",
+      "en": "Gambol",
+      "es": "Brinco",
+      "pt": "Rondada"
+    },
+    "description": {
+      "fr": "Inflige des dommages et confère un bonus de mobilité au lanceur.",
+      "en": "Inflicts damage and gives the caster a mobility bonus.",
+      "es": "Inflige daños y confiere un bonus de movilidad al lanzador.",
+      "pt": "Inflige danos e concede um bônus de mobilidade ao lançador."
+    }
+  },
+  {
+    "spellId": 7316,
+    "name": {
+      "fr": "Frappe du craqueleur",
+      "en": "Crackler Punch",
+      "es": "Golpe del Crujidor",
+      "pt": "Golpe do Smagador"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone. En dragon, attire les combattants en ligne avec la cible vers celle-ci.",
+      "en": "Inflicts damage in an area of effect. In dragon form, attracts fighters in line with the target toward the target.",
+      "es": "Inflige daños en zona. En dragón, atrae a los luchadores en línea con el objetivo hacia este.",
+      "pt": "Inflige danos em zona. Como dragão, atrai os combatentes alinhados com o alvo até ele."
+    }
+  },
+  {
+    "spellId": 7317,
+    "name": {
+      "fr": "Fouet",
+      "en": "Whip",
+      "es": "Látigo",
+      "pt": "Chicote"
+    },
+    "description": {
+      "fr": "Inflige des dommages doublés sur les invocations.",
+      "en": "Inflicts double damage on summons.",
+      "es": "Inflige daños duplicados a las invocaciones.",
+      "pt": "Inflige danos dobrados nas invocações."
+    }
+  },
+  {
+    "spellId": 7318,
+    "name": {
+      "fr": "Déplumage",
+      "en": "Plucking",
+      "es": "Desplume",
+      "pt": "Depenagem"
+    },
+    "description": {
+      "fr": "Tourne le regard de la cible, de manière à donner son dos.",
+      "en": "Changes where the target is looking in order to turn its back.",
+      "es": "Atrae la atención del objetivo, de forma que quede de espaldas.",
+      "pt": "Vira o alvo, deixando-o de costas."
+    }
+  },
+  {
+    "spellId": 7319,
+    "name": {
+      "fr": "Transfert",
+      "en": "Transfer",
+      "es": "Transferencia",
+      "pt": "Transferência"
+    },
+    "description": {
+      "fr": "La cible échange de position avec l'invocation. En dragon, l'Osamodas et son invocation échangent de position, puis l'Osamodas inflige des dommages.",
+      "en": "The target switches places with the summons. In dragon form, the Osamodas and their summons switch places then the Osamodas inflicts damage.",
+      "es": "Cambia de posición con la invocación. En dragón, el osamodas y su invocación intercambian la posición, luego el osamodas inflige daños.",
+      "pt": "O alvo troca de lugar com a invocação. Como dragão, o Osamodas e sua invocação trocam de lugar e, em seguida, o Osamodas inflige danos."
+    }
+  },
+  {
+    "spellId": 7320,
+    "name": {
+      "fr": "Souffle répulsif",
+      "en": "Repulsive Breath",
+      "es": "Soplido Repulsivo",
+      "pt": "Sopro Repulsivo"
+    },
+    "description": {
+      "fr": "Pousse la cible d'une case.",
+      "en": "Pushes the target 1 cell.",
+      "es": "Empuja al objetivo una casilla.",
+      "pt": "Empurra o alvo por 1 célula."
+    }
+  },
+  {
+    "spellId": 7321,
+    "name": {
+      "fr": "Tornade de plumes",
+      "en": "Feather Tornado",
+      "es": "Tornado de Plumas",
+      "pt": "Tornado de Penas"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone. Téléporte l'invocation si le sort est lancé sur une case vide dans un périmètre proche.",
+      "en": "Inflicts damage in an area of effect. Teleports the summons if the spell is cast on a nearby empty cell.",
+      "es": "Inflige daños en zona. Teletransporta la invocación si el hechizo se lanza sobre una casilla vacía en un perímetro cercano.",
+      "pt": "Inflige danos em zona. Teletransporta a invocação se o feitiço for lançado numa célula vazia num perímetro próximo."
+    }
+  },
+  {
+    "spellId": 7322,
+    "name": {
+      "fr": "Dernier souffle",
+      "en": "Last Breath",
+      "es": "Último Aliento",
+      "pt": "Último Suspiro"
+    },
+    "description": {
+      "fr": "L'invocation de l'Osamodas gagne des bonus importants mais meurt à la fin de son tour.",
+      "en": "The Osamodas's summons gains large bonuses but dies at the end of its turn.",
+      "es": "La invocación del osamodas gana importantes bonus, pero muere al final de su turno.",
+      "pt": "A invocação do Osamodas ganha bônus significativos, mas morre no fim do turno."
+    }
+  },
+  {
+    "spellId": 7323,
+    "name": {
+      "fr": "Piqure motivante",
+      "en": "Motivating Shot",
+      "es": "Chute Motivador",
+      "pt": "Picada Motivante"
+    },
+    "description": {
+      "fr": "La cible gagne un bonus de PA et de dommages infligés. Si l'Osamodas cible son invocation, il regagne 2 PA.",
+      "en": "The target gains an AP bonus and damage inflicted. If the Osamodas targets their summons, they regain 2 AP.",
+      "es": "El objetivo gana un bonus de PA y de daños infligidos. Si el osamodas elige a su invocación, recupera 2 PA.",
+      "pt": "O alvo ganha um bônus de PA e de danos infligidos. Se o Osamodas mirar em sua invocação, ele recuperará 2 PA."
+    }
+  },
+  {
+    "spellId": 7324,
+    "name": {
+      "fr": "Célérité",
+      "en": "Velocity",
+      "es": "Celeridad",
+      "pt": "Velocidade"
+    },
+    "description": {
+      "fr": "L'Osamodas transmet tous ses PM restants à la cible. L'allié infligera également plus de dommages en mêlée.",
+      "en": "The Osamodas transfers all their remaining MP to the target. The ally will also inflict more damage in melee.",
+      "es": "El osamodas transmite todos sus PM restantes al aliado. El aliado también infligirá más daños en melé.",
+      "pt": "O Osamodas transmite todos os seus PM restantes ao alvo. O aliado também infligirá mais danos a curta distância."
+    }
+  },
+  {
+    "spellId": 7325,
+    "name": {
+      "fr": "Cri affaiblissant",
+      "en": "Weakening Cry",
+      "es": "Grito Debilitador",
+      "pt": "Grito Enfraquecedor"
+    },
+    "description": {
+      "fr": "La cible réduit les dommages subis par l'invocation de l'Osamodas, mais perd en contrepartie des résistances lorsque celle-ci lui inflige des dommages.",
+      "en": "The target reduces the damage suffered by the Osamodas's summons, but in exchange loses resistance when the target inflicts damage on it.",
+      "es": "El objetivo reduce los daños sufridos por la invocación del osamodas, pero a cambio pierde resistencias cuando esta le inflige daños.",
+      "pt": "O alvo reduz os danos sofridos pela invocação do Osamodas, mas perde resistências quando ela lhe inflige danos."
+    }
+  },
+  {
+    "spellId": 7326,
+    "name": {
+      "fr": "Relais",
+      "en": "Relay",
+      "es": "Relevo",
+      "pt": "Transmissor"
+    },
+    "description": {
+      "fr": "En début de tour, l'allié échange de place avec l'invocation de l'Osamodas. Si son invocation n'est pas en jeu, l'allié échange de place avec l'Osamodas. \\nLancé sur son invocation ou le Gobgob, l'Osamodas échange instantanément de place avec.",
+      "en": "At the start of the turn, the ally changes places with the Osamodas's summons. If the summons is not in play, the ally changes places with the Osamodas. \\nCast on their summons or the Gobgob, the Osamodas instantly changes places with them.",
+      "es": "Al principio del turno, el aliado cambia de posición con la invocación del osamodas. Si su invocación no está en juego, el aliado cambia de posición con el osamodas. \\nLanzado sobre su invocación o el jamajam, el osamodas cambia instantáneamente de posición con ellos.",
+      "pt": "No começo do turno, o aliado troca de lugar com a invocação do Osamodas. Se sua invocação não estiver em jogo, o aliado trocará de lugar com o Osamodas. \\nLançado na invocação ou no Komekom, o Osamodas troca imediatamente de lugar com o alvo."
+    }
+  },
+  {
+    "spellId": 7327,
+    "name": {
+      "fr": "Lien animal",
+      "en": "Animal Link",
+      "es": "Vínculo Animal",
+      "pt": "Elo Animal"
+    },
+    "description": {
+      "fr": "L'Osamodas sacrifie ses points de vie pour les donner en armure à un allié. L'Osamodas regagne 2 PW.",
+      "en": "The Osamodas sacrifices health points to give them as armor to an ally. The Osamodas regains 2 WP.",
+      "es": "El osamodas sacrifica sus puntos de vida para darlos en armadura a un aliado. El osamodas recupera 2 PW.",
+      "pt": "O Osamodas sacrifica seus pontos de vida para dá-los em forma de armadura a um aliado. O Osamodas recupera 2 PW"
+    }
+  },
+  {
+    "spellId": 2008,
+    "name": {
+      "fr": "Pelle du jugement",
+      "en": "Shovel of Judgment",
+      "es": "Pala del Juicio",
+      "pt": "Pá do Julgamento"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Si l'Enutrof est en phorzerker, les dommages traversent l'Armure et ignorent la Parade. Sinon, la cible perd de la Portée.",
+      "en": "Inflicts Earth damage. If the Enutrof is in Drhellzerker form, the damage passes through Armor and ignores Block. Otherwise, the target loses Range.",
+      "es": "Inflige daños de tierra. Si el anutrof está en forma de perfórserker, los daños atraviesan la armadura e ignoran la anticipación. Si no, el objetivo pierde alcance.",
+      "pt": "Inflige danos de terra. Se o Enutrof estiver em Perforzerker, os danos atravessam a armadura e ignoram a parada. Caso contrário, o alvo perde alcance."
+    }
+  },
+  {
+    "spellId": 2010,
+    "name": {
+      "fr": "Pelle tueuse",
+      "en": "Killer Spade",
+      "es": "Pala Asesina",
+      "pt": "Pá Assassina"
+    },
+    "description": {
+      "fr": "Pousse la cible en forme normale et échange de position en Phorzerker. Inflige ensuite des dommages Terre.",
+      "en": "Pushes the target back in normal form and switches places in Drhellzerker form. Then, inflicts Earth damage.",
+      "es": "Empuja al objetivo en forma normal y cambia de posición en forma de perfórserker. Inflige seguidamente daños de tierra.",
+      "pt": "Empurra o alvo na forma normal e troca de posição na Perforzerker. Depois inflige danos de terra."
+    }
+  },
+  {
+    "spellId": 2011,
+    "name": {
+      "fr": "Roulage de pelle",
+      "en": "Shovel Kiss",
+      "es": "Jarabe de Pala",
+      "pt": "Pá Virada"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. En forme normale, ce sort retire des PM à la cible. En phorzerker, l'Enutrof se rapproche au contact de la cible avant d'infliger les dommages.",
+      "en": "Inflicts Earth damage. In normal form, this spell removes MP from the target. In Drhellzerker form, the Enutrof moves into close-combat range of the target before inflicting damage.",
+      "es": "Inflige daños de tierra. En forma normal, este hechizo retira PM al objetivo. En perfórserker, el anutrof se acerca al contacto del objetivo y le inflige daños.",
+      "pt": "Inflige danos de terra. Na forma normal, este feitiço retira PM do alvo. Na Perforzerker, o Enutrof se aproxima do alvo antes de infligir os danos."
+    }
+  },
+  {
+    "spellId": 2012,
+    "name": {
+      "fr": "Pelle mêle",
+      "en": "Shady Shovel",
+      "es": "Pala Drona",
+      "pt": "Pá Sombria"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre. Retire des PA à la cible en forme normale et vole de la vie en Phorzerker. Si l'Enutrof possède l'état Trésors, il le consomme pour doubler les effets secondaires du sort.",
+      "en": "Inflicts Earth damage. Removes AP from the target in normal form, and steals HP in Drhellzerker form. If the Enutrof has the Treasures state, they consume it to double the spell's secondary effects.",
+      "es": "Inflige daños de tierra. En forma normal, retira PA al objetivo; y en perfórserker, roba vida. Si el anutrof tiene el estado Tesoros, lo consume para duplicar los efectos secundarios del hechizo.",
+      "pt": "Inflige danos de terra. Retira PA do alvo na forma normal e rouba vida na Perforzerker. Se o Enutrof já tiver o estado Tesouros, ele o consome para dobrar os efeitos secundários do feitiço."
+    }
+  },
+  {
+    "spellId": 2013,
+    "name": {
+      "fr": "Pelle sismique",
+      "en": "Shovel Shaker",
+      "es": "Pala Sísmica",
+      "pt": "Pá Sísmica"
+    },
+    "description": {
+      "fr": "Inflige des dommages en ligne face à l'Enutrof. Si son Phorreur se trouve au bout de la zone, il réplique les dommages à son tour.",
+      "en": "Inflicts damage in a straight line in front of the Enutrof. If their Drheller is at the edge of the area, it replicates the damage on its turn.",
+      "es": "Inflige daños en línea frente al anutrof. Si su perforatroz se encuentra al final de la zona, también replica los daños.",
+      "pt": "Inflige danos em linha à frente do Enutrof. Se seu Perfuratroz estiver no final da zona, ele replica os danos no seu turno."
+    }
+  },
+  {
+    "spellId": 2014,
+    "name": {
+      "fr": "Coupures",
+      "en": "Cutting",
+      "es": "Cortes",
+      "pt": "Cortes"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau à une cible, quadruplés s'il s'agit d'une invocation. Si l'Enutrof tue sa cible avec ce sort, il gagne l'état Trésors.",
+      "en": "Inflicts Water damage on a target, quadrupled if the target is a summons. If the Enutrof kills their target with this spell, the Enutrof gains the Treasures state.",
+      "es": "Inflige daños de agua a un objetivo, cuadruplicados si se trata de una invocación. Si el anutrof mata a su objetivo con este hechizo, gana el estado Tesoros.",
+      "pt": "Inflige danos de água a um alvo, quadruplicados se for uma invocação. Se o Enutrof matar seu alvo com o feitiço, ele ganha o estado Tesouros."
+    }
+  },
+  {
+    "spellId": 2015,
+    "name": {
+      "fr": "Filouterie",
+      "en": "Rascalry",
+      "es": "Timo",
+      "pt": "Patifaria"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau et vole 1 PM à la cible ou 2 PM si elle en possède plus que l'Enutrof.",
+      "en": "Inflicts Water damage and steals 1 MP from the target, or 2 MP if target has more MP than the Enutrof.",
+      "es": "Inflige daños de agua y roba 1 PM al objetivo o 2 PM si tiene más que el anutrof.",
+      "pt": "Inflige danos de água e rouba 1 PM do alvo, ou 2 se ele tiver mais que o Enutrof."
+    }
+  },
+  {
+    "spellId": 2016,
+    "name": {
+      "fr": "Taxe",
+      "en": "Tax",
+      "es": "Impuesto",
+      "pt": "Taxa"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau. Si l'Énutrof possède l'état Trésors, l'état est consommé et inflige une perte de PM à sa cible.",
+      "en": "Inflicts Water damage. If the Enutrof has the Treasures state, the state is consumed and inflicts an MP loss on the target.",
+      "es": "Causa daños de agua. Si el anutrof tiene el estado Tesoros, el estado se consume e inflige una pérdida de PM a su objetivo.",
+      "pt": "Inflige danos de água. Se o Enutrof tiver o estado Tesouros, o estado será consumido e infligirá uma perda de PM ao alvo."
+    }
+  },
+  {
+    "spellId": 2017,
+    "name": {
+      "fr": "Epuration",
+      "en": "Refinement",
+      "es": "Depuración",
+      "pt": "Refinamento"
+    },
+    "description": {
+      "fr": "Inflige de lourds dommages Eau. Si l'Énutrof possède l'état Trésors, l'état est consommé pour infliger davantage de dommages.",
+      "en": "Inflicts heavy Water damage. If the Enutrof has the Treasures state, the state is consumed to inflict more damage.",
+      "es": "Inflige grandes daños de agua. Si el anutrof posee el estado Tesoros, el estado se consume para infligir todavía más daños.",
+      "pt": "Inflige danos pesados de água. Se o Enutrof tiver o estado Tesouros, o estado é consumido para infligir mais danos."
+    }
+  },
+  {
+    "spellId": 2018,
+    "name": {
+      "fr": "Fusion",
+      "en": "Fusion",
+      "es": "Fusión",
+      "pt": "Fusão"
+    },
+    "description": {
+      "fr": "Si l'Enutrof est sur un Gisement, il le déplace instantanément sous sa cible avant de lui infliger des dommages feu. S'il possède l'état Trésors en plus, il consomme l'état pour invoquer aussitôt un nouveau Gisement sur sa position (seulement si le Gisement déplacé a été consommé). Dans ce cas-là, le Gisement consommé ne donne pas de Trésors à l'Enutrof.",
+      "en": "If the Enutrof is on a Mine, the Mine immediately moves underneath the target and inflicts Fire damage on the target. If the Enutrof also has the Treasures state, they consume the state to immediately summon a new Mine at their position (only if the moved Mine was consumed). In this case, the consumed Mine does not give Treasures to the Enutrof.",
+      "es": "Si el anutrof está sobre un filón, lo desplaza instantáneamente bajo su objetivo y le inflige daños de fuego. Si además tiene el estado Tesoros, consume el estado para invocar inmediatamente un nuevo filón en su posición (solo si el filón desplazado ha sido consumido). En ese caso, el filón consumido no da Tesoros al anutrof.",
+      "pt": "Se o Enutrof estiver sobre uma Mina, ele a desloca imediatamente para o seu alvo antes de infligir danos de fogo a ele. Se ele já tiver o estado Tesouros, ele consome o estado para invocar uma nova Mina na sua posição (somente se a Mina deslocada tiver sido consumida). Nesse caso, a Mina consumida não concede Tesouros ao Enutrof."
+    }
+  },
+  {
+    "spellId": 2019,
+    "name": {
+      "fr": "Météore",
+      "en": "Meteor",
+      "es": "Meteoro",
+      "pt": "Meteoro"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu aux ennemis en zone. L'Enutrof déplace le Gisement le plus proche sur la case ciblée.",
+      "en": "Inflicts Fire damage on enemies in an area of effect. The Enutrof moves the closest Mine to the targeted cell.",
+      "es": "Inflige daños de fuego a los enemigos en zona. El anutrof desplaza el filón más cercano a la casilla objetivo.",
+      "pt": "Inflige danos de fogo aos inimigos em zona. O Enutrof desloca a Mina mais próxima para a célula visada."
+    }
+  },
+  {
+    "spellId": 2021,
+    "name": {
+      "fr": "Braise",
+      "en": "Ember",
+      "es": "Brasas",
+      "pt": "Brasas"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu en zone.",
+      "en": "Inflicts Fire damage in an area of effect.",
+      "es": "Inflige daños de fuego en zona.",
+      "pt": "Inflige danos de fogo na zona."
+    }
+  },
+  {
+    "spellId": 2022,
+    "name": {
+      "fr": "Coulée de lave",
+      "en": "Hot Magma",
+      "es": "Río de Lava",
+      "pt": "Torrente de Lava"
+    },
+    "description": {
+      "fr": "Inflige d'importants dommages Feu en zone. Si l'Enutrof est en forme Phorzerker et que la case visée est libre, il se téléporte.",
+      "en": "Inflicts major Fire damage in an area of effect. If the Enutrof is in Drhellzerker form and the targeted cell is free, the Enutrof teleports.",
+      "es": "Inflige importantes daños de fuego en zona. Si el anutrof está en forma de perfórserker y la casilla objetivo está libre, se teletransporta.",
+      "pt": "Inflige grandes danos de fogo em zona. Se o Enutrof estiver na forma Perforzerker e a célula visada estiver livre, ele se teletransporta."
+    }
+  },
+  {
+    "spellId": 2026,
+    "name": {
+      "fr": "Richesse sismique",
+      "en": "Seismic Wealth",
+      "es": "Riqueza Sísmica",
+      "pt": "Riqueza Sísmica"
+    },
+    "description": {
+      "fr": "L'Enutrof consomme tous ses Gisements. Chaque Gisement consommé octroie un bonus important de dommages à l'Énutrof pour une durée de 2 tours.",
+      "en": "The Enutrof consumes all of their Mines. Each Mine consumed grants a significant damage bonus to the Enutrof for a period of 2 turns.",
+      "es": "El anutrof consume todos sus filones. Cada filón consumido otorga un importante bonus de daños al anutrof durante 2 turnos.",
+      "pt": "O Enutrof consome todas as Minas dele. Cada Mina consumida concede um bônus significativo ao Enutrof durante 2 turnos."
+    }
+  },
+  {
+    "spellId": 2032,
+    "name": {
+      "fr": "Purge",
+      "en": "Purge",
+      "es": "Purga",
+      "pt": "Purgação"
+    },
+    "description": {
+      "fr": "Inflige des dommages eau à longue distance et vole de la portée à la cible. Si l'Enutrof cible un Gisement, la zone d'effet du sort est augmentée.",
+      "en": "Inflicts Water damage at long range and steals Range from the target. If the Enutrof targets a Mine, the spell's area of effect is increased.",
+      "es": "Inflige daños de agua a larga distancia y roba alcance al objetivo. Si el anutrof selecciona un filón, la zona de efecto del hechizo aumenta.",
+      "pt": "Inflige danos de água a distância e rouba alcance do alvo. Se o Enutrof visar uma Mina, a zona de efeito do feitiço aumenta."
+    }
+  },
+  {
+    "spellId": 2037,
+    "name": {
+      "fr": "Coup de grisou",
+      "en": "Firedamp Explosion",
+      "es": "Explosión de Grisú",
+      "pt": "Explosão de Grisu"
+    },
+    "description": {
+      "fr": "L'Enutrof inflige des dommages importants autour d'un de ses Gisements. Ce sort peut être lancé n'importe où sur le terrain, mais il doit cibler un Gisement.",
+      "en": "The Enutrof inflicts major damage around one of their Mines. This spell can be cast anywhere on the battlefield, but it must target a Mine.",
+      "es": "El anutrof inflige importantes daños alrededor de uno de sus filones. Este hechizo puede lanzarse a cualquier casilla del terreno, pero siempre seleccionando un filón.",
+      "pt": "O Enutrof inflige danos consideráveis ao redor de uma de suas Minas. Esse feitiço pode ser lançado em qualquer lugar do terreno, mas deve ter como alvo uma Mina."
+    }
+  },
+  {
+    "spellId": 2064,
+    "name": {
+      "fr": "Force de l'âge",
+      "en": "Prime of Life",
+      "es": "Fuerza de la Edad",
+      "pt": "Flor da Idade"
+    },
+    "description": {
+      "fr": "Donne un bonus conséquent de PM et d'esquive à l'Énutrof ou en fait profiter un allié pour le tour en cours. Si l'Enutrof a l'état Trésors, il consomme l'état pour donner des PA en plus.",
+      "en": "Gives a significant MP and Dodge bonus to the Enutrof or an ally for the current turn. If the Enutrof has the Treasures state, they consume the state to grant additional AP.",
+      "es": "Otorga un bonus sustancial de PM y de esquiva al anutrof, o se lo da a un aliado durante el turno en curso. Si el anutrof tiene el estado Tesoros, consume el estado y da PA adicionales.",
+      "pt": "Dá um bônus substancial de PM e de esquiva ao Enutrof ou a um aliado durante o turno em andamento. Se o Enutrof tiver o estado Tesouros, ele consumirá o estado para conceder mais PA."
+    }
+  },
+  {
+    "spellId": 6324,
+    "name": {
+      "fr": "Accélération",
+      "en": "Acceleration",
+      "es": "Aceleración",
+      "pt": "Aceleração"
+    },
+    "description": {
+      "fr": "Donne un PM à l'Énutrof ou à un allié pour une durée de 2 tours. Si l'Enutrof a l'état Trésors, il consomme l'état pour doubler le bonus.",
+      "en": "Gives 1 MP to the Enutrof or to an ally for two turns. If the Enutrof has the Treasures state, they consume the state to double the bonus.",
+      "es": "Da un PM al anutrof o a un aliado durante 2 turnos. Si el anutrof tiene el estado Tesoros, consume el estado para duplicar el bonus.",
+      "pt": "Dá um PM ao Enutrof ou a um aliado durante 2 turnos. Se o Enutrof tiver o estado Tesouros, ele consumirá o estado para dobrar o bônus."
+    }
+  },
+  {
+    "spellId": 6337,
+    "name": {
+      "fr": "Maladresse",
+      "en": "Clumsiness",
+      "es": "Torpeza",
+      "pt": "Desastre"
+    },
+    "description": {
+      "fr": "Retire des PM à la cible et lui vole du Tacle et de l'Esquive, réduisant sa mobilité et augmentant celle de l'Enutrof.",
+      "en": "Removes MP from the target and steals Lock and Dodge from it, reducing its mobility and increasing the Enutrof's.",
+      "es": "Le quita PM al objetivo y le roba placaje y esquiva, reduciendo su movilidad y aumentando la del anutrof.",
+      "pt": "Retira PM e rouba bloqueio e esquiva do alvo, reduzindo sua mobilidade e aumentando a do Enutrof."
+    }
+  },
+  {
+    "spellId": 8240,
+    "name": {
+      "fr": "Avarice",
+      "en": "Miserliness",
+      "es": "Avaricia",
+      "pt": "Avareza"
+    },
+    "description": {
+      "fr": "L'Enutrof consomme un Gisement à distance, lui permettant d'obtenir l'état Trésors et de gagner une partie du bonus du Gisement pendant 1 tour. Si l'Enutrof a l'état Trésors, il consomme l'état pour gagner le bonus complet du Gisement.",
+      "en": "The Enutrof consumes a Mine at range, allowing them to gain the Treasures state and gain part of the Mine's bonus for 1 turn. If the Enutrof has the Treasures state, they consume the state to gain the Mine's full bonus.",
+      "es": "El anutrof consume un filón a distancia, lo que le permite obtener el estado Tesoros y ganar una parte del bonus del filón durante 1 turno. Si el anutrof tiene el estado Tesoros, lo consume para ganar el bonus completo del filón.",
+      "pt": "O Enutrof consome uma Mina a distância, obtendo o estado Tesouros e ganhando uma parte do bônus dela durante 1 turno. Se o Enutrof tiver o estado Tesouros, ele consumirá o estado para ganhar o bônus completo da Mina."
+    }
+  },
+  {
+    "spellId": 8242,
+    "name": {
+      "fr": "Corruption",
+      "en": "Corruption",
+      "es": "Corrupción",
+      "pt": "Corrupção"
+    },
+    "description": {
+      "fr": "L'Enutrof rend transparente (ne bloque plus la ligne de vue) une cible pendant 2 tours. S'il s'agit d'un allié, il est soigné. S'il s'agit d'un ennemi, il subit un malus de dommages infligés, de soins réalisés et d'armure donnée.",
+      "en": "The Enutrof turns a target transparent (no longer blocks line of sight) for 2 turns. If it is an ally, they are healed. If it is an enemy, they suffer a penalty on damage inflicted, heals performed, and armor given.",
+      "es": "El anutrof vuelve transparente a un objetivo (ya no bloquea la línea de visión) 2 turnos. Si se trata de un aliado, lo cura. Si se trata de un enemigo, sufre un malus de daños infligidos, de curas realizadas y de armadura dada.",
+      "pt": "O Enutrof deixa um alvo transparente (não bloqueia a linha de visão) por 2 turnos. Se for um aliado, ele é curado. Se for um inimigo, ele sofre uma penalidade de danos infligidos, curas realizadas e armadura concedida."
+    }
+  },
+  {
+    "spellId": 4579,
+    "name": {
+      "fr": "Arnaque",
+      "en": "Scam",
+      "es": "Estafa",
+      "pt": "Burla"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau et consomme le Point faible pour faire des dommages supplémentaires et se soigner. En fonction du nombre de Point faible consommé, le Sram regagne des PA, des PM et des PW et applique de l'Hémorragie sur la cible avant d'avoir infligé les dommages. Hémorragie ajoute des dommages à la cible lorsque le Sram lui inflige des dommages directs.",
+      "en": "Inflicts Water damage and consumes Weak Point to inflict additional damage and heal themself. Depending on the amount of Weak Point consumed, the Sram regains AP, MP, and WP, and applies Hemorrhage on the target before inflicting damage. Hemorrhage inflicts additional damage on the target when the Sram inflicts direct damage on it.",
+      "es": "Inflige daños de agua y consume el Punto Débil para ocasionar daños adicionales y curarse. Según la cantidad de Punto Débil consumido, el sram recupera PA, PM y PW además de aplicar Hemorragia al objetivo antes de infligirle daños. Hemorragia añade daños al objetivo cuando el sram le inflige daños directos.",
+      "pt": "Inflige danos de Água e consome o Ponto Fraco para provocar danos adicionais e se curar. Em função da quantidade de Ponto Fraco consumido, o Sram recupera PA, PM e PW, e aplica Hemorragia ao alvo antes de infligir danos. A Hemorragia adiciona danos ao alvo quando o Sram infligir danos diretos a ele."
+    }
+  },
+  {
+    "spellId": 4581,
+    "name": {
+      "fr": "Attaque mortelle",
+      "en": "Deadly Attack",
+      "es": "Ataque Mortal",
+      "pt": "Ataque Mortal"
+    },
+    "description": {
+      "fr": "Inflige des dommages importants à la cible. Les dommages sont plus élevés si la cible possède moins de la moitié de ses Points de vie. Ce sort génère du Point faible.",
+      "en": "Inflicts major damage on the target. The damage is greater if the target has less than half of its HP. This spell generates Weak Point.",
+      "es": "Inflige daños importantes al objetivo. Los daños son mayores si el objetivo tiene menos de la mitad de sus puntos de vida. Este hechizo genera Punto Débil.",
+      "pt": "Inflige danos consideráveis ao alvo. Os danos são maiores se o alvo tiver menos da metade dos seus Pontos de Vida. Este feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4583,
+    "name": {
+      "fr": "Attaque létale",
+      "en": "Lethal Attack",
+      "es": "Ataque Letal",
+      "pt": "Ataque Letal"
+    },
+    "description": {
+      "fr": "Si le sort tue la cible ennemie, le Sram regagne des PA et des PM. Ce sort génère du Point faible.",
+      "en": "If the spell kills the enemy target, the Sram regains AP and MP. This spell generates Weak Point.",
+      "es": "Si el hechizo mata al objetivo enemigo, el sram recupera PA y PM. Este hechizo genera Punto Débil.",
+      "pt": "Se o feitiço matar o alvo inimigo, o Sram recupera PA e PM. Este feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4584,
+    "name": {
+      "fr": "Kleptosram",
+      "en": "Kleptosram",
+      "es": "Cleptosram",
+      "pt": "Cleptosram"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau et génère davantage de Point Faible si la cible est de dos.",
+      "en": "Inflicts Water damage and generates more Weak Point if the target has its back turned.",
+      "es": "Inflige daños de agua y genera más Punto Débil si el objetivo está de espaldas.",
+      "pt": "Inflige danos de Água e gera mais Ponto Fraco se o alvo estiver de costas."
+    }
+  },
+  {
+    "spellId": 4585,
+    "name": {
+      "fr": "Attaque perfide",
+      "en": "Perfidious Attack",
+      "es": "Ataque Pérfido",
+      "pt": "Ataque Pérfido"
+    },
+    "description": {
+      "fr": "Inflige des dommages Eau élevés qui passent sous l'Armure. Une partie des dommages infligés est convertie en Armure sur la cible. Ce sort génère du Point Faible.",
+      "en": "Inflicts heavy Water damage that penetrates Armor. A portion of damage inflicted is converted into Armor on the target. This spell generates Weak Point.",
+      "es": "Inflige daños de agua elevados que atraviesan la armadura. Una parte de los daños infligidos se convierte en armadura en el objetivo. Este hechizo genera Punto Débil.",
+      "pt": "Inflige danos de Água elevados que atravessam a Armadura. Parte dos danos infligidos é convertida em Armadura para o alvo. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4586,
+    "name": {
+      "fr": "Mise à mort",
+      "en": "Execution",
+      "es": "Ejecución",
+      "pt": "Execução"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu et consomme le Point faible pour faire des dommages supplémentaires. En fonction du nombre de Point faible consommé, le Sram regagne des PA, des PM et des PW et applique de l'Hémorragie sur la cible avant d'avoir infligé les dommages. Hémorragie ajoute des dommages à la cible lorsque le Sram lui inflige des dommages directs.",
+      "en": "Inflicts Fire damage and consumes Weak Point to inflict additional damage. Depending on the amount of Weak Point consumed, the Sram regains AP, MP, and WP, and applies Hemorrhage on the target before inflicting damage. Hemorrhage inflicts additional damage on the target when the Sram inflicts direct damage on it.",
+      "es": "Inflige daños de fuego y consume el Punto Débil para ocasionar daños adicionales. Según la cantidad de Punto Débil consumido, el sram recupera PA, PM y PW además de aplicar Hemorragia al objetivo antes de infligirle daños. Hemorragia añade daños al objetivo cuando el sram le inflige daños directos.",
+      "pt": "Inflige danos de Fogo e consome o Ponto Fraco para provocar danos adicionais. Em função da quantidade de Ponto Fraco consumido, o Sram recupera PA, PM e PW, e aplica Hemorragia ao alvo antes de infligir danos. A Hemorragia adiciona danos ao alvo quando o Sram infligir danos diretos a ele."
+    }
+  },
+  {
+    "spellId": 4587,
+    "name": {
+      "fr": "Saignée mortelle",
+      "en": "Bled Dry",
+      "es": "Sangría Mortal",
+      "pt": "Sangria Mortal"
+    },
+    "description": {
+      "fr": "Inflige des dommages et applique de l'Hémorragie à la cible. Hémorragie ajoute des dommages à la cible lorsque le Sram lui inflige des dommages directs. Les dommages infligés par l'Hémorragie activée par ce sort sont convertis en vol de vie sur le Sram. Au début du prochain tour du Sram, il lance une réplique du sort sur la cible. Ce sort génère du Point Faible.",
+      "en": "Inflicts damage on and applies Hemorrhage to the target. Hemorrhage inflicts additional damage on the target when the Sram inflicts direct damage on it. The damage inflicted by the Hemorrhage activated by this spell is converted to health steal on the Sram. At the start of the Sram's next turn, they cast a replica of the spell on the target. This spell generates Weak Point.",
+      "es": "Inflige daños y aplica Hemorragia al objetivo. Hemorragia añade daños al objetivo cuando el sram le inflige daños directos. Los daños infligidos por la hemorragia activada por este hechizo se convierten en robo de vida en el sram. Al principio del próximo turno del sram, lanza una réplica del hechizo en el objetivo. Este hechizo genera Punto Débil.",
+      "pt": "Inflige danos e aplica Hemorragia ao alvo. A Hemorragia adiciona danos ao alvo quando o Sram infligir danos diretos a ele. Os danos infligidos pela Hemorragia ativada a partir desse feitiço são convertidos em roubo de vida para o Sram. No início do próximo turno do Sram, ele lança uma réplica do feitiço no alvo. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4588,
+    "name": {
+      "fr": "Premier Sang",
+      "en": "First Blood",
+      "es": "Primer Sangrado",
+      "pt": "Eliminação Sangrenta"
+    },
+    "description": {
+      "fr": "Premier sang applique un montant élevé d'Hémorragie aux ennemis qui n'en ont pas. Hémorragie ajoute des dommages à la cible lorsque le Sram lui inflige des dommages directs. Ce sort génère du Point Faible.",
+      "en": "First Blood applies a high amount of Hemorrhage to enemies who don't have any. Hemorrhage inflicts additional damage on the target when the Sram inflicts direct damage on it. This spell generates Weak Point.",
+      "es": "Primer Sangrado aplica una gran cantidad de Hemorragia a los enemigos que no la tienen. Hemorragia añade daños al objetivo cuando el sram le inflige daños directos. Este hechizo genera Punto Débil.",
+      "pt": "Eliminação Sangrenta aplica uma grande quantidade de Hemorragia aos inimigos que não a possuem. A Hemorragia adiciona danos ao alvo quando o Sram infligir danos diretos a ele. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4589,
+    "name": {
+      "fr": "Châtiment",
+      "en": "Punishment",
+      "es": "Castigo",
+      "pt": "Castigo"
+    },
+    "description": {
+      "fr": "Les dommages de ce sort sont plus élevés si le Sram a consommé du Point Faible dans son tour. Ce sort génère du Point Faible.",
+      "en": "This spell's damage is greater if the Sram consumed Weak Point during their turn. This spell generates Weak Point.",
+      "es": "Los daños de este hechizo son mayores si el sram ha consumido Punto Débil en su turno. Este hechizo genera Punto Débil.",
+      "pt": "Os danos deste feitiço são maiores se o Sram tiver consumido Ponto Fraco em seu turno. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4590,
+    "name": {
+      "fr": "Ouvrir les veines",
+      "en": "Cold Blood",
+      "es": "Abrir las Venas",
+      "pt": "Abrir as Veias"
+    },
+    "description": {
+      "fr": "En plus d'infliger des dommages, le Sram consomme l'Hémorragie de sa cible pour se soigner et gagner du Point faible. Ce sort génère du Point Faible.",
+      "en": "In addition to inflicting damage, the Sram consumes Hemorrhage on their target to heal themself and gain Weak Point. This spell generates Weak Point.",
+      "es": "Además de infligir daños, el sram consume la Hemorragia de su objetivo para curarse y ganar Punto Débil. Este hechizo genera Punto Débil.",
+      "pt": "Além de infligir danos, o Sram consome a Hemorragia do alvo para se curar e ganhar Ponto Fraco. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4592,
+    "name": {
+      "fr": "Traumatisme",
+      "en": "Trauma",
+      "es": "Traumatismo",
+      "pt": "Trauma"
+    },
+    "description": {
+      "fr": "Inflige des dommages Air toujours mêlée et consomme le Point faible pour faire des dommages supplémentaires. En fonction du nombre de Point faible consommé, le Sram regagne des PA, des PM et des PW et applique de l'Hémorragie sur la cible avant d'avoir infligé les dommages. Hémorragie ajoute des dommages à la cible lorsque le Sram lui inflige des dommages directs.",
+      "en": "Inflicts Air damage that is always melee and consumes Weak Point to inflict additional damage. Depending on the amount of Weak Point consumed, the Sram regains AP, MP, and WP, and applies Hemorrhage on the target before inflicting damage. Hemorrhage inflicts additional damage on the target when the Sram inflicts direct damage on it.",
+      "es": "Inflige daños de aire en melé y consume Punto Débil para ocasionar daños adicionales. Según la cantidad de Punto Débil consumido, el sram recupera PA, PM y PW además de aplicar Hemorragia al objetivo antes de infligirle daños. Hemorragia añade daños al objetivo cuando el sram le inflige daños directos.",
+      "pt": "Inflige danos de Ar sempre de curta distância e consome Ponto Fraco para causar danos adicionais. Em função da quantidade de Ponto Fraco consumido, o Sram recupera PA, PM e PW, e aplica Hemorragia ao alvo antes de infligir danos. A Hemorragia adiciona danos ao alvo quando o Sram infligir danos diretos a ele."
+    }
+  },
+  {
+    "spellId": 4593,
+    "name": {
+      "fr": "Coup Sournois",
+      "en": "Tricky Blow",
+      "es": "Golpe Solapado",
+      "pt": "Golpe Dissimulado"
+    },
+    "description": {
+      "fr": "Inflige des dommages Air aux ennemis et s'éloigne de la cible. À chaque lancer du sort, les dommages sont répétés sur les cibles précédentes. Ce sort génère du Point Faible. Le Sram gagne du Point faible supplémentaire pour chaque ennemi qui subit des dommages.",
+      "en": "Inflicts Air damage on enemies and moves the caster away from the target. Each time the spell is cast, the damage is repeated on the previous targets. This spell generates Weak Point. The Sram gains additional Weak Point for each enemy that suffers damage.",
+      "es": "Inflige daños de aire a los enemigos y se aleja del objetivo. Con cada lanzamiento del hechizo, los daños se repiten en los objetivos anteriores. Este hechizo genera Punto Débil. El sram gana Punto Débil adicional por cada enemigo que sufra daños.",
+      "pt": "Inflige danos de Ar aos inimigos e se afasta do alvo. Cada vez que o feitiço é lançado, os danos se repetem nos alvos anteriores. Esse feitiço gera Ponto Fraco. O Sram ganha Ponto Fraco extra a cada inimigo que sofre danos."
+    }
+  },
+  {
+    "spellId": 4594,
+    "name": {
+      "fr": "Coup pénétrant",
+      "en": "Forceful Blow",
+      "es": "Golpe Penetrante",
+      "pt": "Golpe Enérgico"
+    },
+    "description": {
+      "fr": "Inflige des dommages en ligne de 3 cases. Une ligne de dommages supplémentaires est appliquée sur l'Armure. Les dommages de ce sort sont toujours considérés mêlée, même si la cible est à plus de 2 cases. Ce sort génère du Point Faible.",
+      "en": "Inflicts damage in a 3-cell line. A line of additional damage is applied to Armor. This spell's damage is always considered melee damage, even if the target is more than 2 cells away. This spell generates Weak Point.",
+      "es": "Inflige daños en línea de 3 casillas. Una línea de daños adicionales se aplica a la armadura. Los daños de este hechizo se consideran siempre en melé, incluso si el objetivo está a más de 2 casillas. Este hechizo genera Punto Débil.",
+      "pt": "Inflige danos em linha de 3 células. Uma linha de danos adicionais é aplicada à Armadura. Os danos deste feitiço são sempre considerados de curta distância, mesmo que o alvo esteja a mais de 2 células de distância. Esse feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4595,
+    "name": {
+      "fr": "Fourberie",
+      "en": "Wily",
+      "es": "Estratagema",
+      "pt": "Perfídia"
+    },
+    "description": {
+      "fr": "Le Sram utilise les Ombres pour passer discrètement derrière sa cible. Ce sort génère du Point Faible.",
+      "en": "The Sram uses the Shadows to pass sneakily behind his target. This spell generates Weak Point.",
+      "es": "El sram utiliza las sombras para pasar discretamente detrás de su objetivo. Este hechizo genera Punto Débil.",
+      "pt": "O Sram usa as sombras para passar sorrateiramente por trás de seu alvo. Esst feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4596,
+    "name": {
+      "fr": "Effroi",
+      "en": "Fright",
+      "es": "Pavor",
+      "pt": "Terror"
+    },
+    "description": {
+      "fr": "Retourne la cible avant de lui infliger des dommages. Les dommages sont plus élevés si le Sram a consommé du Point Faible dans son tour. Ce sort génère du Point faible.",
+      "en": "Turns the target around before inflicting damage on it. The damage is greater if the Sram consumed Weak Point during their turn. This spell generates Weak Point.",
+      "es": "Voltea al objetivo antes de infligirle daños. Los daños son mayores si el sram ha consumido Punto Débil en su turno. Este hechizo genera Punto Débil.",
+      "pt": "Vira o alvo antes de infligir danos a ele. Os danos são mais fortes se o Sram consumiu Ponto Fraco em seu turno. Este feitiço gera Ponto Fraco."
+    }
+  },
+  {
+    "spellId": 4597,
+    "name": {
+      "fr": "Sournoiserie",
+      "en": "Deviousness",
+      "es": "Engaño",
+      "pt": "Engano"
+    },
+    "description": {
+      "fr": "Le Sram marque la cible pendant un tour. Si elle déclenche un piège du Sram, celui-ci se téléporte dans son dos.",
+      "en": "The Sram marks the target for 1 turn. If the target triggers one of the Sram's traps, the Sram teleports behind it.",
+      "es": "El sram marca al objetivo durante un turno. Si el objetivo activa una trampa del sram, el sram se teletransporta detrás del objetivo.",
+      "pt": "O Sram marca o alvo durante 1 turno. Se ele acionar uma Armadilha do Sram, este se teletransporta para suas costas."
+    }
+  },
+  {
+    "spellId": 4601,
+    "name": {
+      "fr": "Galopade",
+      "en": "Scram",
+      "es": "Galopada",
+      "pt": "Galopada"
+    },
+    "description": {
+      "fr": "Permet au Sram ou à un de ses alliés de gagner en mobilité.",
+      "en": "Allows the Sram or one of their allies to gain mobility.",
+      "es": "Permite al sram o a uno de sus aliados tener más movilidad.",
+      "pt": "Permite que o Sram ou um de seus aliados ganhe mobilidade."
+    }
+  },
+  {
+    "spellId": 4602,
+    "name": {
+      "fr": "Surineur",
+      "en": "Stabber",
+      "es": "Destripador",
+      "pt": "Apunhalador"
+    },
+    "description": {
+      "fr": "Au prochain tour, le Sram gagne des dommages infligés en coup critique et de dos, et devient stabilisé pour le tour en cours.",
+      "en": "On the next turn, the Sram gains damage inflicted as a critical hit and from behind, and becomes stabilized for the current turn.",
+      "es": "En el próximo turno, el sram gana daños infligidos en golpe crítico y por la espalda, además queda estabilizado durante el turno en curso.",
+      "pt": "No turno seguinte, o Sram recebe danos infligidos em golpe crítico e pelas costas, e fica estabilizado durante o turno atual."
+    }
+  },
+  {
+    "spellId": 6850,
+    "name": {
+      "fr": "Assassinat",
+      "en": "Assassination",
+      "es": "Asesinato",
+      "pt": "Assassinato"
+    },
+    "description": {
+      "fr": "Le Sram réduit les résistances de la cible pour la tuer. Si elle est encore en vie à la fin du tour, elle gagne des résistances pendant 1 tour.",
+      "en": "The Sram reduces the target's resistances in order to kill it. If it is still alive at end of turn, it gains resistances for 1 turn.",
+      "es": "El sram reduce las resistencias del objetivo para matarlo. El objetivo gana resistencias durante 1 turno si sigue con vida al final del turno.",
+      "pt": "O Sram reduz as resistências do alvo para matá-lo. Se o alvo ainda estiver vivo no fim do turno, ele ganha resistências durante 1 turno."
+    }
+  },
+  {
+    "spellId": 8479,
+    "name": {
+      "fr": "Peur",
+      "en": "Fear",
+      "es": "Miedo",
+      "pt": "Medo"
+    },
+    "description": {
+      "fr": "Un sort de poussée modulable. La cible face au Sram est poussée sur la case visée. Le Sram regagne 2 PA si la cible poussée est son Double.",
+      "en": "An adjustable pushback spell. The target facing the Sram is pushed onto the targeted cell. The Sram regains 2 AP if the pushed target is their Double.",
+      "es": "Un hechizo de empuje modulable. Se empuja al objetivo frente al sram hasta la casilla seleccionada. El sram recupera 2 PA si el objetivo empujado es su doble.",
+      "pt": "Um feitiço para dar um empurrão flexível. O alvo de frente para o Sram é empurrado para a célula visada. O Sram recupera 2 PA se o alvo empurrado for seu Dublê."
+    }
+  },
+  {
+    "spellId": 8481,
+    "name": {
+      "fr": "Entourloupe",
+      "en": "Dirty Trick",
+      "es": "Jugarreta",
+      "pt": "Truque Sujo"
+    },
+    "description": {
+      "fr": "Permet au Sram d'échanger de position avec son Double. La deuxième utilisation dans le même tour est gratuite.",
+      "en": "Allows the Sram to switch places with their Double. Using it a second time in the same turn is free.",
+      "es": "Permite al sram intercambiar de posición con su doble. La segunda utilización en el mismo turno es gratuita.",
+      "pt": "Permite que o Sram troque de posição com seu Dublê. A segunda utilização no mesmo turno é gratuita."
+    }
+  },
+  {
+    "spellId": 749,
+    "name": {
+      "fr": "Martel'heure",
+      "en": "Hammhour",
+      "es": "Martillhora",
+      "pt": "Martel'hora"
+    },
+    "description": {
+      "fr": "Inflige des dommages et retire des PA à la cible.",
+      "en": "Inflicts damage and reduces the target's AP.",
+      "es": "Inflige daños y retira PA al objetivo.",
+      "pt": "Inflige danos e retira PA do alvo."
+    }
+  },
+  {
+    "spellId": 750,
+    "name": {
+      "fr": "Perturbation",
+      "en": "Disruption",
+      "es": "Perturbación",
+      "pt": "Perturbação"
+    },
+    "description": {
+      "fr": "Inflige des dommages de zone sur 5 cases devant le Xélor.",
+      "en": "Inflicts area-of-effect damage over 5 cells in front of the Xelor.",
+      "es": "Inflige daños de zona en 5 casillas delante del xelor.",
+      "pt": "Inflige danos de zona a 5 células à frente do Xelor."
+    }
+  },
+  {
+    "spellId": 751,
+    "name": {
+      "fr": "Suspension",
+      "en": "Suspension",
+      "es": "Suspensión",
+      "pt": "Suspensão"
+    },
+    "description": {
+      "fr": "Ce sort stabilise le Xélor jusqu'à la fin de son tour tout en infligeant des dommages feu. Lancé sur le cadran, l'heure courante est bloquée et toute son avancée est sauvegardée dans un état. Au prochain lancé sur le cadran, l'état est consommé pour faire avancer l'heure courante d'un coup.",
+      "en": "This spell stabilizes the Xelor until the end of their turn while inflicting Fire damage. When cast on the dial, the current hour freezes, and all its forward movement is saved in a state. The next time it is cast on the dial, the state is consumed to move the current hour forward in one go.",
+      "es": "Este hechizo estabiliza al xelor hasta el final de su turno e inflige daños de fuego. Lanzado sobre la esfera, la hora actual se bloquea y todo su avance se guarda en un estado. Al siguiente lanzamiento sobre la esfera, el estado se consume para adelantar la hora actual de golpe.",
+      "pt": "Este feitiço estabiliza o Xelor até o fim do seu turno e inflige danos de fogo. Lançado sobre o quadrante, a hora atual é bloqueada e todo seu avanço é armazenado em um estado. No próximo lançamento sobre o quadrante, o estado é consumido para avançar a hora atual de uma só vez."
+    }
+  },
+  {
+    "spellId": 752,
+    "name": {
+      "fr": "Éclair obscur",
+      "en": "Dark Bolt",
+      "es": "Rayoscuro",
+      "pt": "Relâmpago Obscuro"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu sur la cible du sort. Puis, un rebond est effectué : des dommages sont infligés à un autre ennemi présent à proximité de la cible du sort.",
+      "en": "Inflicts Fire damage on the spell's target. Then a rebound happens and damage is inflicted on another enemy present near the spell's target.",
+      "es": "Inflige daños de fuego en el objetivo del hechizo. Luego, se efectúa un rebote: se infligen daños a otro enemigo presente cerca del objetivo del hechizo.",
+      "pt": "Inflige danos de fogo ao alvo do feitiço. Depois, há um ricochete: danos são infligidos a outro inimigo que estiver perto do alvo do feitiço."
+    }
+  },
+  {
+    "spellId": 753,
+    "name": {
+      "fr": "Poussière",
+      "en": "Dust",
+      "es": "Polvo",
+      "pt": "Poeira"
+    },
+    "description": {
+      "fr": "À chaque utilisation ce sort augmente sa portée minimale et sa portée maximale de lancer. Ce sort ne nécessite pas de ligne de vue : il peut donc être lancé au travers de n'importe quel obstacle pour infliger des dommages élevés.",
+      "en": "With each use, this spell increases its minimum and maximum casting ranges. This spell does not require a line of sight. It can therefore be cast through any obstacle to inflict great damage.",
+      "es": "Con cada utilización, este hechizo aumenta su alcance mínimo y su alcance máximo de lanzamiento. Este hechizo no necesita línea de visión: así que puede lanzarse a través de cualquier obstáculo para infligir daños elevados.",
+      "pt": "Toda vez que este feitiço é usado, seu alcance mínimo e alcance máximo de lançamento aumentam. Este feitiço não necessita de linha de visão: ele pode ser lançado através de qualquer obstáculo para infligir danos elevados."
+    }
+  },
+  {
+    "spellId": 754,
+    "name": {
+      "fr": "Aiguille",
+      "en": "Hand",
+      "es": "Aguja",
+      "pt": "Ponteiro"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu à distance. Le coût du sort est variable : il consomme tous les PA du lanceur, jusqu'à un maximum de 4. Si ce sort tue un combattant, le coût du sort est remboursé immédiatement.",
+      "en": "Inflicts Fire damage from a distance. The spell cost varies: It consumes all of the caster's AP, up to 4 AP. If this spell kills a fighter, the spell cost is reimbursed immediately.",
+      "es": "Inflige daños de fuego a distancia. El coste del hechizo es variable: consume todos los PA del lanzador hasta un máximo de 4. Si el hechizo mata a un luchador, el coste del hechizo se devuelve inmediatamente.",
+      "pt": "Inflige danos de fogo a distância. O custo do feitiço é variável: ele consome todos os PA do lançador, até um máximo de 4. Quando o feitiço mata um combatente, o custo do feitiço é devolvido imediatamente."
+    }
+  },
+  {
+    "spellId": 757,
+    "name": {
+      "fr": "Prémonition",
+      "en": "Premonition",
+      "es": "Premonición",
+      "pt": "Premonição"
+    },
+    "description": {
+      "fr": "Ce sort sauvegarde les PV de la cible. Au prochain tour du Xélor, les PV sont fixés à cette valeur, ce qui permet d'annuler les gains ou pertes de PV s'étant produits entre temps.",
+      "en": "This spell saves the target's HP. On the Xelor's next turn, the HP are set back to this value, thereby canceling any HP gains or losses that have happened in the meantime.",
+      "es": "Este hechizo guarda los PdV del objetivo. En el próximo turno del xelor, los PdV se fijan en este valor, lo que permite anular las ganancias o las pérdidas de PdV producidas mientras tanto.",
+      "pt": "Este feitiço salva os PV do alvo. No próximo turno do Xelor, os PV são fixados nesse valor, o que permite anular os ganhos ou perdas de PV que ocorreram nesse meio-tempo."
+    }
+  },
+  {
+    "spellId": 763,
+    "name": {
+      "fr": "Horloge",
+      "en": "Clock",
+      "es": "Reloj",
+      "pt": "Relógio"
+    },
+    "description": {
+      "fr": "Applique un état de dommages indirects. Lorsque le Xélor regagne 12 Points de Wakfu dans un combat, le prochain sort Horloge est deux fois plus puissant.",
+      "en": "Applies an indirect damage state. When the Xelor regains 12 Wakfu points in combat, the next Clock spell is twice as powerful.",
+      "es": "Aplica un estado de daños indirectos. Cuando el xelor recupera 12 PW en un combate, el próximo hechizo Reloj es el doble de fuerte.",
+      "pt": "Aplica um estado de danos indiretos. Quando o Xelor recupera 12 Pontos de Wakfu em um combate, o próximo feitiço Relógio fica duas vezes mais forte."
+    }
+  },
+  {
+    "spellId": 765,
+    "name": {
+      "fr": "Tempus fugit",
+      "en": "Tempus Fugit",
+      "es": "Tempus Fugit",
+      "pt": "Tempus Fugit"
+    },
+    "description": {
+      "fr": "La cible du sort est téléportée sur la case heure courante du cadran (6 cases maximum). Lancé sur le cadran, ce dernier est déplacé sur l'heure courante.",
+      "en": "The spell's target is teleported to the current hour cell on the dial (6 cells maximum). When cast on the dial, the dial is moved to the current hour.",
+      "es": "El objetivo del hechizo se teletransporta a la casilla de la hora actual de la esfera (6 casillas como máximo). Lanzado sobre la esfera, se desplaza a la hora actual.",
+      "pt": "O alvo do feitiço é teletransportado para a célula hora atual do quadrante (máximo de 6 células). Lançado sobre o quadrante, este é movido para a hora atual."
+    }
+  },
+  {
+    "spellId": 766,
+    "name": {
+      "fr": "Rouage",
+      "en": "Cog",
+      "es": "Rueda Dentada",
+      "pt": "Roda Dentada"
+    },
+    "description": {
+      "fr": "Invoque un Rouage. Cette invocation ne joue pas de tour. Lorsque le Xélor déplace des combattants, il génère des charges : en fonction de ces charges, le Rouage inflige des dommages autour de sa position lorsque le Xélor termine son tour.",
+      "en": "Summons a Cog. This summons does not play a turn. By moving fighters, the Xelor generates charges; based on the charges, the Cog deals damage around its position when the Xelor ends their turn.",
+      "es": "Invoca una rueda dentada. Esta invocación no juega turno. Cuando el xelor desplaza luchadores, genera cargas: en función de esas cargas, la rueda dentada causa daños alrededor de su posición cuando el xelor termina su turno.",
+      "pt": "Invoca uma Roda Dentada. Esta invocação não tem turno. Quando o Xelor desloca os combatentes, ele gera cargas: em função dessas cargas, a Roda Dentada inflige danos ao redor de sua posição quando o Xelor termina seu turno."
+    }
+  },
+  {
+    "spellId": 767,
+    "name": {
+      "fr": "Pointe-heure",
+      "en": "Underhand",
+      "es": "Hora Punta",
+      "pt": "Hora de Ponta"
+    },
+    "description": {
+      "fr": "La cible est téléportée deux cases en arrière.",
+      "en": "The target is teleported two cells back.",
+      "es": "El objetivo es teletransportado dos casillas hacia atrás.",
+      "pt": "O alvo é teletransportado duas células para trás."
+    }
+  },
+  {
+    "spellId": 771,
+    "name": {
+      "fr": "Retour spontané",
+      "en": "Spontaneous Return",
+      "es": "Regreso Espontáneo",
+      "pt": "Retorno Espontâneo"
+    },
+    "description": {
+      "fr": "Ce sort annule le dernier mouvement ayant eu lieu pendant le tour du Xélor. Qu'il s'agisse d'une poussée, attirance, téléportation ou échange de position, la dernière cible à avoir été déplacée retourne à sa position précédente.",
+      "en": "This spell cancels the last movement executed on the Xelor's turn. Whether from a pushback, attraction, teleportation, or position swap, the last target to have moved returns to its previous position.",
+      "es": "Este hechizo anula el último movimiento que se haya producido durante el turno del xelor. Ya sea empuje, atracción, teletransporte o intercambio de posición, el último objetivo desplazado vuelve a su posición anterior.",
+      "pt": "Este feitiço anula o último movimento que tiver acontecido no turno do Xelor. Quer se trate de empurrão, atração, teletransporte ou trocar de posição, o último alvo que tiver sido deslocado volta à sua posição anterior."
+    }
+  },
+  {
+    "spellId": 772,
+    "name": {
+      "fr": "Symétrie",
+      "en": "Symmetry",
+      "es": "Simetría",
+      "pt": "Simetria"
+    },
+    "description": {
+      "fr": "Ce sort permet au Xélor de se téléporter en symétrie par rapport à sa cible ou inversement selon l'heure courante. Si la case d'arrivée est occupée par un obstacle, alors le combattant échange de position avec celui-ci.",
+      "en": "This spell allows the Xelor to teleport symmetrically in relation to its target or vice versa, depending on the current hour. If the destination cell is occupied by an obstacle, the fighter switches places with it.",
+      "es": "Este hechizo permite al xelor teletransportarse simétricamente con respecto a su objetivo o al revés, dependiendo de la hora actual. Si la casilla de llegada está ocupada por un obstáculo, entonces el luchador cambia de posición con este.",
+      "pt": "Este feitiço permite que o Xelor se teletransporte simetricamente com relação ao seu alvo ou inversamente de acordo com a hora atual. Se a célula final estiver ocupada por um obstáculo, o combatente troca de lugar com ele."
+    }
+  },
+  {
+    "spellId": 775,
+    "name": {
+      "fr": "Ralentissement",
+      "en": "Slow Down",
+      "es": "Ralentización",
+      "pt": "Desaceleração"
+    },
+    "description": {
+      "fr": "Ce sort très peu coûteux augmente la Volonté du Xélor pendant un tour (capacité de résistance ainsi que de retrait) : ce sort est d'autant plus astucieux que le Xélor tente dans un second temps de retirer des PA à la cible.",
+      "en": "This very inexpensive spell boosts the Xelor's Force of Will for one turn (resistance and removal capacity). This spell is even craftier when the Xelor later attempts to remove AP from the target.",
+      "es": "Este hechizo poco costoso aumenta la voluntad del xelor durante un turno (capacidades de resistencia y de retirada): este hechizo es aún más ingenioso cuando el xelor trata de retirar PA por segunda vez al objetivo.",
+      "pt": "Este feitiço de baixo custo aumenta a Vontade do Xelor durante um turno (capacidade de resistência e de retirada): este feitiço é ainda mais astucioso quando o Xelor tenta retirar PA do alvo em um segundo momento."
+    }
+  },
+  {
+    "spellId": 776,
+    "name": {
+      "fr": "Contre la montre",
+      "en": "Against the Clock",
+      "es": "Contrarreloj",
+      "pt": "Contra o relógio"
+    },
+    "description": {
+      "fr": "À la fin du tour de la cible de ce sort, la cible est téléportée sur la case du début de son tour. Si la case est occupée par un obstacle, la cible du sort et l'obstacle échangent de position.",
+      "en": "At the end of this spell's target's turn, the target is teleported to their start-of-turn cell. If the cell is occupied by an obstacle, the target of the spell and the obstacle switch places.",
+      "es": "Al final del turno del objetivo de este hechizo, el objetivo se teletransporta a la casilla del principio de su turno. Si la casilla está ocupada por un obstáculo, el objetivo del hechizo y el obstáculo intercambian de posición.",
+      "pt": "No fim do turno do alvo deste feitiço, ele é teletransportado para a célula em que estava no começo do turno. Se a célula estiver ocupada por um obstáculo, o alvo do feitiço e o obstáculo trocam de lugar."
+    }
+  },
+  {
+    "spellId": 777,
+    "name": {
+      "fr": "Sinistro",
+      "en": "Sinistro",
+      "es": "Sinistro",
+      "pt": "Sinistro"
+    },
+    "description": {
+      "fr": "Invoque un Sinistro. Cette invocation ne joue pas de tour. Les combattants à proximité du Sinistro gagnent un PA.",
+      "en": "Summons a Sinistro. This summons does not play a turn. Fighters near the Sinistro gain one AP.",
+      "es": "Invoca un sinistro. Esta invocación no juega turno. Los combatientes cerca del sinistro ganan un PA.",
+      "pt": "Invoca um Sinistro. Esta invocação não tem turno. Os combatentes que estiverem perto do Sinistro ganham um PA."
+    }
+  },
+  {
+    "spellId": 783,
+    "name": {
+      "fr": "Sablier",
+      "en": "Sandglass",
+      "es": "Reloj de Arena",
+      "pt": "Ampulheta"
+    },
+    "description": {
+      "fr": "Applique un état de dommages indirects. Au début du tour de la cible du sort, le Xélor inflige des dommages en zone sur la cible et les ennemis au contact et déclenche les autres sabliers dans la zone d'effet.",
+      "en": "Applies an indirect damage state. At the start of the spell's target's turn, the Xelor inflicts damage in an area of effect on the target and adjacent enemies, and triggers other sandglasses in the area of effect.",
+      "es": "Aplica un estado de daños indirectos. Al principio del turno del objetivo del hechizo, el xelor inflige daños en zona al objetivo y los enemigos en contacto, y activa los demás relojes de arena en la zona de efecto.",
+      "pt": "Aplica um estado de danos indiretos. No começo do turno do alvo do feitiço, o Xelor inflige danos em zona no alvo e nos inimigos em contato, além de ativar as outras ampulhetas na zona de efeito."
+    }
+  },
+  {
+    "spellId": 1417,
+    "name": {
+      "fr": "Désynchronisation",
+      "en": "Desynchronization",
+      "es": "Desincronización",
+      "pt": "Dessincronização"
+    },
+    "description": {
+      "fr": "Retire des PA dans une zone, tout en infligeant des dommages eau. Lancé sur le cadran, l'heure courante avance de six heures.",
+      "en": "Reduces AP in an area of effect while inflicting Water damage. Cast on the dial, the current hour advances by 6 hours.",
+      "es": "Retira PA en una zona e inflige daños de agua. Lanzado sobre la esfera, la hora actual avanza seis horas.",
+      "pt": "Retira PA em uma zona enquanto inflige danos de água. Quando é lançado no Quadrante, a Hora Atual avança 6 horas."
+    }
+  },
+  {
+    "spellId": 1418,
+    "name": {
+      "fr": "Paradoxe",
+      "en": "Paradox",
+      "es": "Paradoja",
+      "pt": "Paradoxo"
+    },
+    "description": {
+      "fr": "Téléporte symétriquement les cibles dans la zone du sort, par rapport à la case ciblée.\\nUn échange de position entre les cibles se produit si elles sont opposées symétriquement.",
+      "en": "Teleports the targets within the spell's area of effect symmetrically in relation to the targeted cell.\\nTargets that are symmetrically opposite to each other switch places.",
+      "es": "Teletransporta simétricamente a los objetivos en la zona del hechizo, con respecto a la casilla seleccionada.\\nSe produce un intercambio de posición entre los objetivos si estos están opuestos simétricamente.",
+      "pt": "Teletransporta os alvos presentes na zona do feitiço simetricamente com relação ao alvo visado.\\nOs alvos que estiverem simetricamente opostos trocam de lugar."
+    }
+  },
+  {
+    "spellId": 2839,
+    "name": {
+      "fr": "Dévouement",
+      "en": "Devotion",
+      "es": "Devoción",
+      "pt": "Devoção"
+    },
+    "description": {
+      "fr": "Augmente les PA sur un allié pendant un tour.",
+      "en": "Increases AP on an ally for one turn.",
+      "es": "Aumenta los PA en un aliado durante un turno.",
+      "pt": "Aumenta os PA de um aliado por um turno."
+    }
+  },
+  {
+    "spellId": 5344,
+    "name": {
+      "fr": "Régulateur",
+      "en": "Regulator",
+      "es": "Regulador",
+      "pt": "Regulador"
+    },
+    "description": {
+      "fr": "Invoque un Régulateur. Le Régulateur redirige vers lui les dommages que reçoivent les autres invocations du Xélor (Cadran, Sinistro, Rouage) vers lui.",
+      "en": "Summons a Regulator. The Regulator redirects the damage taken by the Xelor's other summons (Dial, Sinistro, and Cog) toward itself.",
+      "es": "Invoca un regulador. El regulador redirige hacia él los daños que reciben las otras invocaciones del xelor (esfera, sinistro, rueda dentada).",
+      "pt": "Invoca um Regulador. O Regulador redireciona para ele os danos recebidos pelas outras invocações do Xelor (Quadrante, Sinistro, Roda Dentada)."
+    }
+  },
+  {
+    "spellId": 2041,
+    "name": {
+      "fr": "Pile ou face",
+      "en": "Heads or Tails",
+      "es": "Cara o Cruz",
+      "pt": "Cara ou Coroa"
+    },
+    "description": {
+      "fr": "Lancé sur un ennemi, ce sort lui inflige des dommages et régénère l'Ecaflip à une hauteur des PV perdus par la cible. Lancé sur un allié, ce sort soigne à la fois l'allié et l'Ecaflip.",
+      "en": "Cast on an enemy, this spell deals damage and heals the Ecaflip for an amount equal to the HP lost by the target. Cast on an ally, the spell heals the ally and the Ecaflip.",
+      "es": "Lanzado sobre un enemigo, este hechizo le inflige daños y regenera al zurcarák a la altura de los PdV que pierde el objetivo. Lanzado sobre un aliado, este hechizo cura al mismo tiempo al aliado y al zurcarák.",
+      "pt": "Quando lançado em um inimigo, este feitiço inflige danos e regenera o Ecaflip na proporção dos PV perdidos pelo alvo. Quando lançado em um aliado, este feitiço cura o aliado e o Ecaflip."
+    }
+  },
+  {
+    "spellId": 2042,
+    "name": {
+      "fr": "Dé six",
+      "en": "D-Six",
+      "es": "Dado Seis",
+      "pt": "Dado Seis"
+    },
+    "description": {
+      "fr": "La prochaine fois que ce sort est lancé, il coûte moins cher.",
+      "en": "The next time this spell is cast, its cost is lower.",
+      "es": "La próxima vez que se lance el hechizo costará menos.",
+      "pt": "Da próxima vez que este feitiço for lançado, ele custará menos."
+    }
+  },
+  {
+    "spellId": 2043,
+    "name": {
+      "fr": "Tout ou rien",
+      "en": "All or Nothing",
+      "es": "Todo o Nada",
+      "pt": "Tudo ou Nada"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages élevés. En revanche, l'Ecaflip a une chance sur deux de se blesser lui-même. Moins les PV (en %) de l'Ecaflip sont élevés par rapport à sa cible, moins il a de chance de subir les dommages.",
+      "en": "This spell inflicts heavy damage. However, the Ecaflip has a 50% chance of getting hurt themself. The lower the Ecaflip's HP (as a %) is in relation to their target, the lower their chance of suffering damage.",
+      "es": "Este hechizo causa daños elevados. En cambio, el zurcarák tiene un 50% de probabilidades de herirse a sí mismo. Cuanto menos elevados sean los PdV (en %) del zurcarák con respecto a su objetivo, menores son sus probabilidades de sufrir los daños.",
+      "pt": "Este feitiço inflige danos elevados. Por outro lado, o Ecaflip tem 50% de chance de ferir a si próprio. Quanto menores forem os PV (em %) do Ecaflip em relação ao alvo, menores serão as chances de sofrer danos."
+    }
+  },
+  {
+    "spellId": 2044,
+    "name": {
+      "fr": "Trois cartes",
+      "en": "Three Cards",
+      "es": "Tres Cartas",
+      "pt": "Três Cartas"
+    },
+    "description": {
+      "fr": "Inflige des dommages terre et soigne les alliés en ligne. L'Ecaflip utilise les cartes de sa main pour augmenter les effets du sort avant de les défausser.",
+      "en": "Inflicts Earth damage and heals allies in a straight line. The Ecaflip uses the cards in their hand to increase the spell's effects before discarding them.",
+      "es": "Inflige daños de tierra y cura a los aliados en línea. El zurcarák usa las cartas de su mano para aumentar los efectos del hechizo antes de descartarlas.",
+      "pt": "Inflige danos de terra e cura aliados em linha. O Ecaflip usa as cartas da sua mão para aumentar os efeitos do feitiço antes de descartá-las."
+    }
+  },
+  {
+    "spellId": 2045,
+    "name": {
+      "fr": "Craps",
+      "en": "Craps",
+      "es": "Craps",
+      "pt": "Craps"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu aux ennemis et applique de la Préparation à l'Ecaflip. Sur un allié, la cible reçoit également de la Préparation. La Préparation augmente les dommages du prochain sort.",
+      "en": "Inflicts Fire damage on enemies and applies Preparation on the Ecaflip. On an ally, the target also receives Preparation. Preparation increases the damage of the next spell.",
+      "es": "Inflige daños de fuego a los enemigos y aplica Preparación al zurcarák. En un aliado, el objetivo también recibe Preparación. La Preparación aumenta los daños del próximo hechizo.",
+      "pt": "Inflige danos de fogo aos inimigos e aplica a Preparação ao Ecaflip. Em um aliado, o alvo também recebe a Preparação. Preparação aumenta os danos do próximo feitiço."
+    }
+  },
+  {
+    "spellId": 2046,
+    "name": {
+      "fr": "Feulement",
+      "en": "Yowling",
+      "es": "Bufido",
+      "pt": "Rugido Felino"
+    },
+    "description": {
+      "fr": "Ce sort de zone permet à l'Ecaflip de regagner de la vie et de l'armure en fonction du nombre d'adversaires dans la zone d'effet.",
+      "en": "With this AoE spell, the Ecaflip can regain health and armor based on the number of opponents in the area of effect.",
+      "es": "Con este hechizo de zona, el zurcarák recupera vida y armadura según el número de adversarios en la zona de efecto.",
+      "pt": "Este feitiço de zona permite ao Ecaflip recuperar vida e armadura em função do número de adversários na zona de efeito."
+    }
+  },
+  {
+    "spellId": 2047,
+    "name": {
+      "fr": "All in",
+      "en": "All In",
+      "es": "All In",
+      "pt": "All In"
+    },
+    "description": {
+      "fr": "Ce sort utilise les PA restants de l'Ecaflip (max 10). Plus il met de PA en jeu, plus il inflige des dommages. L'Ecaflip a ensuite 50 % de chances de récupérer la totalité des PA utilisés par ce sort.",
+      "en": "This spell uses the Ecaflip's remaining AP (up to 10). The more AP used, the more damage it deals. The Ecaflip then has a 50% chance to recover all AP used by this spell.",
+      "es": "Este hechizo utiliza los PA que le queden al zurcarák (máx. 10). Cuantos más PA consuma, más daños causa. Luego, el zurcarák tiene un 50% de probabilidad de recuperar todos los PA usados con este hechizo.",
+      "pt": "Este feitiço utiliza os PA restantes do Ecaflip (máx.: 10). Quanto mais PA ele coloca em jogo, mais danos ele inflige. O Ecaflip passa a ter 50% de chance de recuperar a totalidade dos PA utilizados por este feitiço."
+    }
+  },
+  {
+    "spellId": 2048,
+    "name": {
+      "fr": "Roulette à dés",
+      "en": "Dice Roulette",
+      "es": "Ruleta de Dados",
+      "pt": "Roleta de Dados"
+    },
+    "description": {
+      "fr": "Ce sort de zone se produit autour de l'Ecaflip. Il inflige des dommages aux ennemis et soigne les alliés.",
+      "en": "This area-of-effect spell is cast around the Ecaflip. It inflicts damage on enemies and heals allies.",
+      "es": "Este hechizo de zona tiene lugar alrededor del zurcarák. Causa daños a los enemigos y cura a los aliados.",
+      "pt": "Este feitiço de zona acontece ao redor do Ecaflip. Inflige danos aos inimigos e cura os aliados."
+    }
+  },
+  {
+    "spellId": 2049,
+    "name": {
+      "fr": "Bataille",
+      "en": "Battle",
+      "es": "Batalla",
+      "pt": "Batalha Numérica"
+    },
+    "description": {
+      "fr": "L'Ecaflip joue à la bataille avec sa cible. En cas de victoire, l'Ecaflip gagne des PA et des Coups critiques. En cas de défaite, c'est l'inverse : il perd des PA courants. Plus les PV (en %) de l'Ecaflip sont élevés par rapport à sa cible, plus il a de chance de gagner la bataille.",
+      "en": "The Ecaflip plays battle with their target. If the Ecaflip wins, they gain AP and Critical Hit. If they lose, the opposite happens: They lose their current AP. The higher the Ecaflip's HP (as a %) is in relation to their target, the greater their chance of winning the battle.",
+      "es": "El zurcarák juega a la batalla con su objetivo. En caso de victoria, el zurcarák gana PA y golpes críticos. En caso de derrota, es al revés: pierde PA actuales. Cuanto más elevados sean los PdV (en %) del zurcarák con respecto a su objetivo, mayores son sus probabilidades de ganar la batalla.",
+      "pt": "O Ecaflip joga Batalha Numérica com seu alvo. Em caso de vitória, o Ecaflip ganha PA e golpes críticos. Se perder, é o contrário: ele perderá PA. Quanto maiores forem os PV (em %) do Ecaflip em relação ao alvo, maiores serão as chances de ganhar a batalha."
+    }
+  },
+  {
+    "spellId": 2050,
+    "name": {
+      "fr": "Dé du chateux",
+      "en": "Loaded Dice",
+      "es": "Dado Gatuno",
+      "pt": "Dados Adulterados"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Si l'Ecaflip tue un combattant avec, il gagne 2 PA. Plus la veine de l'Ecaflip est élevée, plus les chances d'infliger une deuxième ligne de dommages sont élevées.",
+      "en": "Inflicts Fire damage. If the Ecaflip kills a fighter with it, they gain 2 AP. The higher the Ecaflip's Lucky Day, the greater the chance of inflicting a second damage line.",
+      "es": "Inflige daños de fuego. Si el zurcarák mata a un luchador con estos, gana 2 PA. Cuanto más elevada sea la racha del zurcarák, más aumenta la probabilidad de infligir una segunda línea de daños.",
+      "pt": "Inflige danos de Fogo. Se o Ecaflip derrotar um combatente com este feitiço, ele ganha 2 PA. Quanto maior a Ventura do Ecaflip, maiores são as chances de infligir uma segunda linha de danos."
+    }
+  },
+  {
+    "spellId": 2060,
+    "name": {
+      "fr": "Quitte ou double",
+      "en": "Double or Quits",
+      "es": "Doble o Nada",
+      "pt": "Dobro ou Nada"
+    },
+    "description": {
+      "fr": "Ce sort permet de piocher trois cartes de tarot de la pioche puis les jouer immédiatement sur l'Ecaflip.",
+      "en": "This spell draws three tarot cards from the draw pile and immediately plays them on the Ecaflip.",
+      "es": "Este hechizo permite robar tres cartas de tarot del mazo y jugarlas inmediatamente sobre el zurcarák.",
+      "pt": "Este feitiço permite comprar 3 cartas de tarô e depois jogá-las imediatamente no Ecaflip."
+    }
+  },
+  {
+    "spellId": 2061,
+    "name": {
+      "fr": "Félintuition",
+      "en": "Felintuition",
+      "es": "Felintuición",
+      "pt": "Felintuição"
+    },
+    "description": {
+      "fr": "Pose un glyphe qui reste 1 tour sur le terrain. Le glyphe s'active lorsqu'un combattant allié ou ennemi commence son tour dessus.",
+      "en": "Places a glyph that stays on the field for 1 turn. The glyph activates when an allied or enemy fighter starts their turn on it.",
+      "es": "Pone un glifo que permanece 1 turno en el terreno. El glifo se activa cuando un luchador aliado o enemigo empieza su turno sobre él.",
+      "pt": "Coloca um glifo que permanece 1 turno no terreno. O glifo é ativado quando um combatente aliado ou inimigo começa seu turno em cima dele."
+    }
+  },
+  {
+    "spellId": 2065,
+    "name": {
+      "fr": "Langue rapeuse",
+      "en": "Rough Tongue",
+      "es": "Lengua Raspadora",
+      "pt": "Língua Áspera"
+    },
+    "description": {
+      "fr": "Attire la cible vers le lanceur du sort. Soigne les alliés, inflige des dommages aux ennemis.",
+      "en": "Draws the target toward the caster. Heals allies and inflicts damage on enemies.",
+      "es": "Atrae al objetivo hacia el lanzador del hechizo. Cura a los aliados, causa daños a los enemigos.",
+      "pt": "Atrai o alvo em direção ao lançador do feitiço. Cura os aliados, inflige danos aos inimigos."
+    }
+  },
+  {
+    "spellId": 2066,
+    "name": {
+      "fr": "Lacérations",
+      "en": "Up to Scratch",
+      "es": "Laceraciones",
+      "pt": "Lacerações"
+    },
+    "description": {
+      "fr": "L'Ecaflip se téléporte à plusieurs cases de distance tout en faisant des dommages sur son passage. Si des alliés sont sur son chemin, ils sont soignés.",
+      "en": "The Ecaflip teleports several cells away, dealing damage along the way. If any allies are in their path, those allies are healed.",
+      "es": "El zurcarák se teletransporta varias casillas de distancia, causando daños a su paso. Si hay aliados en su camino, los cura.",
+      "pt": "O Ecaflip se teletransporta a várias células de distância infligindo danos por onde passa. Se houver aliados no caminho, eles são curados."
+    }
+  },
+  {
+    "spellId": 2067,
+    "name": {
+      "fr": "Capucine",
+      "en": "Fleahopper",
+      "es": "Pulga Arcito",
+      "pt": "Pulgarzinho"
+    },
+    "description": {
+      "fr": "Les dommages de ce sort sont effectués sous forme de rebonds. Si le sort cible un ennemi A, le sort rebondit sur un ennemi B à 3 cases ou moins de l'ennemi A. Puis, le sort rebondit sur un ennemi C à 3 cases ou moins du combattant B. Le fonctionnement est le même si le sort est lancé sur un allié, mais là, le sort fera des rebonds de soin.",
+      "en": "The damage from this spell is inflicted as rebounds. If the spell targets an enemy A, the spell rebounds to an enemy B within 3 cells or less from enemy A. It then rebounds again to an enemy C within 3 cells or less from fighter B. It works the same way if the spell is cast on an ally, but then the spell will do a chain heal.",
+      "es": "Los daños de este hechizo se efectúan en forma de rebote. Si el hechizo se lanza sobre un enemigo A, rebota a un enemigo B a 3 casillas o menos de distancia del A. Luego, rebota a un enemigo C a 3 casillas o menos de distancia del B. Su funcionamiento es el mismo si se lanza sobre un aliado, salvo que el hechizo cura con los rebotes.",
+      "pt": "Os danos deste feitiço são efetuados sob a forma de ricochetes. Se o feitiço visar um inimigo A, ele ricocheteará em um inimigo B que estiver a até 3 células do inimigo A. Depois, o feitiço ricocheteará em um inimigo C a até 3 células do combatente B. O funcionamento será o mesmo se o feitiço for lançado em um aliado, mas, neste caso, o feitiço fará ricochetes de cura."
+    }
+  },
+  {
+    "spellId": 2072,
+    "name": {
+      "fr": "Bas les pattes",
+      "en": "Paws Off",
+      "es": "¡Zarpas Quietas!",
+      "pt": "Tira a Pata"
+    },
+    "description": {
+      "fr": "Ce sort pousse la cible d'une case par sort eau lancé au préalable dans le tour.",
+      "en": "This spell pushes the target one cell per water spell previously cast in the turn.",
+      "es": "Este hechizo empuja al objetivo una casilla por cada hechizo de agua lanzado anteriormente en ese mismo turno.",
+      "pt": "Este feitiço empurra o alvo por uma célula por feitiço de água lançado anteriormente no turno."
+    }
+  },
+  {
+    "spellId": 2073,
+    "name": {
+      "fr": "Pupuce",
+      "en": "Fleeflee",
+      "es": "Pulguita",
+      "pt": "Pupulga"
+    },
+    "description": {
+      "fr": "Ce sort très puissant a un effet différent selon la cible sur laquelle il est lancé : sur un allié, il va soigner, augmenter les Points de Mouvement (PM) et les Points de Wakfu (PW). En revanche, sur un ennemi, le sort va réduire ses PW et sa vie.",
+      "en": "This super-powerful spell has a different effect depending on the target it is cast on: on an ally, it provides healing and increases MP and WP. On an enemy, however, the spell reduces their WP and health.",
+      "es": "Este potente hechizo tiene un efecto distinto dependiendo del objetivo al que se le lance: en un aliado, lo cura, aumenta los puntos de movimiento (PM) y los puntos de Wakfu (PW). En cambio, en un enemigo, el hechizo reducirá sus PW y su vida.",
+      "pt": "Este poderosíssimo feitiço tem um efeito diferente de acordo com o alvo no qual ele é lançado: em um aliado, ele cura, aumenta os Pontos de Movimento (PM) e os Pontos de Wakfu (PW). Por outro lado, em um inimigo, o feitiço reduz seus PW e sua vida."
+    }
+  },
+  {
+    "spellId": 2075,
+    "name": {
+      "fr": "Topkaj",
+      "en": "Topkaj",
+      "es": "Topkaj",
+      "pt": "Topkaj"
+    },
+    "description": {
+      "fr": "Ce sort, s'il est lancé sur un allié K.O., permet de le réanimer (un allié ne peut être réanimé qu'une fois par combat) et lui donner des PM. Si le sort est lancé sur l'Ecaflip, celui-ci donne un bonus de chances aux coups critiques et des PM pendant 2 tours à lui et ses alliés à proximité.",
+      "en": "If cast on a KO'd ally, this spell revives the ally (an ally can only be revived once per fight) and gives them MP. If cast on the Ecaflip, it gives a bonus to critical hit rate and boosts MP for 2 turns, applied to the Ecaflip and their nearby allies.",
+      "es": "Si este hechizo se lanza a un aliado K.O., lo reanima (cada aliado solo se puede reanimar una única vez por combate) y le da PM. Si el hechizo se lanza al zurcarák, otorga un bonus a la probabilidad de golpe crítico y PM durante 2 turnos al zurcarák y sus aliados cercanos.",
+      "pt": "Este feitiço, ao ser lançado em um aliado derrotado, permite que ele seja reanimado (um aliado só pode ser reanimado uma vez por combate) e dá PM a ele. Se o feitiço for lançado no Ecaflip, ele concede um bônus de chance de golpes críticos e PM durante 2 turnos para ele e para seus aliados próximos."
+    }
+  },
+  {
+    "spellId": 2078,
+    "name": {
+      "fr": "Jeton de vie",
+      "en": "Life Token",
+      "es": "Ficha de Vida",
+      "pt": "Ficha de Vida"
+    },
+    "description": {
+      "fr": "La cible de ce sort gagne un jeton de vie. Elle pourra survivre à une attaque mortelle, une fois par tour. Le jeton dure un tour : s'il n'est pas consommé, au tour suivant de l'Ecaflip, ce dernier le récupère et fixe la valeur de ses propres PV à la valeur des PV de la cible du sort.",
+      "en": "This spell's target gains a life token. The target can survive a lethal attack once per turn. The token lasts for one turn: if not consumed, on the Ecaflip's next turn, the Ecaflip recovers it and sets their HP to be the same as the spell target's HP.",
+      "es": "El objetivo de este hechizo gana una ficha de vida. Una vez por turno, podrá sobrevivir a un ataque mortal. La ficha dura un turno: si no se consume, al siguiente turno del zurcarák este la recupera y fija el valor de sus propios PdV al valor de PdV del objetivo del hechizo.",
+      "pt": "O alvo deste feitiço ganha uma Ficha de Vida. Ele poderá sobreviver a um ataque mortal, uma vez por turno. A ficha dura um turno: se não for consumida, no turno seguinte do Ecaflip, ele a pegará e fixará o valor de seus próprios PV ao valor dos PV do alvo do feitiço."
+    }
+  },
+  {
+    "spellId": 2079,
+    "name": {
+      "fr": "Coup du sort",
+      "en": "Spell Strike",
+      "es": "Mala Suerte",
+      "pt": "Feitiço do Destino"
+    },
+    "description": {
+      "fr": "Ce sort joue avec les cartes en main.",
+      "en": "This spell uses the cards in hand.",
+      "es": "Este hechizo juega con las cartas en mano.",
+      "pt": "Este feitiço joga com as cartas da mão."
+    }
+  },
+  {
+    "spellId": 7225,
+    "name": {
+      "fr": "Trèfle",
+      "en": "Clubs",
+      "es": "Trébol",
+      "pt": "Paus"
+    },
+    "description": {
+      "fr": "Ce sort peut aider un allié en lui conférant divers bonus ou affaiblir un ennemi en le rendant plus vulnérable pendant 2 tours.",
+      "en": "This spell can help an ally by granting various bonuses or weaken an enemy by making them more vulnerable for 2 turns.",
+      "es": "Este hechizo puede ayudar a un aliado dándole varios bonus o debilitar a un enemigo volviéndolo más vulnerable durante 2 turnos.",
+      "pt": "Este feitiço pode ajudar um aliado dando a ele vários bônus ou pode enfraquecer um inimigo deixando-o mais vulnerável durante 2 turnos."
+    }
+  },
+  {
+    "spellId": 623,
+    "name": {
+      "fr": "Colli-mateur",
+      "en": "Cross-Airs",
+      "es": "Colimador",
+      "pt": "Coli-mador"
+    },
+    "description": {
+      "fr": "Inflige des dommages air sur la cible et la rend sensible aux collisions. Pour provoquer une collision, il faut pousser un obstacle contre un autre.",
+      "en": "Inflicts Air damage on the target and makes the target vulnerable to collisions. To cause a collision, you must push one obstacle against another one.",
+      "es": "Inflige daños de aire en el objetivo y lo vuelve sensible a las colisiones. Para provocar una colisión, hay que empujar un obstáculo contra otro.",
+      "pt": "Inflige danos de ar ao alvo e o torna vulnerável às colisões. Para provocar uma colisão, é preciso empurrar um obstáculo contra outro."
+    }
+  },
+  {
+    "spellId": 625,
+    "name": {
+      "fr": "Reconstitution",
+      "en": "Regeneration",
+      "es": "Reconstitución",
+      "pt": "Reconstituição"
+    },
+    "description": {
+      "fr": "Reconstitution peut cibler à travers les obstacles. Il soigne l'allié ciblé et augmente les soins réalisés par l'Eniripsa pour le reste de son tour.",
+      "en": "This spell can reach targets through obstacles. It heals the targeted ally and increases healing done by the Eniripsa for the rest of their turn.",
+      "es": "Reconstitución puede seleccionar un objetivo a través de los obstáculos. Cura al objetivo aliado y aumenta las curas realizadas por el aniripsa durante el resto de su turno.",
+      "pt": "Reconstituição pode visar através dos obstáculos. Cura o aliado visado e aumenta as curas realizadas pelo Eniripsa pelo resto do turno."
+    }
+  },
+  {
+    "spellId": 627,
+    "name": {
+      "fr": "Déphasage",
+      "en": "Transcendence",
+      "es": "Desfase",
+      "pt": "Defasagem"
+    },
+    "description": {
+      "fr": "La cible perd la totalité de ses PA, mais devient insensible aux dégâts pendant un tour.",
+      "en": "The target loses all AP but becomes immune to damage for one turn.",
+      "es": "El objetivo pierde la totalidad de sus PA, pero se vuelve insensible a los daños durante un turno.",
+      "pt": "O alvo perde todos os seus PA, mas torna-se imune aos danos por um turno."
+    }
+  },
+  {
+    "spellId": 630,
+    "name": {
+      "fr": "Anatomie",
+      "en": "Anatomy",
+      "es": "Anatomía",
+      "pt": "Anatomia"
+    },
+    "description": {
+      "fr": "Inflige des dommages air qui passent sous l'Armure. Ces dommages sont plus élevés si la cible possède beaucoup de PV.",
+      "en": "Inflicts Air damage that penetrates Armor. This damage is greater if the target has high HP.",
+      "es": "Inflige daños de aire que atraviesan la armadura. Estos daños son mayores si el objetivo tiene muchos PdV.",
+      "pt": "Inflige danos de ar que atravessam a armadura. Esses danos serão maiores se o alvo tiver muitos PV."
+    }
+  },
+  {
+    "spellId": 636,
+    "name": {
+      "fr": "Corro-soin",
+      "en": "Corrosive Heal",
+      "es": "Corrosana",
+      "pt": "Corro-são"
+    },
+    "description": {
+      "fr": "La cible devient marquée : les trois prochains sorts de dommages directs et monocible qu'elle subit sont renforcés. De plus, une partie des dommages infligés à la cible est redistribuée sous forme de soin autour de la cible.",
+      "en": "The target becomes marked: boosts the next three direct, single-target damage spells suffered by the target. Also, a portion of damage inflicted on the target is redistributed in the form of healing around the target.",
+      "es": "El objetivo queda marcado: se refuerza los tres próximos hechizos de daños directos y objetivo único que sufre. Además, una parte de los daños infligidos al objetivo se redistribuyen en forma de cura alrededor del objetivo.",
+      "pt": "O alvo fica marcado: os três próximos feitiços de danos diretos e de alvo único que ele sofrer serão reforçados. Além disso, uma parte dos danos infligidos ao alvo será redistribuída em forma de cura em volta do alvo."
+    }
+  },
+  {
+    "spellId": 638,
+    "name": {
+      "fr": "Feu gardien",
+      "en": "Guardian Fire",
+      "es": "Fuego Guardián",
+      "pt": "Fogo Guardião"
+    },
+    "description": {
+      "fr": "Soigne un allié et lui applique une marque : si l'allié perd des PV et tombe sous 50 % de ses PV max, il est soigné une seconde fois par l'Eniripsa.",
+      "en": "Heals an ally and applies a mark to the ally: If the ally loses HP and falls below 50% of their max HP, they are healed by the Eniripsa a second time.",
+      "es": "Cura a un aliado y le aplica una marca: si el aliado pierde PdV y cae por debajo del 50% de sus PdV máx., el aniripsa lo cura una segunda vez.",
+      "pt": "Cura um aliado e aplica uma marca: se o aliado perder PV e ficar com menos de 50% de seus PV máx., ele será curado uma segunda vez pelo Eniripsa."
+    }
+  },
+  {
+    "spellId": 645,
+    "name": {
+      "fr": "Explo-soin",
+      "en": "Heal-splosion",
+      "es": "Explosana",
+      "pt": "Explo-são"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu aux ennemis en zone. Pose une Marque itsade : l'Eniripsa inflige des dommages feu autour de la cible lorsqu'elle passe KO.",
+      "en": "Inflicts Fire damage on enemies in an area of effect. Places a Sadist Mark: The Eniripsa deals Fire damage around the target when the target is KO'd.",
+      "es": "Inflige daños de fuego a los enemigos en zona. Pone una Marca Sdesade: el aniripsa inflige daños de fuego alrededor del objetivo cuando este pasa a K.O.",
+      "pt": "Inflige danos de fogo aos inimigos em zona. Coloca uma Marca Dessade: o Eniripsa inflige danos de fogo em volta do alvo quando ele é nocauteado."
+    }
+  },
+  {
+    "spellId": 779,
+    "name": {
+      "fr": "Mot soignant",
+      "en": "Healing Word",
+      "es": "Palabra Sanadora",
+      "pt": "Palavra Curativa"
+    },
+    "description": {
+      "fr": "Soigne l'allié ciblé et lui offre un bonus de portée pendant un tour. Chaque point de portée permet d'augmenter la portée maximale des sorts à portée modifiable.",
+      "en": "Heals the targeted ally and gives them a Range bonus for one turn. Each Range point increases the max range of Range-modifiable spells.",
+      "es": "Cura al aliado objetivo y le ofrece un bonus de alcance durante un turno. Cada punto de alcance permite aumentar el alcance máximo de los hechizos de alcance modificable.",
+      "pt": "Cura o aliado visado e concede a ele um bônus de alcance durante um turno. Cada ponto de alcance permite amentar o alcance máximo dos feitiços de alcance modificável."
+    }
+  },
+  {
+    "spellId": 780,
+    "name": {
+      "fr": "Revitalisation",
+      "en": "Revitalization",
+      "es": "Revitalización",
+      "pt": "Revitalização"
+    },
+    "description": {
+      "fr": "Soigne les alliés en zone et leur procure un bonus sur les dommages qu'ils infligent.",
+      "en": "Heals allies in an area of effect and gives them a bonus to damage inflicted.",
+      "es": "Cura a los aliados en zona y les da un bonus en los daños que infligen.",
+      "pt": "Cura os aliados em zona e concede a eles um bônus nos danos que infligirem."
+    }
+  },
+  {
+    "spellId": 781,
+    "name": {
+      "fr": "Lien d'amitié",
+      "en": "Bond of Friendship",
+      "es": "Vínculo de Amistad",
+      "pt": "Laço de Amizade"
+    },
+    "description": {
+      "fr": "Ce sort applique l'état Lien d'amitié, l'allié ciblé sera renforcé en dommages infligés et résistance s'il subit des dommages. L'Eniripsa ne peut poser qu'une seule Régénération par équipe.",
+      "en": "Applies the Bond of Friendship state: The targeted ally gets a boost to damage inflicted and resistance if they suffer damage. The Eniripsa can only place one Regeneration per team.",
+      "es": "Este hechizo aplica el estado Vínculo de Amistad, se reforzará al aliado objetivo en daños infligidos y resistencia si sufre daños. El aniripsa solo puede lanzar una Regeneración por equipo.",
+      "pt": "Este feitiço aplica o estado Laço de Amizade: o aliado visado será fortalecido em danos infligidos e resistência se sofrer dano. O Eniripsa só pode colocar uma Regeneração por equipe."
+    }
+  },
+  {
+    "spellId": 782,
+    "name": {
+      "fr": "Jouvence",
+      "en": "Fountain of Youth",
+      "es": "Juventud",
+      "pt": "Juventude"
+    },
+    "description": {
+      "fr": "Pendant deux tours, l'Eniripsa perd une partie de ses PV max, mais il devient plus mobile et possède de meilleures capacités de soin.",
+      "en": "For two turns, the Eniripsa loses some of their max HP, but they become more mobile and have enhanced healing abilities.",
+      "es": "Durante dos turnos, el aniripsa pierde una parte de sus PdV máx., pero se vuelve más móvil y posee mejores capacidades de cura.",
+      "pt": "Por dois turnos, o Eniripsa perde parte de seus PV máx., mas ganha em mobilidade e em habilidades de cura."
+    }
+  },
+  {
+    "spellId": 1532,
+    "name": {
+      "fr": "Infusion",
+      "en": "Infusion",
+      "es": "Infusión",
+      "pt": "Infusão"
+    },
+    "description": {
+      "fr": "Lancé sur un allié, l'allié ciblé est soigné pendant plusieurs tours de suite.",
+      "en": "Cast on an ally, the targeted ally is healed several turns in a row.",
+      "es": "Lanzado sobre un aliado, el aliado objetivo se cura durante varios turnos seguidos.",
+      "pt": "Quando lançado em um aliado, o aliado visado é curado durante vários turnos seguidos."
+    }
+  },
+  {
+    "spellId": 1533,
+    "name": {
+      "fr": "Vivification",
+      "en": "Invigoration",
+      "es": "Vivificación",
+      "pt": "Vivificação"
+    },
+    "description": {
+      "fr": "Soigne l'allié ciblé et lui donne un petit gain d'esquive. Ce sort possède une grande portée.",
+      "en": "Heals the targeted ally and gives a small Dodge gain. This spell has a long range.",
+      "es": "Cura al aliado objetivo y le da una pequeña ganancia de esquiva. Este hechizo tiene mucho alcance.",
+      "pt": "Cura o aliado visado e concede a ele um pequeno ganho de esquiva. Este feitiço tem um longo alcance."
+    }
+  },
+  {
+    "spellId": 1534,
+    "name": {
+      "fr": "Flamme purificatrice",
+      "en": "Purifying Flame",
+      "es": "Llama Purificadora",
+      "pt": "Chama Purificadora"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages aux ennemis et soigne les alliés. Il applique également une marque, quelle que soit l'équipe de la cible : la cible gagne 1 PM et déclenche la marque lorsqu'elle finit son tour au contact d'un allié de l'Eniripsa. Une fois déclenchée, la marque soigne les alliés de l'Eniripsa à proximité du porteur de la marque.",
+      "en": "This spell inflicts damage on enemies and heals allies. It also applies a mark, no matter what team the target is on: The target gains 1 MP and triggers the mark if the target ends their turn next to an ally of the Eniripsa. When triggered, the mark heals the Eniripsa's allies near the mark bearer.",
+      "es": "Este hechizo inflige daños a los enemigos y cura a los aliados. También aplica una marca, sea cual sea el equipo del objetivo: el objetivo gana 1 PM y activa la marca cuando termina su turno en contacto con un aliado del aniripsa. Una vez activada, la marca cura a los aliados del aniripsa cercanos al portador de la marca.",
+      "pt": "Este feitiço inflige danos aos inimigos e cura os aliados. Também aplica uma marca, independentemente da equipe do alvo: o alvo ganha 1 PM e aciona a marca quando termina seu turno em contato com um aliado do Eniripsa. Uma vez acionada, a marca cura os aliados do Eniripsa próximos ao portador da marca."
+    }
+  },
+  {
+    "spellId": 1535,
+    "name": {
+      "fr": "Rénisurrection",
+      "en": "Eniraser",
+      "es": "Anisurrección",
+      "pt": "Renissurreição"
+    },
+    "description": {
+      "fr": "L'Eniripsa peut ressusciter un allié KO. Attention, un personnage ne peut être ressuscité qu'une seule fois par combat, et il mourra aussi si son réanimateur passe KO.",
+      "en": "The Eniripsa can revive a KO'ed ally. Be careful, a character can only be revived once per combat, and he will also die if his reanimator is KO'ed.",
+      "es": "Solo se puede resucitar a un aliado K.O. Solo funciona una vez por aliado y este morirá si su reanimador queda fuera de combate.",
+      "pt": "O Eniripsa pode ressuscitar um aliado nocauteado. Atenção: um personagem só pode ser ressuscitado uma vez por combate e ele morrerá assim que seu reanimador for nocauteado."
+    }
+  },
+  {
+    "spellId": 1538,
+    "name": {
+      "fr": "Interdiction",
+      "en": "Ban",
+      "es": "Prohibición",
+      "pt": "Proibição"
+    },
+    "description": {
+      "fr": "Applique un malus d'armure ou de soin reçu sur la cible pendant un tour. De plus, ce sort vole de l'Armure sur la cible et la récupère en PV.",
+      "en": "Applies a penalty to armor or healing received by the target for one turn. This spell also steals Armor from the target and gets it back as HP.",
+      "es": "Aplica un malus de armadura o de cura recibida al objetivo durante un turno. Además, este hechizo roba armadura al objetivo y la recupera en PdV.",
+      "pt": "Aplica uma penalidade de armadura ou de cura recebida no alvo durante um turno. Além disso, este feitiço rouba armadura do alvo como PV."
+    }
+  },
+  {
+    "spellId": 1539,
+    "name": {
+      "fr": "Cure alternative",
+      "en": "Alternative Cure",
+      "es": "Cura Alternativa",
+      "pt": "Cura Alternativa"
+    },
+    "description": {
+      "fr": "Soigne un allié. La cible captera ensuite 20 % des soins que l'Eniripsa réalise sur d'autres combattants que la cible, jusqu'à ce que la cible atteigne 100 % de ses PV.",
+      "en": "Heals an ally. The target will then get 20% of the heals done by the Eniripsa on fighters other than the target, until the target reaches 100% HP.",
+      "es": "Cura a un aliado. El objetivo captará a continuación el 20% de las curas que el aniripsa realice a otros luchadores aparte del objetivo, hasta que el objetivo llegue al 100% de sus PdV.",
+      "pt": "Cura um aliado. Em seguida, o alvo receberá 20% da cura que o Eniripsa realizar em combatentes que não sejam o alvo, até que ele atinja 100% de seus PV."
+    }
+  },
+  {
+    "spellId": 1540,
+    "name": {
+      "fr": "Psychose",
+      "en": "Psychosis",
+      "es": "Psicosis",
+      "pt": "Psicose"
+    },
+    "description": {
+      "fr": "Ce sort de zone affaiblit tous les combattants dans sa zone d'effet pendant un tour, en plus d'infliger des dommages.",
+      "en": "This area-of-effect spell weakens all fighters in an area for one turn, in addition to dealing damage.",
+      "es": "Este hechizo de zona debilita a todos los luchadores en su zona de efecto durante un turno, además de infligir daños.",
+      "pt": "Este feitiço de zona enfraquece todos os combatentes em sua área de efeito durante um turno, além de infligir danos."
+    }
+  },
+  {
+    "spellId": 1541,
+    "name": {
+      "fr": "Torpeur",
+      "en": "Lethargy",
+      "es": "Aletargamiento",
+      "pt": "Torpor"
+    },
+    "description": {
+      "fr": "Si l'Eniripsa possède une grande quantité de PV, ce sort inflige plus de dommages, mais blesse également l'Eniripsa lanceur.",
+      "en": "If the Eniripsa has very high HP, this spell deals more damage, but it also hurts the Eniripsa casting it.",
+      "es": "Si el aniripsa tiene una gran cantidad de PdV, este hechizo inflige más daños, pero también hiere al aniripsa lanzador.",
+      "pt": "Se o Eniripsa tiver uma grande quantidade de PV, este feitiço causará mais danos, mas também acertará o Eniripsa lançador."
+    }
+  },
+  {
+    "spellId": 1542,
+    "name": {
+      "fr": "Fiole infectée",
+      "en": "Infected Flask",
+      "es": "Matraz Infectado",
+      "pt": "Frasco Infectado"
+    },
+    "description": {
+      "fr": "Ce sort vole la vie de sa cible : une première fois lors du premier lancer, une seconde fois à la fin du tour de la cible.",
+      "en": "This spell steals health from the target: one time when it is cast, and a second time at the end of the target's turn.",
+      "es": "Este hechizo roba vida a su objetivo: una primera vez durante el primer lanzamiento, una segunda vez al final del turno del objetivo.",
+      "pt": "Esse feitiço rouba a vida do alvo: uma vez no primeiro lançamento e outra vez no final do turno do alvo."
+    }
+  },
+  {
+    "spellId": 7985,
+    "name": {
+      "fr": "Fontaine salvatrice",
+      "en": "Life-Saving Fountain",
+      "es": "Fuente salvadora",
+      "pt": "Fonte Salvadora"
+    },
+    "description": {
+      "fr": "Pose un grand glyphe de soin, pour les alliés comme pour les ennemis.",
+      "en": "Places a large healing glyph that affects both allies and enemies.",
+      "es": "Pone un gran glifo de cura, tanto para los aliados como para los enemigos.",
+      "pt": "Coloca um grande glifo de cura para aliados e inimigos."
+    }
+  },
+  {
+    "spellId": 4775,
+    "name": {
+      "fr": "Fulgur",
+      "en": "Thunderbolt",
+      "es": "Fulgor",
+      "pt": "Fulgor"
+    },
+    "description": {
+      "fr": "Inflige des dommages sur la cible et lui applique un état Égaré. Lorsque le Iop atteint 100 de Concentration, l'état Égaré inflige des dommages supplémentaires.",
+      "en": "Inflicts damage on the target and applies the Lost state to it. When the Iop reaches 100 Concentration, the Lost state inflicts extra damage.",
+      "es": "Inflige daños al objetivo y le aplica el estado Perdido. Cuando el yopuka alcanza 100 de Concentración, el estado Perdido causa daños adicionales.",
+      "pt": "Inflige danos ao alvo e aplica um estado Perdido. Quando o Iop chega a 100 de Concentração, o estado Perdido inflige danos adicionais."
+    }
+  },
+  {
+    "spellId": 4776,
+    "name": {
+      "fr": "Jugement",
+      "en": "Judgment",
+      "es": "Juicio",
+      "pt": "Sentença"
+    },
+    "description": {
+      "fr": "Inflige des dommages à un ennemi et lui applique une vulnérabilité aux prochains dommages feu subis. Lancé sur un allié, augmente les dommages du prochain sort de cet allié.",
+      "en": "Inflicts damage on an enemy and makes them vulnerable to the next Fire damage suffered. If cast on an ally, increases the damage of the ally's next spell.",
+      "es": "Inflige daños a un enemigo y le aplica una vulnerabilidad a los próximos daños de fuego sufridos. Lanzado a un aliado, aumenta los daños del próximo hechizo de dicho aliado.",
+      "pt": "Inflige danos a um inimigo e aplica uma vulnerabilidade aos próximos danos de fogo sofridos. Lançado em um aliado, aumenta os danos do próximo feitiço dele."
+    }
+  },
+  {
+    "spellId": 4777,
+    "name": {
+      "fr": "Super Iop Punch",
+      "en": "Super Iop Punch",
+      "es": "Súper Puño Yopuka",
+      "pt": "Supersoco de Iop"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages. Lorsque ce sort achève une cible, le Iop regagne des Points d'Action (PA).",
+      "en": "This spell inflicts damage. When this spell kills a target, the Iop regains AP.",
+      "es": "Este hechizo inflige daños. Cuando este hechizo acaba con un objetivo, el yopuka recupera puntos de acción (PA).",
+      "pt": "Este feitiço inflige danos. Quando este feitiço derrota um alvo, o Iop recupera Pontos de Ação (PA)."
+    }
+  },
+  {
+    "spellId": 4778,
+    "name": {
+      "fr": "Épée céleste",
+      "en": "Celestial Sword",
+      "es": "Espada Celeste",
+      "pt": "Espada Celestial"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone : les dommages sont plus élevés sur les cibles qui ont tous leurs points de vie.",
+      "en": "Inflicts area-of-effect damage; damage is greater on targets at full health.",
+      "es": "Inflige daños en zona: los daños son más elevados en los objetivos que tienen todos sus puntos de vida.",
+      "pt": "Inflige danos em zona: os danos são mais elevados nos alvos com todos os pontos de vida."
+    }
+  },
+  {
+    "spellId": 4779,
+    "name": {
+      "fr": "Colère de Iop",
+      "en": "Iop's Wrath",
+      "es": "Ira de Yopuka",
+      "pt": "Ira de Iop"
+    },
+    "description": {
+      "fr": "Inflige des dommages tout autour du Iop, appliquant l'état Égaré aux ennemis touchés. Lorsque le Iop atteint 100 de Concentration, l'état Égaré inflige des dommages supplémentaires.",
+      "en": "Inflicts damage all around the Iop, applying the Lost state to affected enemies. When the Iop reaches 100 Concentration, the Lost state inflicts extra damage.",
+      "es": "Inflige daños alrededor del yopuka y aplica el estado Perdido a los enemigos alcanzados. Cuando el yopuka alcanza 100 de Concentración, el estado Perdido causa daños adicionales.",
+      "pt": "Inflige danos ao redor do Iop, aplicando o estado Perdido aos inimigos atingidos. Quando o Iop chega a 100 de Concentração, o estado Perdido inflige danos adicionais."
+    }
+  },
+  {
+    "spellId": 4780,
+    "name": {
+      "fr": "Ébranler",
+      "en": "Shaker",
+      "es": "Sacudida",
+      "pt": "Sacudida"
+    },
+    "description": {
+      "fr": "Inflige des dommages sur la cible et lui applique l'état Ébranlé. Les pertes d'Armure subies sont augmentées de 30 % pendant 1 tour.",
+      "en": "Inflicts damage on the target and applies the Shaken state to it. Armor losses are increased by 30% for 1 turn.",
+      "es": "Inflige daños al objetivo y le aplica el estado Sacudido. Las pérdidas de armadura sufridas aumentan un 30% durante 1 turno.",
+      "pt": "Inflige danos ao alvo e aplica o estado Sacudido. As perdas de armadura sofridas aumentam em 30% durante 1 turno."
+    }
+  },
+  {
+    "spellId": 4781,
+    "name": {
+      "fr": "Roknocerok",
+      "en": "Rocknoceros",
+      "es": "Lanza Rocas",
+      "pt": "Roknocerrok"
+    },
+    "description": {
+      "fr": "Inflige des dommages sur la cible. Si la cible possède de l'Armure, ce sort lui inflige une perte d'Armure supplémentaire.",
+      "en": "Inflicts damage on the target. If the target has Armor, this spell inflicts an extra loss of Armor on it.",
+      "es": "Inflige daños al objetivo. Si el objetivo posee armadura, este hechizo le inflige una pérdida de armadura extra.",
+      "pt": "Inflige danos ao alvo. Se o alvo estiver com armadura, este feitiço inflige uma perda de armadura adicional."
+    }
+  },
+  {
+    "spellId": 4782,
+    "name": {
+      "fr": "Fendoir",
+      "en": "Cleaver",
+      "es": "Cuchillo de Carnicero",
+      "pt": "Rachador"
+    },
+    "description": {
+      "fr": "Ce sort de zone est versatile : dans une zone d'effet en croix, les ennemis subissent des dommages et les alliés gagnent de l'Armure et de la Parade. Pour chaque cible alliée ou ennemie touchée, le Iop gagne lui-même en Armure.",
+      "en": "This area-of-effect spell is versatile; within a cross-shaped area of effect, enemies suffer damage, and allies gain Armor and Block. And for every ally or enemy target hit, the Iop gains Armor.",
+      "es": "Este hechizo de zona es versátil: en una zona de efecto en cruz, los enemigos sufren daños y los aliados ganan armadura y anticipación. Por cada objetivo aliado o enemigo alcanzado, el propio yopuka gana armadura.",
+      "pt": "Este feitiço de zona é versátil: em uma zona de efeito em cruz, os inimigos sofrem danos e os aliados ganham armadura e parada. Para cada aliado ou inimigo atingido, o Iop também ganha armadura."
+    }
+  },
+  {
+    "spellId": 4783,
+    "name": {
+      "fr": "Charge",
+      "en": "Charge",
+      "es": "Carga",
+      "pt": "Carga"
+    },
+    "description": {
+      "fr": "Le Iop se rapproche au contact de sa cible avant de lui infliger des dommages. Lancé plusieurs tours de suite sur la même cible, la Charge inflige davantage de dommages.",
+      "en": "The Iop comes right up to their target before inflicting damage on it. Charge inflicts more damage if cast on the same target several turns in a row.",
+      "es": "El yopuka se acerca al contacto con el objetivo antes de causarle daños. Si carga contra un mismo objetivo en turnos sucesivos, le causa aún más daños.",
+      "pt": "O Iop fica em contato com o alvo antes de infligir danos. Se lançado vários turnos seguidos no mesmo alvo, a Carga inflige mais danos."
+    }
+  },
+  {
+    "spellId": 4784,
+    "name": {
+      "fr": "Ravage",
+      "en": "Devastate",
+      "es": "Estragos",
+      "pt": "Devastação"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages en zone autour du Iop. Si le sort est lancé sur une case libre, le Iop se téléporte dessus avant d'infliger les dommages. En fonction du nombre de cibles touchées, le Iop gagne davantage de Concentration.",
+      "en": "This spell inflicts damage in an area of effect around the Iop. If the spell is cast on a free cell, the Iop teleports onto it before inflicting damage. Based on the number of targets hit, the Iop gains more Concentration.",
+      "es": "Este hechizo causa daños en zona alrededor del yopuka. Si el hechizo se lanza a una casilla libre, el yopuka se teletransporta a ella antes de infligir los daños. En función del número de objetivos alcanzados, el yopuka gana aún más concentración.",
+      "pt": "Este feitiço inflige danos em zona ao redor do Iop. Se este feitiço for lançado em uma célula vazia, o Iop se teletransporta para ela antes de infligir os danos. Em função do número de alvos atingidos, o Iop ganha mais concentração."
+    }
+  },
+  {
+    "spellId": 4785,
+    "name": {
+      "fr": "Jabs",
+      "en": "Jabs",
+      "es": "Jabs",
+      "pt": "Jabs"
+    },
+    "description": {
+      "fr": "Ce sort augmente davantage la Concentration du Iop. La Concentration est un état qui permet de régénérer des Points de Wakfu (PW) et d'infliger plus de dommages.",
+      "en": "This spell boosts the Iop's Concentration even more. Concentration is a state that allows the Iop to regenerate Wakfu points (WP) and inflict more damage.",
+      "es": "Este hechizo aumenta aún más la concentración del yopuka. Concentración es un estado que permite regenerar puntos de Wakfu (PW) e infligir más daños",
+      "pt": "Este feitiço aumenta mais a Concentração do Iop. A Concentração é um estado que permite regenerar pontos de Wakfu (PW) e infligir mais danos."
+    }
+  },
+  {
+    "spellId": 4786,
+    "name": {
+      "fr": "Rafale",
+      "en": "Flurry",
+      "es": "Ráfaga",
+      "pt": "Rajada"
+    },
+    "description": {
+      "fr": "La cible du sort est attirée vers le Iop.",
+      "en": "The spell's target is drawn to the Iop.",
+      "es": "El objetivo del hechizo se atrae hacia el yopuka.",
+      "pt": "O alvo do feitiço é atraído para o Iop."
+    }
+  },
+  {
+    "spellId": 4787,
+    "name": {
+      "fr": "Torgnole",
+      "en": "Wallop",
+      "es": "Bofetada",
+      "pt": "Pancada"
+    },
+    "description": {
+      "fr": "Ce sort augmente davantage la Concentration du Iop. La Concentration est un état qui permet de régénérer des Points de Wakfu (PW) et d'infliger plus de dommages.",
+      "en": "This spell boosts the Iop's Concentration even more. Concentration is a state that allows the Iop to regenerate Wakfu points (WP) and inflict more damage.",
+      "es": "Este hechizo aumenta aún más la concentración del yopuka. Concentración es un estado que permite regenerar puntos de Wakfu (PW) e infligir más daños",
+      "pt": "Este feitiço aumenta mais a Concentração do Iop. A Concentração é um estado que permite regenerar pontos de Wakfu (PW) e infligir mais danos."
+    }
+  },
+  {
+    "spellId": 4788,
+    "name": {
+      "fr": "Tannée",
+      "en": "Pounding",
+      "es": "Casca",
+      "pt": "Zurzidela"
+    },
+    "description": {
+      "fr": "Inflige des dommages air très élevés. La cible gagne ensuite un montant d'Armure équivalent à la moitié des dommages subis. Cette Armure ne peut pas être augmentée ni diminuée par les caractéristiques Armure donnée et Armure reçue.",
+      "en": "Inflicts a great deal of Air damage. The target then gains an amount of Armor equal to half of the damage suffered. This Armor cannot be increased or decreased by the Armor Given or Armor Received characteristics.",
+      "es": "Inflige daños de aire muy elevados. Luego, el objetivo gana una cantidad de armadura equivalente a la mitad de los daños sufridos. Esta armadura no se puede aumentar ni disminuir mediante las características de armadura dada ni armadura recibida.",
+      "pt": "Inflige danos de ar muito elevados. Em seguida, o alvo ganha uma quantidade de armadura equivalente a metade dos danos sofridos. Essa armadura não pode ser aumentada nem reduzida pelas características armadura concedida e armadura recebida."
+    }
+  },
+  {
+    "spellId": 4789,
+    "name": {
+      "fr": "Épée de Iop",
+      "en": "Sword of Iop",
+      "es": "Espada de Yopuka",
+      "pt": "Espada de Iop"
+    },
+    "description": {
+      "fr": "En zone, ce sort inflige des dommages légers aux ennemis et augmente les dommages des alliés.",
+      "en": "In an area of effect, this spell inflicts minor damage on enemies and increases allies' damage.",
+      "es": "En zona, este hechizo inflige daños ligeros a los enemigos y aumenta los daños de los aliados.",
+      "pt": "Em zona, este feitiço inflige danos leves aos inimigos e aumenta os danos dos aliados."
+    }
+  },
+  {
+    "spellId": 4790,
+    "name": {
+      "fr": "Focus",
+      "en": "Focus",
+      "es": "Focalización",
+      "pt": "Foco"
+    },
+    "description": {
+      "fr": "Le Iop immobilise la cible et réduit ses résistances ainsi que le soin et l'armure qu'elle reçoit pendant 1 tour.",
+      "en": "The Iop immobilizes the target and reduces the target's resistances, as well as healing and armor received, for 1 turn.",
+      "es": "El yopuka inmoviliza al objetivo y le reduce sus resistencias, así como las curas y armadura que reciba durante 1 turno.",
+      "pt": "O Iop imobiliza o alvo e reduz suas resistências, bem como a cura e a armadura que ele recebe durante 1 turno."
+    }
+  },
+  {
+    "spellId": 4791,
+    "name": {
+      "fr": "Vertu",
+      "en": "Virtue",
+      "es": "Virtud",
+      "pt": "Virtude"
+    },
+    "description": {
+      "fr": "Le Iop se soigne lui-même ainsi que ses alliés autour de lui. Le soin se produit également autour de l'étendard du Iop.",
+      "en": "The Iop heals themself and allies around them. The healing is also done around the Iop's standard.",
+      "es": "El yopuka se cura a sí mismo y cura a los aliados a su alrededor. La cura también se produce alrededor del estandarte del yopuka.",
+      "pt": "O Iop cura a si mesmo e aos aliados a seu redor. A cura também é realizada ao redor do estandarte do Iop."
+    }
+  },
+  {
+    "spellId": 4792,
+    "name": {
+      "fr": "Posture",
+      "en": "Stance",
+      "es": "Postura",
+      "pt": "Postura"
+    },
+    "description": {
+      "fr": "Applique une posture sur le Iop. Le type de posture dépend du dernier sort utilisé par le Iop et se déclenche lorsque le Iop subit des dommages directs.",
+      "en": "Applies a stance to the Iop. The type of stance is based on the Iop's last spell used and is triggered when the Iop suffers direct damage.",
+      "es": "Aplica una postura en el yopuka. El tipo de postura depende del último hechizo utilizado por el yopuka y se activa cuando el yopuka sufre daños directos.",
+      "pt": "Aplica uma postura no Iop. O tipo de postura vai depender do último feitiço utilizado por ele e se ativa quando o Iop sofre danos diretos."
+    }
+  },
+  {
+    "spellId": 4793,
+    "name": {
+      "fr": "Amplification",
+      "en": "Increase",
+      "es": "Amplificación",
+      "pt": "Amplificação"
+    },
+    "description": {
+      "fr": "Le Iop augmente ses dommages et ceux des alliés autour de lui. Ce sort augmente également les Points de Mouvement (PM) du Iop Les effets sont répercutés autour de l'Etendard.",
+      "en": "The Iop increases their damage and that of allies around them. This spell also increases the Iop's movement points (MP). The effects are applied around the standard.",
+      "es": "El yopuka aumenta sus daños y los de los aliados a su alrededor. Este hechizo aumenta también los puntos de movimiento (PM) del yopuka. Los efectos repercuten alrededor del estandarte.",
+      "pt": "O Iop aumenta seus danos e os dos aliados ao redor dele. Este feitiço também aumenta os pontos de movimento (PM) do Iop. Os efeitos repercutem ao redor do Estandarte."
+    }
+  },
+  {
+    "spellId": 4794,
+    "name": {
+      "fr": "Duel",
+      "en": "Duel",
+      "es": "Duelo",
+      "pt": "Duelo"
+    },
+    "description": {
+      "fr": "La cible se retourne vers le Iop, et tous deux perdent des chances d'effectuer une parade.",
+      "en": "The target turns to face the Iop, and both of them have a reduced chance of blocking.",
+      "es": "El objetivo se da la vuelta hacia el yopuka, y ambos pierden probabilidad de realizar una anticipación.",
+      "pt": "O alvo se volta para o Iop, e os dois perdem chances de executar uma parada."
+    }
+  },
+  {
+    "spellId": 5130,
+    "name": {
+      "fr": "Heure de gloire",
+      "en": "Hour of Glory",
+      "es": "Hora de Gloria",
+      "pt": "Hora da Glória"
+    },
+    "description": {
+      "fr": "Ce passif permet de passer en mode \"distance\" pendant un tour. Les sorts élémentaires augmentent de Portée afin de pouvoir atteindre des cibles plus éloignées.",
+      "en": "This passive lets you switch to Ranged mode for one turn. Elemental spells increase in Range to reach targets farther away.",
+      "es": "Este pasivo permite pasar al modo distancia durante un turno. Los hechizos elementales aumentan su alcance para poder alcanzar objetivos más alejados.",
+      "pt": "Este passivo permite entrar no modo \"distância\" durante um turno. Os feitiços elementares ganham alcance para atingir alvos mais afastados."
+    }
+  },
+  {
+    "spellId": 4769,
+    "name": {
+      "fr": "Flèche ardente",
+      "en": "Blazing Arrow",
+      "es": "Flecha Ardiente",
+      "pt": "Flecha Ardente"
+    },
+    "description": {
+      "fr": "Vole 1 PM à la cible. Ce sort génère 20 d'Affûtage et de Précision.",
+      "en": "Steals 1 MP from the target. This spell generates 20 Sharpening and Precision.",
+      "es": "Roba 1 PM al objetivo. Este hechizo genera 20 de Afiladura y de Precisión.",
+      "pt": "Rouba 1 PM do alvo. Este feitiço gera 20 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4774,
+    "name": {
+      "fr": "Roulade",
+      "en": "Roly-Poly",
+      "es": "Voltereta",
+      "pt": "Rolamento"
+    },
+    "description": {
+      "fr": "Roule jusqu'à la case ciblée. Le Crâ peut ainsi échapper à un combattant qui le taclait, ou bien se mettre en position privilégiée pour infliger des dommages.",
+      "en": "Rolls to the targeted cell. The Cra can use this spell to escape from an enemy that was locking them, or move to a more favorable position to inflict damage.",
+      "es": "Rueda hasta la casilla objetivo. El ocra puede huir de un combatiente que lo placa o colocarse en una buena posición para infligirle daños.",
+      "pt": "Rola até a célula visada. Assim, o Cra pode escapar de um combatente que o bloqueia ou então ficar em uma posição privilegiada para infligir danos."
+    }
+  },
+  {
+    "spellId": 4805,
+    "name": {
+      "fr": "Retraite balisée",
+      "en": "Beacon Sneakin'",
+      "es": "Retirada Balizada",
+      "pt": "Retirada Balizada"
+    },
+    "description": {
+      "fr": "Se téléporte sur la case ciblée, si la case ciblée est au contact d'une Balise du Crâ.",
+      "en": "Teleports to the targeted cell, if the targeted cell is adjacent to one of the Cra's Beacons.",
+      "es": "Se teletransporta a la casilla objetivo si esta está en contacto con una baliza del ocra.",
+      "pt": "Teletransporta-se para a célula visada, se ela estiver em contato com uma baliza do Cra."
+    }
+  },
+  {
+    "spellId": 4806,
+    "name": {
+      "fr": "Eclaireur",
+      "en": "Scout",
+      "es": "Explorador",
+      "pt": "Explorador"
+    },
+    "description": {
+      "fr": "Le lanceur gagne en dommages, et convertit toute sa Précision en Affûtage.",
+      "en": "The caster gains damage and converts all their Precision into Sharpening.",
+      "es": "El lanzador gana daños y convierte toda su Precisión en Afiladura.",
+      "pt": "O lançador ganha danos e converte toda a sua Precisão em Afiação."
+    }
+  },
+  {
+    "spellId": 4808,
+    "name": {
+      "fr": "Frappe incisive",
+      "en": "Biting Blow",
+      "es": "Golpe Incisivo",
+      "pt": "Golpe Incisivo"
+    },
+    "description": {
+      "fr": "Stabilise la cible, qui ne pourra ainsi pas être poussée, attirée, téléportée ou portée pendant 1 tour. De plus, les soins reçus par la cible seront diminués durant 1 tour.",
+      "en": "Stabilizes the target, which therefore cannot be pushed, attracted, teleported or carried for 1 turn. In addition, healing received by the target will decrease for 1 turn.",
+      "es": "Estabiliza al objetivo, que no podrá ser empujado, atraído, teletransportado ni portado durante 1 turno. Además, las curas recibidas por el objetivo disminuirán durante 1 turno.",
+      "pt": "Estabiliza o alvo, que não poderá mais ser empurrado, atraído, teletransportado ou carregado durante 1 turno. Além disso, as curas recebidas pelo alvo serão reduzidas durante 1 turno."
+    }
+  },
+  {
+    "spellId": 4809,
+    "name": {
+      "fr": "Flèche tempête",
+      "en": "Storm Arrow",
+      "es": "Flecha de Tempestad",
+      "pt": "Flecha Tempestuosa"
+    },
+    "description": {
+      "fr": "Inflige des dommages air en zone cône. Ce sort génère 30 d'Affûtage et de Précision.",
+      "en": "Inflicts Air damage in a cone-shaped area of effect. This spell generates 30 Sharpening and Precision.",
+      "es": "Ocasiona daños de aire en zona cono. Este hechizo genera 30 de Afiladura y de Precisión.",
+      "pt": "Inflige danos de ar em zona (cone). Este feitiço gera 30 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4810,
+    "name": {
+      "fr": "Flèche de recul",
+      "en": "Retreat Arrow",
+      "es": "Flecha de Retroceso",
+      "pt": "Flecha de Recuo"
+    },
+    "description": {
+      "fr": "Repousse la cible de plusieurs cases. Ce sort génère 40 d'Affûtage et de Précision.",
+      "en": "Repels the target by several cells. This spell generates 40 Sharpening and Precision.",
+      "es": "Repele al objetivo varias casillas. Este hechizo genera 40 de Afiladura y de Precisión.",
+      "pt": "Afasta o alvo ao longo de várias células. Este feitiço gera 40 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4811,
+    "name": {
+      "fr": "Flèche harcelante",
+      "en": "Plaguing Arrow",
+      "es": "Flecha Acosante",
+      "pt": "Flecha Inconveniente"
+    },
+    "description": {
+      "fr": "Ce sort est sans ligne de vue. Il peut ainsi traverser les obstacles pour infliger des dommages à des cibles cachées. Ce sort génère 40 d'Affûtage et de Précision.",
+      "en": "This spell does not require line of sight. It can pass through obstacles to inflict damage on hidden targets. This spell generates 40 Sharpening and Precision.",
+      "es": "Hechizo sin línea de visión. Puede atravesar los obstáculos para infligir daños a los objetivos escondidos. Este hechizo genera 40 de Afiladura y de Precisión.",
+      "pt": "Este feitiço não tem linha de visão. Assim, ele pode atravessar os obstáculos para infligir danos aos alvos que estiverem escondidos. Este feitiço gera 40 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4812,
+    "name": {
+      "fr": "Flèche statique",
+      "en": "Static Arrow",
+      "es": "Flecha Estática",
+      "pt": "Flecha Estática"
+    },
+    "description": {
+      "fr": "Si le lanceur n'a pas effectué de déplacement avec des PM dans son tour, ce sort inflige des dommages élevés. Ce sort génère 60 d'Affûtage et de Précision.",
+      "en": "If the caster has not moved using MP during their turn, this spell inflicts increased damage. This spell generates 60 Sharpening and Precision.",
+      "es": "Si el lanzador no se ha desplazado con PM durante su turno, este hechizo inflige grandes daños. Este hechizo genera 60 de Afiladura y de Precisión.",
+      "pt": "Se o lançador não tiver efetuado deslocamentos usando PM em seu turno, este feitiço inflige grandes danos. Este feitiço gera 60 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4813,
+    "name": {
+      "fr": "Flèche chercheuse",
+      "en": "Homing Arrow",
+      "es": "Flecha Buscadora",
+      "pt": "Flecha Guiada"
+    },
+    "description": {
+      "fr": "Ce sort possède une très grande portée. De plus, il peut traverser les obstacles si le Crâ est sous Tir précis. Ce sort génère 20 d'Affûtage et de Précision.",
+      "en": "This spell has a very long range. It can also pass through obstacles if the Cra is in Precision Shot. This spell generates 20 Sharpening and Precision.",
+      "es": "Este hechizo tiene mucho alcance. Además, puede atravesar obstáculos si el ocra está bajo Tiro Preciso. Este hechizo genera 20 de Afiladura y de Precisión.",
+      "pt": "Este feitiço tem um alcance enorme. Além disso, ele pode atravessar os obstáculos se o Cra estiver sob Tiro Preciso. Este feitiço gera 20 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4814,
+    "name": {
+      "fr": "Flèche destructrice",
+      "en": "Destructive Arrow",
+      "es": "Flecha Destructiva",
+      "pt": "Flecha Destrutiva"
+    },
+    "description": {
+      "fr": "Inflige des dommages terre élevés. Ce sort génère 70 d'Affûtage et de Précision.",
+      "en": "Inflicts heavy Earth damage. This spell generates 70 Sharpening and Precision.",
+      "es": "Inflige daños de tierra elevados. Este hechizo genera 70 de Afiladura y de Precisión.",
+      "pt": "Inflige grandes danos de terra. Este feitiço gera 70 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4815,
+    "name": {
+      "fr": "Flèche perçante",
+      "en": "Piercing Arrow",
+      "es": "Flecha Atravesadora",
+      "pt": "Flecha Perfurante"
+    },
+    "description": {
+      "fr": "Les dommages de ce sort sont effectués sous forme de rebonds. Si le sort cible un ennemi A, le sort rebondit sur un ennemi B à 3 cases ou moins de l'ennemi A. Puis, le sort rebondit sur un ennemi C à 3 cases ou moins du combattant B. Les balises peuvent être déclenchées par l'intermédiaire de ce sort. Ce sort génère 50 d'Affûtage et de Précision.",
+      "en": "The damage from this spell is inflicted as rebounds. If the spell targets an enemy A, the spell rebounds to an enemy B within 3 cells or less from enemy A. It then rebounds again to an enemy C within 3 cells or less from fighter B. Beacons can be triggered using this spell. This spell generates 50 Sharpening and Precision.",
+      "es": "Los daños de este hechizo se efectúan en forma de rebote. Si el objetivo es un enemigo A, el hechizo rebota en un enemigo B a 3 casillas o menos del enemigo A. Luego, rebota en un enemigo C a 3 casillas o menos del combatiente B. Las balizas pueden activarse con este hechizo. Este hechizo genera 50 de Afiladura y de Precisión.",
+      "pt": "Os danos deste feitiço são efetuados sob a forma de ricochetes. Se o feitiço visar um inimigo A, ele ricocheteará em um inimigo B que estiver a até 3 células do inimigo A. Depois, o feitiço ricocheteará em um inimigo C a até 3 células do combatente B. As balizas podem ser acionadas por meio deste feitiço. Este feitiço gera 50 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4816,
+    "name": {
+      "fr": "Flèche cinglante",
+      "en": "Lashing Arrow",
+      "es": "Flecha Azotadora",
+      "pt": "Flecha Fustigante"
+    },
+    "description": {
+      "fr": "Retire des PM à la cible. Ce sort génère 30 d'Affûtage et de Précision.",
+      "en": "Reduces the target's MP. This spell generates 30 Sharpening and Precision.",
+      "es": "Le quita PM al objetivo. Este hechizo genera 30 de Afiladura y de Precisión.",
+      "pt": "Retira PM do alvo. Este feitiço gera 30 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4817,
+    "name": {
+      "fr": "Pluie de flèches",
+      "en": "Raining Arrows",
+      "es": "Lluvia de Flechas",
+      "pt": "Chuva de Flechas"
+    },
+    "description": {
+      "fr": "Inflige des dommages terre. Au début du prochain tour du Crâ, le sort est répliqué sur la case ciblée, ce qui inflige des dommages supplémentaires si la cible n'a pas bougé par exemple. Ce sort génère 40 d'Affûtage et de Précision.",
+      "en": "Inflicts Earth damage. At the start of the Cra's next turn, the spell is replicated on the targeted cell. This will inflict additional damage if the target has not moved, for example. This spell generates 40 Sharpening and Precision.",
+      "es": "Inflige daños de tierra. Al principio del próximo turno del ocra, el hechizo es replicado en la casilla objetivo, lo que inflige daños adicionales si el objetivo, por ejemplo, no se ha movido. Este hechizo genera 40 de Afiladura y de Precisión.",
+      "pt": "Inflige danos de terra. No começo do próximo turno do Cra, o feitiço é replicado na célula visada, infligindo danos adicionais se o alvo não tiver saído do lugar, por exemplo. Este feitiço gera 40 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4818,
+    "name": {
+      "fr": "Flèche criblante",
+      "en": "Riddling Arrow",
+      "es": "Flecha Perforante",
+      "pt": "Flecha Crivante"
+    },
+    "description": {
+      "fr": "En plus des dommages que ce sort inflige, le Crâ marque sa cible et lui inflige des dommages à chaque fois qu'il consomme de la Précision. Ce sort génère 40 d'Affûtage et de Précision.",
+      "en": "In addition to the damage inflicted by this spell, the Cra marks their target and inflicts damage on it each time they consume Precision. This spell generates 40 Sharpening and Precision.",
+      "es": "Además de los daños que inflige el hechizo, el ocra marca a su objetivo y le inflige daños cada vez que consume Precisión. Este hechizo genera 40 de Afiladura y de Precisión.",
+      "pt": "Além dos danos infligidos por este feitiço, o Cra marca seu alvo e inflige danos a ele toda vez que consome Precisão. Este feitiço gera 40 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4819,
+    "name": {
+      "fr": "Flèche explosive",
+      "en": "Explosive Arrow",
+      "es": "Flecha Explosiva",
+      "pt": "Flecha Explosiva"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu élevés en cercle de taille 2. Ce sort génère 60 d'Affûtage et de Précision.",
+      "en": "Inflicts heavy Fire damage in a 2-cell circle. This spell generates 60 Sharpening and Precision.",
+      "es": "Inflige daños de fuego elevados en círculo de tamaño 2. Este hechizo genera 60 de Afiladura y de Precisión.",
+      "pt": "Inflige grandes danos de fogo em círculo de tamanho 2. Este feitiço gera 60 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4820,
+    "name": {
+      "fr": "Flèche fulminante",
+      "en": "Fulminating Arrow",
+      "es": "Flecha Fulminante",
+      "pt": "Flecha Fulminante"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu importants sur la cible. Ce sort génère 30 d'Affûtage et de Précision.",
+      "en": "Inflicts considerable Fire damage on the target. This spell generates 30 Sharpening and Precision.",
+      "es": "Inflige importantes daños de fuego en el objetivo. Este hechizo genera 30 de Afiladura y de Precisión.",
+      "pt": "Inflige danos de fogo consideráveis ao alvo. Este feitiço gera 30 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4821,
+    "name": {
+      "fr": "Flèche enflammée",
+      "en": "Flaming Arrow",
+      "es": "Flecha Flamígera",
+      "pt": "Flecha Flamejante"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone, touchant 5 cases à la verticale à partir de la case sur laquelle est lancé le sort. De plus, les ennemis touchés par ce sort subissent davantage de dommages indirects (poisons, pièges...) pendant un tour. Ce sort génère 40 d'Affûtage et de Précision.",
+      "en": "Inflicts damage in an area of effect, hitting 5 cells in a vertical line from the cell where the spell is cast. In addition, enemies hit by this spell take greater indirect damage (poisons, traps, etc.) for one turn. This spell generates 40 Sharpening and Precision.",
+      "es": "Inflige daños en zona, alcanzando 5 casillas en vertical desde la casilla sobre la que se lanza el hechizo. Además, los enemigos alcanzados por el hechizo sufren más daños indirectos (venenos, trampas, etc.) durante un turno. Este hechizo genera 40 de Afiladura y de Precisión.",
+      "pt": "Inflige danos em zona, atingindo 5 células na vertical a partir da célula em que o feitiço foi lançado. Além disso, os inimigos atingidos por este feitiço sofrem mais danos indiretos (venenos, armadilhas...) durante um turno. Este feitiço gera 40 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 4822,
+    "name": {
+      "fr": "Flèche d'immolation",
+      "en": "Burning Arrow",
+      "es": "Flecha de Inmolación",
+      "pt": "Flecha de Imolação"
+    },
+    "description": {
+      "fr": "Inflige des dommages feu en croix. Le sort inflige des dommages doublés sur les invocations ciblées. Ce sort génère 20 d'Affûtage et de Précision.",
+      "en": "Inflicts Fire damage in a cross-shaped area of effect. The spell inflicts double damage on targeted summons. This spell generates 20 Sharpening and Precision.",
+      "es": "Inflige daños de fuego en cruz. El hechizo inflige daños duplicados en las invocaciones objetivo. Este hechizo genera 20 de Afiladura y de Precisión.",
+      "pt": "Inflige danos de fogo em cruz. O feitiço inflige danos dobrados nas invocações visadas. Este feitiço gera 20 de Afiação e de Precisão."
+    }
+  },
+  {
+    "spellId": 6842,
+    "name": {
+      "fr": "Rafale",
+      "en": "Flurry",
+      "es": "Ráfaga",
+      "pt": "Rajada"
+    },
+    "description": {
+      "fr": "Le Crâ débloque 3 flèches lumineuses qu'il peut utiliser au moment opportun. Les dommages lumière prennent en compte l'élément de la meilleure maîtrise du lanceur.",
+      "en": "The Cra unlocks 3 luminous arrows to use whenever needed. Light damage draws on the element of the caster's best mastery.",
+      "es": "El ocra desbloquea 3 flechas luminosas que puede usar en el momento oportuno. Los daños de luz toman en cuenta el elemento del mejor dominio del lanzador.",
+      "pt": "O Cra desbloqueia 3 Flechas Luminosas, que ele pode usar no momento oportuno. Os danos Luz levam em consideração o elemento do melhor domínio do lançador."
+    }
+  },
+  {
+    "spellId": 7753,
+    "name": {
+      "fr": "Œil de taupe",
+      "en": "Bat's Eye",
+      "es": "Ojo de Topo",
+      "pt": "Olho de Toupeira"
+    },
+    "description": {
+      "fr": "Retire 4 de Portée aux ennemis en zone. Leurs sorts pourront toucher des cibles moins lointaines. Cependant, si ce sort est lancé sur le Crâ, lui et ses alliés à son contact gagnent 4 Portée.",
+      "en": "Removes 4 Range from enemies in an area of effect. Their spells can hit less distant targets. However, if the spell is cast on the Cra, they and their adjacent allies gain 4 Range.",
+      "es": "Retira 4 AL a los enemigos en zona. Sus hechizos podrán alcanzar objetivos menos alejados. Sin embargo, si este hechizo se lanza sobre el ocra, sus aliados en contacto y él ganan 4 AL.",
+      "pt": "Retira 4 AL dos inimigos em zona. Os feitiços deles poderão atingir os alvos menos distantes. No entanto, se o feitiço for lançado no Cra, ele e os aliados que estiverem em contato com ele ganham 4 AL."
+    }
+  },
+  {
+    "spellId": 914,
+    "name": {
+      "fr": "Toxines",
+      "en": "Toxines",
+      "es": "Toxinas",
+      "pt": "Toxinas"
+    },
+    "description": {
+      "fr": "Le Sadida applique des toxines à la cible pendant 2 tours. S'il s'agit d'un ennemi, il perd des résistances élémentaires et subit des dommages en début de tour. Si c'est un allié, il gagne des résistances élémentaires et est soigné en début de tour.",
+      "en": "The Sadida applies toxins to the target for 2 turns. If the target is an enemy, they lose elemental resistance and take damage at start of turn. If the target is an ally, they gain elemental resistance and are healed at start of turn.",
+      "es": "El sadida aplica toxinas al objetivo durante 2 turnos. Si se trata de un enemigo, perderá resistencias elementales y sufrirá daños al principio del turno. Si se trata de un aliado, ganará resistencias elementales y se curará al principio del turno.",
+      "pt": "O Sadida aplica toxinas ao alvo durante 2 turnos. Se for um inimigo, ele perde as resistências elementares e sofre danos no início do turno. Se for um aliado, ele ganha resistências elementares e é curado no início do turno."
+    }
+  },
+  {
+    "spellId": 915,
+    "name": {
+      "fr": "Arbre",
+      "en": "Tree",
+      "es": "Árbol",
+      "pt": "Árvore"
+    },
+    "description": {
+      "fr": "Le Sadida se transforme en arbre pour un tour, il ne peut plus bouger, se soigne et augmente ses résistances.",
+      "en": "The Sadida transforms into a tree for one turn. The Sadida can no longer move, but can heal and resistances are increased.",
+      "es": "El sadida se transforma en árbol durante un turno y no puede moverse, pero se cura y aumenta sus resistencias.",
+      "pt": "O Sadida se transforma em uma árvore por um turno. Ele não pode mais se mover, mas é curado e as resistências são aumentadas."
+    }
+  },
+  {
+    "spellId": 918,
+    "name": {
+      "fr": "Larme du Sadida",
+      "en": "Sadida's Tear",
+      "es": "Lágrima de Sadida",
+      "pt": "Lágrima do Sadida"
+    },
+    "description": {
+      "fr": "Ce sort peut infliger des dommages à un ennemi ou soigner un allié sans ligne de vue. Il permet également de rendre une poupée plus résistante. Si le sort est lancé sur une graine, le Sadida invoque une Gonflable capable d'augmenter les dommages des alliés.",
+      "en": "This spell can deal damage to an enemy or heal an ally without line of sight. It can also be used to make a doll more resistant. If the spell is cast on a seed, the Sadida summons an Inflatable that can increase allies' damage.",
+      "es": "Este hechizo puede causar daños a un enemigo o curar a un aliado sin línea de visión. También permite volver más resistente a una muñeca. Si se lanza el hechizo sobre une semilla, el sadida invoca una hinchable capaz de aumentar los daños de los aliados.",
+      "pt": "Esse feitiço pode infligir dano a um inimigo ou curar um aliado sem linha de visão. Ele também pode tornar uma boneca mais resistente. Se o feitiço for lançado em uma semente, o Sadida invocará uma Inflável capaz de aumentar os danos dos aliados."
+    }
+  },
+  {
+    "spellId": 919,
+    "name": {
+      "fr": "Vent Empoisonné",
+      "en": "Poisoned Wind",
+      "es": "Viento Envenenado",
+      "pt": "Vento Envenenado"
+    },
+    "description": {
+      "fr": "Le Sadida invoque un puissant vent empoisonné affectant toutes les cibles dans une zone autour de la case ciblée pendant 2 tours. Les cibles touchées par le poison voient leurs dommages réduits et subissent des dommages pour chaque PM ou PA perdu.",
+      "en": "The Sadida summons a powerful poisoned wind that affects all targets in an area around the target cell for 2 turns. Targets hit by the poison have their damage reduced and suffer damage for every MP or AP lost.",
+      "es": "El sadida invoca un potente viento tóxico que afecta a todos los objetivos situados en la zona alrededor de la casilla objetivo durante 2 turnos. Los objetivos alcanzados por el veneno ven sus daños reducidos y sufren daños por cada PM o PA perdido.",
+      "pt": "O Sadida invoca um vento envenenado poderoso que afeta todos os alvos em uma zona ao redor da célula visada durante 2 turnos. Os alvos atingidos pelo veneno têm seu dano reduzido e sofrem dano para cada PM ou PA perdido."
+    }
+  },
+  {
+    "spellId": 920,
+    "name": {
+      "fr": "Sacrifice Poupesque",
+      "en": "Dolly Sacrifice",
+      "es": "Sacrificio Muñequero",
+      "pt": "Sacrifício Bonecal"
+    },
+    "description": {
+      "fr": "Le Sadida sacrifie toutes ses poupées. Il est soigné et gagne des PA en fonction du niveau d'Engrainé des poupées sacrifiées.",
+      "en": "The Sadida sacrifices all their dolls. They are healed and gain AP based on the sacrificed dolls' level of Nettled.",
+      "es": "El sadida sacrifica todas sus muñecas. Se cura y gana PA en función del nivel de Reacción en Cadena de las muñecas sacrificadas.",
+      "pt": "O Sadida sacrifica todas as bonecas. Ele é curado e ganha PA de acordo com o nível de Germinado das bonecas sacrificadas."
+    }
+  },
+  {
+    "spellId": 921,
+    "name": {
+      "fr": "Vaporiser",
+      "en": "Vaporize",
+      "es": "Vaporizar",
+      "pt": "Vaporizar"
+    },
+    "description": {
+      "fr": "Ce sort permet de rendre une invocation transparente (ne bloque plus les lignes de vue). Si la cible est une Poupée du Sadida, celle-ci gagnera un niveau d'Engrainé supplémentaire à la fin de son tour. Si le sort est lancé sur une graine, le Sadida invoque une Goulue avec un bonus de dommages permanent.",
+      "en": "This spell makes a summons transparent (no longer blocks line of sight). If the target is one of the Sadida's Dolls, the Doll gains an additional level of Nettled at the end of its turn. If the spell is cast on a seed, the Sadida summons a Greedy with a permanent damage bonus.",
+      "es": "Este hechizo permite volver una invocación transparente (deja de bloquear la línea de visión). Si el objetivo es una muñeca sadida, esta ganará un nivel de Reacción en Cadena más al final de su turno. Si se lanza el hechizo sobre una semilla, el sadida invoca una ghulotona con un bonus de daños permanente.",
+      "pt": "Esse feitiço torna a invocação transparente (não bloqueia mais as linhas de visão). Se o alvo for uma Boneca do Sadida, ela ganhará um nível de Germinado adicional no fim de seu turno. Se o feitiço for lançado em uma semente, o Sadida invoca uma Gulosa com um bônus de dano permanente."
+    }
+  },
+  {
+    "spellId": 922,
+    "name": {
+      "fr": "Drainage",
+      "en": "Drain",
+      "es": "Drenaje",
+      "pt": "Drenagem"
+    },
+    "description": {
+      "fr": "Le Sadida draine les Points de Vie d'une cible et les transfère aux cibles proches.",
+      "en": "The Sadida drains some Health Points from a target and redistributes them to nearby allies.",
+      "es": "El sadida drena los puntos de vida de un objetivo y los transfiere a sus objetivos cercanos.",
+      "pt": "O Sadida drena os PV de um alvo e os redistribui entre os aliados próximos."
+    }
+  },
+  {
+    "spellId": 925,
+    "name": {
+      "fr": "Ronce",
+      "en": "Bramble",
+      "es": "Zarza",
+      "pt": "Sarça"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre à un ennemi ou donne de l'Armure à un allié. L'Armure absorbe les dommages reçus. Si le sort est lancé sur une graine, le Sadida invoque une Sacrifiée qui devient plus dangereuse à chaque fois que le Sadida subit des dommages d'un ennemi.",
+      "en": "Inflicts Earth damage on an enemy or gives Armor to an ally. The Armor absorbs damage received. If the spell is cast on a seed, the Sadida summons a Sacrificial Doll that becomes more dangerous whenever the Sadida takes damage from an enemy.",
+      "es": "Causa daños de tierra a un enemigo u otorga armadura a un aliado. La armadura absorbe los daños recibidos. Si se lanza el hechizo sobre una semilla, el sadida invoca una sacrificada que se vuelve más peligrosa cada vez que el sadida sufre daños por parte de un enemigo.",
+      "pt": "Inflige danos de terra a um inimigo ou concede armadura a um aliado. A armadura absorve os danos recebidos. Se o feitiço for lançado em uma semente, o Sadida invoca uma Sacrificada, que se torna mais perigosa toda vez que o Sadida sofre danos de um inimigo."
+    }
+  },
+  {
+    "spellId": 927,
+    "name": {
+      "fr": "Herbes Folles",
+      "en": "Wild Grass",
+      "es": "Hierbas Locas",
+      "pt": "Ervas Daninhas"
+    },
+    "description": {
+      "fr": "Herbes Folles permet de réduire le mouvement d'une cible. Si le sort est lancé sur une graine, le Sadida invoque une Sacrifiée capable de retirer des PM aux ennemis lors de son explosion.",
+      "en": "This spell reduces a target's movement. If it's cast on a seed, the Sadida summons a Sacrificial Doll that removes MP from enemies when it explodes.",
+      "es": "Hierbas Locas permite reducir el movimiento de un objetivo. Si se lanza el hechizo sobre una semilla, el sadida invoca una sacrificada capaz de retirar PM a los enemigos al explotar.",
+      "pt": "Ervas Daninhas permite reduzir o movimento de um alvo. Se o feitiço for lançado em uma semente, o Sadida invoca uma Sacrificada capaz de remover PM dos inimigos quando explode."
+    }
+  },
+  {
+    "spellId": 928,
+    "name": {
+      "fr": "Coup de Froid",
+      "en": "Sudden Chill",
+      "es": "Resfriado",
+      "pt": "Arrepio Súbito"
+    },
+    "description": {
+      "fr": "Ce sort permet de baisser les résistances tout en infligeant des dégâts. Si le sort est lancé sur une graine, le Sadida invoque une Goulue capable de baisser les résistances de ses cibles.",
+      "en": "This spell cools down the target, reducing its resistances as well as dealing damage to it. If the spell is cast on a seed, the Sadida summons a Greedy that can lower its targets' resistances.",
+      "es": "Este hechizo baja las resistencias del objetivo a la vez que le causa daños. Si se lanza el hechizo sobre una semilla, el sadida invoca una ghulotona capaz de bajar las resistencias de sus objetivos.",
+      "pt": "Este feitiço esfria o alvo, reduzindo suas resistências e causando-lhe dano. Se o feitiço for lançado em uma semente, o Sadida invoca uma Gulosa capaz de reduzir as resistências de seus alvos."
+    }
+  },
+  {
+    "spellId": 929,
+    "name": {
+      "fr": "Engrais",
+      "en": "Compost",
+      "es": "Abono",
+      "pt": "Adubo"
+    },
+    "description": {
+      "fr": "Ce sort permet de voler 1 PM à un ennemi tout en lui infligeant des dommages Terre, ou d'appliquer une grosse quantité d'Armure sur un allié. L'Armure absorbe les coups reçus. Si le sort est lancé sur une graine, le Sadida invoque une Gonflable capable d'augmenter la mobilité des alliés.",
+      "en": "This spell steals 1 MP from an enemy and inflicts Earth damage on them, or applies a large amount of Armor to an ally. The Armor absorbs hits received. If the spell is cast on a seed, the Sadida summons an Inflatable that can increase allies' mobility.",
+      "es": "Este hechizo permite robar 1 PM a un enemigo y causarle daños de tierra, o aplicarle una gran armadura a un aliado. La armadura absorbe los golpes recibidos. Si se lanza el hechizo sobre una semilla, el sadida invoca una hinchable capaz de aumentar la movilidad de los aliados.",
+      "pt": "Esse feitiço permite que você roube 1 PM de um inimigo ao infligir danos de terra ou que aplique uma grande quantidade de armadura em um aliado. A armadura absorve os golpes recebidos. Se o feitiço for lançado em uma semente, o Sadida invoca uma Inflável capaz de aumentar a mobilidade dos aliados."
+    }
+  },
+  {
+    "spellId": 930,
+    "name": {
+      "fr": "Gadoule",
+      "en": "Mudoll",
+      "es": "Arcilla",
+      "pt": "Lamoneca"
+    },
+    "description": {
+      "fr": "Ce sort permet de soigner un allié ou de retirer un PM à un ennemi tout en lui infligeant des dommages. Si le sort est lancé sur une graine, le Sadida invoque une Bloqueuse qui retire des PM autour d'elle à la fin de son tour.",
+      "en": "This spell either heals an ally or removes an MP from an enemy while inflicting damage on them. If the spell is cast on a seed, the Sadida summons a Block that removes MP around it at end of turn.",
+      "es": "Este hechizo permite curar a un aliado o retirar un PM a un enemigo al tiempo que le causa daños. Si se lanza el hechizo sobre una semilla, el sadida invoca una bloqueadora que retira PM a su alrededor al final de su turno.",
+      "pt": "Este feitiço permite curar um aliado ou retirar PM de um inimigo enquanto inflige danos. Se o feitiço for lançado em uma semente, o Sadida invoca uma Bloqueadora que retira PM ao redor dela no final de seu turno."
+    }
+  },
+  {
+    "spellId": 931,
+    "name": {
+      "fr": "Rouille",
+      "en": "Rust",
+      "es": "Herrumbre",
+      "pt": "Ferrugem"
+    },
+    "description": {
+      "fr": "Le Sadida soigne ses alliés et inflige des dommages à ses ennemis dans la zone.",
+      "en": "The Sadida heals allies and deals damage to enemies in the area of effect.",
+      "es": "El sadida cura a sus aliados y causa daños a sus enemigos en zona.",
+      "pt": "O Sadida cura os aliados e inflige danos aos inimigos na zona."
+    }
+  },
+  {
+    "spellId": 932,
+    "name": {
+      "fr": "Relent Boisé",
+      "en": "Woodland Stench",
+      "es": "Hedor Boscoso",
+      "pt": "Fedor do Bosque"
+    },
+    "description": {
+      "fr": "Ce sort permet au Sadida de maudire un ennemi : celui-ci subira des dommages à chaque fois que le Sadida inflige des poisons. Si le sort est lancé sur une graine, le Sadida invoque une Folle capable d'empoisonner ses cibles.",
+      "en": "This spell allows the Sadida to curse an enemy: the enemy will take damage every time the Sadida inflicts poisons. If the spell is cast on a seed, the Sadida summons a Madoll that can poison targets.",
+      "es": "Con este hechizo, el sadida puede maldecir a un enemigo: este sufrirá daños cada vez que el sadida envenene. Si se lanza el hechizo sobre una semilla, el sadida invoca una loca capaz de envenenar a sus objetivos.",
+      "pt": "Esse feitiço permite que o Sadida amaldiçoe um inimigo: o inimigo sofre dano toda vez que o Sadida inflige veneno. Se o feitiço for lançado em uma semente, o Sadida invoca uma Louca capaz de envenenar seus alvos."
+    }
+  },
+  {
+    "spellId": 934,
+    "name": {
+      "fr": "Kohmir",
+      "en": "K'mir",
+      "es": "Komhir",
+      "pt": "Komhir"
+    },
+    "description": {
+      "fr": "Kohmir permet au Sadida de tirer une cible durant un tour. Si le sort est lancé sur une graine, le Sadida invoque une Bloqueuse capable de tirer des cibles pendant son tour.",
+      "en": "K'mir enables the Sadida to exert a pull on a target for one turn. If the spell is cast on a seed, the Sadida summons a Block that can pull targets during its turn.",
+      "es": "Gracias a Komhir, el sadida puede atraer un objetivo durante un turno. Si se lanza el hechizo sobre una semilla, el sadida invoca una bloqueadora capaz de atraer objetivos durante su turno.",
+      "pt": "Komhir faz com que o Sadida exerça uma atração sobre um alvo por um turno. Se o feitiço for lançado em uma semente, o Sadida invoca uma Bloqueadora que pode puxar os alvos durante seu turno."
+    }
+  },
+  {
+    "spellId": 935,
+    "name": {
+      "fr": "Tremblement de Terre",
+      "en": "Earthquake",
+      "es": "Terremoto",
+      "pt": "Tremor de Terra"
+    },
+    "description": {
+      "fr": "Le Sadida inflige des dommages en zone autour d'une de ses invocations. Ce sort peut être lancé n'importe où sur le terrain, mais il doit cibler une poupée ou un arbre.",
+      "en": "The Sadida deals damage in an area of effect around one of their summons. This spell can be cast anywhere on the battlefield, but it must target a doll or a tree.",
+      "es": "El sadida causa daños en zona alrededor de una de sus invocaciones. Este hechizo puede lanzarse a cualquier casilla del terreno, pero siempre seleccionando a una muñeca o un árbol.",
+      "pt": "O Sadida inflige danos em zona ao redor de uma de suas invocações. Esse feitiço pode ser lançado em qualquer lugar do terreno, mas deve ter como alvo uma boneca ou uma árvore."
+    }
+  },
+  {
+    "spellId": 937,
+    "name": {
+      "fr": "Ronces Multiples",
+      "en": "Manifold Bramble",
+      "es": "Zarzas Múltiples",
+      "pt": "Sarças Múltiplas"
+    },
+    "description": {
+      "fr": "Inflige des dommages Terre et retire des PM dans une grande zone.",
+      "en": "Inflicts Earth damage and removes MP in a large area of effect.",
+      "es": "Causa daños de tierra y retira PM en una gran zona.",
+      "pt": "Inflige danos de terra e retira PM em uma grande zona."
+    }
+  },
+  {
+    "spellId": 938,
+    "name": {
+      "fr": "Bourrasque",
+      "en": "Gust",
+      "es": "Borrasca",
+      "pt": "Borrasca"
+    },
+    "description": {
+      "fr": "Bourrasque permet de repousser les autres combattants autour de la cible. Si la cible est un allié, il gagne un bonus de dommages pour un tour. Si le sort est lancé sur une graine, le Sadida invoque une Folle qui appliquera ses effets en zone.",
+      "en": "This spell repels any other fighters around the target. If the target is an ally, they gain a damage bonus for one turn. If the spell is cast on a seed, the Sadida summons a Madoll that will apply its effects in an area of effect.",
+      "es": "Borrasca permite empujar a los demás luchadores que estén alrededor del objetivo. Si el objetivo es un aliado, gana un bonus de daños durante un turno. Si se lanza el hechizo sobre una semilla, el sadida invoca una loca que aplicará sus efectos en zona.",
+      "pt": "Borrasca permite afastar os outros combatentes ao redor do alvo. Se o alvo for um aliado, ele ganha um bônus de danos por um turno. Se o feitiço for lançado em uma semente, o Sadida invoca uma Louca que aplica seus efeitos em zona."
+    }
+  },
+  {
+    "spellId": 5057,
+    "name": {
+      "fr": "Eveil Sylvestre",
+      "en": "Sylvan Awakening",
+      "es": "Despertar Silvestre",
+      "pt": "Despertar Silvestre"
+    },
+    "description": {
+      "fr": "Le Sadida transmet l'essence même de la forêt à un membre de son équipe, éveillant ses sens à la beauté de la nature. Ce processus est long et dangereux, mais il permet de rendre la vie à un allié tombé au combat.",
+      "en": "The Sadida transmits the very essence of the forest to a team member, awakening their senses to the beauty of nature. This process is long and dangerous, but it can restore life to an ally who's fallen in combat.",
+      "es": "El sadida transmite la esencia misma del bosque a un miembro de su equipo, despertando sus sentidos a la belleza de la naturaleza. Es un proceso largo y peligroso, pero permite devolverle la vida a un aliado caído en combate.",
+      "pt": "O Sadida transmite a essência da floresta a um membro de sua equipe, despertando seus sentidos para a beleza da natureza. O processo é longo e perigoso, mas ele permite devolver à vida um aliado morto em combate."
+    }
+  },
+  {
+    "spellId": 7054,
+    "name": {
+      "fr": "Fertilisant",
+      "en": "Fertilizer",
+      "es": "Fertilizante",
+      "pt": "Fertilizante"
+    },
+    "description": {
+      "fr": "Le Sadida engraine une Poupée afin de la rendre plus puissante rapidement. En revanche, elle est stabilisée et passe son tour. Sur un ennemi, les poupées du Sadida lui infligeront plus de dommages pendant 1 tour. Sur un allié, les poupées du Sadida le soigneront davantage durant 1 tour.",
+      "en": "The Sadida nettles a Doll to quickly make it more powerful. However, the Doll is stabilized and skips a turn. On an enemy, the Sadida's dolls will deal more damage to that enemy for 1 turn. On an ally, the Sadida's dolls will heal that ally more for 1 turn.",
+      "es": "El sadida aplica Reacción en Cadena a una muñeca para volverla más poderosa rápidamente. A cambio, se estabiliza y pasa turno. En un enemigo, las muñecas del sadida le causarán más daños durante 1 turno. En un aliado, las muñecas del sadida le curarán más durante 1 turno.",
+      "pt": "O Sadida germina uma Boneca para que ela se torne mais poderosa rapidamente. Por outro lado, ela fica estabilizada e passa seu turno. Em um inimigo, as bonecas do Sadida infligirão mais dano por 1 turno. Em um aliado, as bonecas do Sadida darão mais cura durante 1 turno."
+    }
+  },
+  {
+    "spellId": 8139,
+    "name": {
+      "fr": "Force de la nature",
+      "en": "Force of Nature",
+      "es": "Fuerza de la Naturaleza",
+      "pt": "Força da Natureza"
+    },
+    "description": {
+      "fr": "Le Sadida peut lancer ce sort seulement s'il possède de l'Armure. Il gagne des PM, de la Portée, des Dommages infligés et des Soins réalisés, mais ne peut plus gagner d'Armure. L'état est perdu si le Sadida perd son Armure initiale.",
+      "en": "The Sadida can only cast this spell if they have Armor. They gain MP, range, damage inflicted, and healing provided, but can no longer gain Armor. The state is lost if the Sadida loses their starting Armor.",
+      "es": "El sadida solo puede lanzar este hechizo si tiene armadura. Gana PM, alcance, daños causados y curas realizadas, pero ya no puede ganar armadura. Se pierde el estado si el sadida pierde su armadura inicial.",
+      "pt": "O Sadida só pode lançar este feitiço se possuir armadura. Ele ganha PM, alcance, dano infligido e cura realizada, mas não pode mais ganhar armadura. O estado se perde se o Sadida perder sua armadura inicial."
+    }
+  },
+  {
+    "spellId": 5028,
+    "name": {
+      "fr": "Sang pour sang",
+      "en": "Blood Rush",
+      "es": "Sangre a Sangre",
+      "pt": "Sangue por Sangue"
+    },
+    "description": {
+      "fr": "Inflige des dommages élevés, mais blesse aussi le lanceur.",
+      "en": "Inflicts high damage but also injures the caster.",
+      "es": "Inflige daños elevados, pero hiere también al lanzador.",
+      "pt": "Inflige danos elevados, mas também fere o lançador."
+    }
+  },
+  {
+    "spellId": 5029,
+    "name": {
+      "fr": "Cage de sang",
+      "en": "Cage of Blood",
+      "es": "Jaula de Sangre",
+      "pt": "Gaiola de Sangue"
+    },
+    "description": {
+      "fr": "Retire des PM à la cible et lui applique un malus de soins reçus.",
+      "en": "Removes MP from the target and applies a penalty on healing received.",
+      "es": "Retira PM al objetivo y le aplica un malus de curas recibidas.",
+      "pt": "Retira PM do alvo e aplica uma penalidade de cura recebida."
+    }
+  },
+  {
+    "spellId": 5030,
+    "name": {
+      "fr": "Furie sanguinaire",
+      "en": "Bloodthirsty Fury",
+      "es": "Furia Sanguinaria",
+      "pt": "Fúria Sanguinária"
+    },
+    "description": {
+      "fr": "Vole la vie d'une cible.",
+      "en": "Steals health from a target.",
+      "es": "Roba la vida de un objetivo.",
+      "pt": "Rouba a vida de um alvo."
+    }
+  },
+  {
+    "spellId": 5031,
+    "name": {
+      "fr": "Sang brûlant",
+      "en": "Burning Blood",
+      "es": "Sangre Ardiente",
+      "pt": "Sangue Fervente"
+    },
+    "description": {
+      "fr": "Brûle une partie de la vie du lanceur pour infliger de lourds dommages aux cibles autour de lui.",
+      "en": "Burns some of the caster's health to inflict heavy damage on nearby targets.",
+      "es": "Quema una parte de la vida del lanzador para infligir grandes daños a los objetivos que haya a su alrededor.",
+      "pt": "Queima parte da vida do lançador para causar grande dano aos alvos em volta dele."
+    }
+  },
+  {
+    "spellId": 5032,
+    "name": {
+      "fr": "Punition",
+      "en": "Punition",
+      "es": "Punición",
+      "pt": "Punição"
+    },
+    "description": {
+      "fr": "Le lanceur atteint directement son potentiel de berserker maximum, en perdant tous les PV qu'il possède au-dessus de 20 %. Il inflige ensuite des dommages feu élevés.",
+      "en": "The caster instantly achieves their maximum berserker potential while losing all HP above 20%. Then they deal high Fire damage.",
+      "es": "El lanzador alcanza directamente su potencial máximo de berserker, perdiendo todos los PdV que posee por encima del 20%. Luego, inflige daños de fuego elevados.",
+      "pt": "O lançador atinge seu potencial máximo de Berserker, perdendo todos os PV que ele tem acima de 20%. Em seguida, ele inflige danos elevados de fogo."
+    }
+  },
+  {
+    "spellId": 5033,
+    "name": {
+      "fr": "Pied rocheux",
+      "en": "Rocky Foot",
+      "es": "Pie de Roca",
+      "pt": "Pé Rochoso"
+    },
+    "description": {
+      "fr": "Le Sacrieur inflige des dommages monocible, et gagne de l'Armure. L'Armure absorbe les prochaines attaques reçues.",
+      "en": "The Sacrier inflicts single-target damage and gains Armor. The Armor absorbs the next attacks received.",
+      "es": "El sacrógrito inflige daños de objetivo único y gana armadura. La armadura absorbe los próximos ataques recibidos.",
+      "pt": "O Sacrier inflige danos de alvo único e ganha armadura. A armadura absorve os próximos ataques recebidos."
+    }
+  },
+  {
+    "spellId": 5034,
+    "name": {
+      "fr": "Tempête spirituelle",
+      "en": "Spiritual Tempest",
+      "es": "Tormenta Espiritual",
+      "pt": "Tempestade Espiritual"
+    },
+    "description": {
+      "fr": "Les adversaires dans la zone subissent des dommages, puis tous les combattants autour de la case ciblée sont repoussés.",
+      "en": "Opponents in the area of effect suffer damage, then all fighters around the targeted cell are pushed back.",
+      "es": "Los adversarios de la zona sufren daños y luego todos los luchadores de alrededor de la casilla objetivo son empujados.",
+      "pt": "Os adversários na zona sofrem danos e, em seguida, todos os combatentes ao redor da célula visada são afastados."
+    }
+  },
+  {
+    "spellId": 5035,
+    "name": {
+      "fr": "Démence",
+      "en": "Insanity",
+      "es": "Demencia",
+      "pt": "Demência"
+    },
+    "description": {
+      "fr": "Le Sacrieur se déchaîne, attirant les cibles et leur infligeant des dégâts, en plus d'augmenter son Tacle.",
+      "en": "The Sacrier rages, increasing their Lock, attracting enemies and inflicting damage.",
+      "es": "El sacrógrito se desata y atrae a los objetivos infligiéndoles daños, además de aumentar su placaje.",
+      "pt": "O Sacrier fica enfurecido, atraindo os alvos e lhes infligindo danos, além de aumentar seu Bloqueio."
+    }
+  },
+  {
+    "spellId": 5036,
+    "name": {
+      "fr": "Fracasse",
+      "en": "Smashes",
+      "es": "Fatal Furiarga",
+      "pt": "Estilhaçar"
+    },
+    "description": {
+      "fr": "Inflige des dommages monocible et crée une Armure dont la puissance dépend des PV manquants du Sacrieur. L'Armure absorbe les prochaines attaques reçues. Les dommages sont plus élevés si la cible possède de l'Armure.",
+      "en": "Inflicts single-target damage and creates an Armor whose power depends on the Sacrier's missing HP. The Armor absorbs the next attacks received. The damage inflicted is greater if the target has Armor.",
+      "es": "Inflige daños de objetivo único y crea una armadura cuyo poder depende de los PdV que le falten al sacrógrito. La armadura absorbe los próximos ataques recibidos. Los daños son más elevados si el objetivo posee armadura.",
+      "pt": "Causa danos de alvo único e cria uma armadura cuja potência depende dos PV perdidos pelo Sacrier. A armadura absorve os próximos ataques recebidos. Os danos serão mais elevados se o alvo tiver armadura."
+    }
+  },
+  {
+    "spellId": 5037,
+    "name": {
+      "fr": "Colonnades",
+      "en": "Colonnades",
+      "es": "Columnata",
+      "pt": "Colunatas"
+    },
+    "description": {
+      "fr": "Le Sacrieur frappe de toutes ses forces sur le sol, faisant ressortir des colonnes autour de la cible. Il inflige des dégâts et génère de l'Armure par adversaire touché : l'Armure absorbe les prochaines attaques reçues.",
+      "en": "The Sacrier smashes the ground with incredible force, making stone columns sprout up around the target. They inflict damage and generate Armor for each enemy hit; the Armor absorbs the next attacks received.",
+      "es": "El sacrógrito golpea con todas sus fuerzas el suelo, alzando columnas alrededor del objetivo. Inflige daños y genera armadura por adversario herido. Esta armadura absorbe los próximos ataques recibidos.",
+      "pt": "O Sacrier bate no chão com toda a força, fazendo com que surjam colunas em torno do alvo. Ele inflige danos e gera armadura por adversário atingido: a armadura absorve os próximos ataques recebidos."
+    }
+  },
+  {
+    "spellId": 5038,
+    "name": {
+      "fr": "Aversion",
+      "en": "Aversion",
+      "es": "Aversión",
+      "pt": "Aversão"
+    },
+    "description": {
+      "fr": "Inflige des dommages monocible à un ennemi. Ces dommages sont plus élevés si le Sacrieur est stabilisé.",
+      "en": "Inflicts single-target damage on an enemy. This damage is greater if the Sacrier is stabilized.",
+      "es": "Inflige daños de objetivo único a un enemigo. Estos daños son mayores si el sacrógrito está Estabilizado.",
+      "pt": "Causa danos de alvo único a um inimigo. Esses danos serão mais elevados se o Sacrier estiver estabilizado."
+    }
+  },
+  {
+    "spellId": 5039,
+    "name": {
+      "fr": "Poing tatoué agrippant",
+      "en": "Sacrier's Fist",
+      "es": "Puño Tatuabalanzante",
+      "pt": "Punho Tatuado"
+    },
+    "description": {
+      "fr": "Ce sort rapproche le lanceur de sa cible de quelques cases.",
+      "en": "This spell moves the caster a few cells closer to their target.",
+      "es": "Este hechizo acerca el lanzador a su objetivo unas casillas.",
+      "pt": "Este feitiço aproxima o lançador do alvo em algumas células."
+    }
+  },
+  {
+    "spellId": 5040,
+    "name": {
+      "fr": "Assaut",
+      "en": "Assault",
+      "es": "Asalto",
+      "pt": "Agressão"
+    },
+    "description": {
+      "fr": "Échange la place du lanceur avec celle de sa cible tout en lui infligeant quelques dégâts au passage.",
+      "en": "The caster switches places with their target, dealing some damage in the process.",
+      "es": "Intercambia la posición del lanzador por la de su objetivo y le inflige algunos daños.",
+      "pt": "Troca o lançador de lugar com o alvo, aproveitando para causar dano a ele."
+    }
+  },
+  {
+    "spellId": 5041,
+    "name": {
+      "fr": "Projection",
+      "en": "Projection",
+      "es": "Proyección",
+      "pt": "Projeção"
+    },
+    "description": {
+      "fr": "Le Sacrieur utilise sa cible pour se projeter vers l'avant et bondir de l'autre côté.",
+      "en": "The Sacrier uses their target to dash forward and jump to the other side.",
+      "es": "El sacrógrito utiliza su objetivo para lanzarse hacia delante y saltar al otro lado.",
+      "pt": "O Sacrier usa seu alvo para se lançar para frente e saltar para o outro lado."
+    }
+  },
+  {
+    "spellId": 5042,
+    "name": {
+      "fr": "Fulgurance",
+      "en": "Light Speed",
+      "es": "Fulgor",
+      "pt": "Fulgurância"
+    },
+    "description": {
+      "fr": "Le Sacrieur inflige des dégâts à ses ennemis dans une grande zone, puis réapparaît de l'autre côté de la zone ciblée.",
+      "en": "The Sacrier inflicts damage on their enemies in a large area of effect then reappears on the other side of the targeted area.",
+      "es": "El sacrógrito inflige daños a los enemigos en una gran zona y luego reaparece al otro lado de la zona en cuestión.",
+      "pt": "O Sacrier inflige danos aos inimigos em uma grande zona e depois reaparece do outro lado da zona visada."
+    }
+  },
+  {
+    "spellId": 5043,
+    "name": {
+      "fr": "Attirance",
+      "en": "Attraction",
+      "es": "Atracción",
+      "pt": "Atração"
+    },
+    "description": {
+      "fr": "Attire une cible vers le Sacrieur depuis une grande distance.",
+      "en": "Attracts a target towards the Sacrier from far away.",
+      "es": "Atrae un objetivo hacia el sacrógrito desde gran distancia.",
+      "pt": "Atrai um alvo em direção ao Sacrier a partir de uma grande distância."
+    }
+  },
+  {
+    "spellId": 5044,
+    "name": {
+      "fr": "Transposition",
+      "en": "Transposition",
+      "es": "Transposición",
+      "pt": "Transposição"
+    },
+    "description": {
+      "fr": "Le Sacrieur échange sa place avec un allié ou ennemi.",
+      "en": "The Sacrier switches places with an ally or enemy.",
+      "es": "El sacrógrito intercambia su posición con un aliado o un enemigo.",
+      "pt": "O Sacrier troca de lugar com um aliado ou com um inimigo."
+    }
+  },
+  {
+    "spellId": 5045,
+    "name": {
+      "fr": "Sacrifice",
+      "en": "Sacrifice",
+      "es": "Sacrificio",
+      "pt": "Sacrifício"
+    },
+    "description": {
+      "fr": "Le Sacrieur se sacrifie pour prendre les coups à la place de ses alliés. À chaque fois qu'un allié subit un sort infligeant des dégâts, le Sacrieur subit les dégâts puis échange de place avec l'allié.",
+      "en": "With a gesture of self-sacrifice, the Sacrier takes blows on behalf of allies. Each time an ally suffers a spell that inflicts damage, the Sacrier suffers the damage, then switches places with the ally.",
+      "es": "El sacrógrito se sacrifica para recibir los golpes en lugar de sus aliados. Cada vez que un aliado recibe un hechizo que cause daños, el sacrógrito recibe los daños y cambia su posición con el aliado.",
+      "pt": "O Sacrier se sacrifica levando os golpes no lugar de seus aliados. Toda vez que um aliado sofre um feitiço que inflige danos, o Sacrier sofre os danos e depois troca de lugar com o aliado."
+    }
+  },
+  {
+    "spellId": 5047,
+    "name": {
+      "fr": "Armure sanguine",
+      "en": "Sanguine Armor",
+      "es": "Armadura Sanguínea",
+      "pt": "Armadura Sanguínea"
+    },
+    "description": {
+      "fr": "Le Sacrieur crée, pour lui ou un allié, une Armure puissante qui absorbe les dégâts jusqu'à un certain seuil. De plus, pendant un tour, il augmente le Tacle pour garder les adversaires au contact et stabilise pour ne plus pouvoir être déplacé.",
+      "en": "The Sacrier creates, for themself or an ally, powerful Armor that absorbs damage up to a certain threshold. Also, for one turn, they increase Lock to keep enemies in close combat and stabilize them so they can't be moved.",
+      "es": "El sacrógrito crea para él o para un aliado una poderosa armadura que absorbe los daños hasta cierto umbral. Además, durante un turno, aumenta el placaje para mantener a los adversarios en el cuerpo a cuerpo y estabiliza para que no lo puedan desplazar.",
+      "pt": "O Sacrier cria, para ele ou para um aliado, uma armadura poderosa que absorve os danos até um determinado limite. Além disso, durante um turno, ele aumenta o bloqueio para manter os adversários em contato e se estabiliza para não poder mais ser deslocado."
+    }
+  },
+  {
+    "spellId": 7211,
+    "name": {
+      "fr": "Entaille",
+      "en": "Gash",
+      "es": "Corte",
+      "pt": "Entalhe"
+    },
+    "description": {
+      "fr": "Le Sacrieur inflige à un allié, ou à lui-même, une partie de sa vie en dégâts pour augmenter les Dommages infligés au prochain sort. Entaille peut être très puissant en combinaison à Sacrifice pour se déplacer.",
+      "en": "The Sacrier inflicts part of their life as damage on an ally (or themself) to increase the damage inflicted next turn. Gash can be very powerful when combined with Sacrifice to move.",
+      "es": "El sacrógrito inflige a un aliado o a sí mismo daños por valor de una parte de su vida para aumentar los daños causados en el siguiente hechizo. Corte puede ser muy poderoso para desplazarse si se combina con Sacrificio.",
+      "pt": "O Sacrier inflige a um aliado ou a si mesmo uma parte de sua vida em danos para aumentar os danos infligidos no próximo feitiço. O Entalhe pode ser muito poderoso se combinado com Sacrifício para se deslocar."
+    }
+  },
+  {
+    "spellId": 7212,
+    "name": {
+      "fr": "Transfert sanguin",
+      "en": "Blood Transfer",
+      "es": "Transferencia Sanguínea",
+      "pt": "Transfusão Sanguínea"
+    },
+    "description": {
+      "fr": "Le Sacrieur transfère une partie de sa vie à un allié, puis échange de position avec. S'il se cible directement, il convertit une partie de son Armure en soin.",
+      "en": "The Sacrier transfers some of their health to an ally and then switches places with them. If they target themself, some of their Armor is converted to healing.",
+      "es": "El sacrógrito transfiere una parte de su vida a un aliado, después cambia de posición con él. Si lo lanza sobre sí mismo, convierte una parte de su armadura en curas.",
+      "pt": "O Sacrier transfere uma parte de sua vida a um aliado e, em seguida, troca de lugar com ele. Se ele visar a si mesmo diretamente, ele converte uma parte de sua armadura em cura."
+    }
+  },
+  {
+    "spellId": 4702,
+    "name": {
+      "fr": "Souffle Enflammé",
+      "en": "Flaming Burp",
+      "es": "Escupe Fuegos",
+      "pt": "Sopro Flamejante"
+    },
+    "description": {
+      "fr": "Le Pandawa souffle vers ses adversaires et leur inflige des dégâts de Feu ! De plus il leur retire des résistances si elles sont <b>Imbibées</b> !",
+      "en": "The Pandawa blows on his opponents and deals them Fire damage! What's more, he removes their resistances if they are <b>Dizzy!</b>",
+      "es": "¡El pandawa escupe hacia sus enemigos y les inflige daños de fuego! Además, les retira resistencias si están <b>achispados</b>.",
+      "pt": "O Pandawa sopra na direção de seus adversários e inflige danos de fogo! Além disso, ele retira as resistências se eles estiverem <b>Tontos</b>!"
+    }
+  },
+  {
+    "spellId": 4703,
+    "name": {
+      "fr": "Tournée Générale",
+      "en": "Light My Fire",
+      "es": "Ronda General",
+      "pt": "Rodada Geral"
+    },
+    "description": {
+      "fr": "Tournée Générale permet au Pandawa d'infliger généreusement des dégâts Feu tout en s'enflammant. Lancés sur le Tonneau, celui-ci est détruit mais applique une grande quantité d'Imbibé autour de lui.",
+      "en": "Light My Fire allows the Pandawa to be really generous with his Fire damage, while becoming Flaming. Cast on a Barrel, the Barrel is destroyed but applies a large quantity of Dizzy around it.",
+      "es": "Ronda General permite al pandawa causar muchos daños de fuego y, al mismo tiempo, inflamarse. Al lanzarlo sobre el tonel, este se destruye pero aplica una gran cantidad de Achispado a su alrededor.",
+      "pt": "Rodada Geral permite que o Pandawa provoque danos generosos de fogo ao mesmo tempo que fica flamejante. Quando lançado no Barril, este é destruído, mas aplica uma grande quantidade de Tonto ao redor dele."
+    }
+  },
+  {
+    "spellId": 4704,
+    "name": {
+      "fr": "Coup Laiteux",
+      "en": "Dairy Springer",
+      "es": "Golpe Lechoso",
+      "pt": "Golpe Leitoso"
+    },
+    "description": {
+      "fr": "Le Pandawa échaude et inflige des dommages en zone sur ses ennemis, avant de se téléporter sur la case ciblée.",
+      "en": "The Pandawa scalds and inflicts damage on their enemies in an area of effect before teleporting to the targeted cell.",
+      "es": "El pandawa escalda e inflige daños en zona en sus enemigos, antes de teletransportarse a la casilla seleccionada.",
+      "pt": "O Pandawa escalda e inflige danos em zona a seus inimigos antes de se teletransportar para a célula visada."
+    }
+  },
+  {
+    "spellId": 4705,
+    "name": {
+      "fr": "Flasque Explosive",
+      "en": "Explosive Flask",
+      "es": "Frasco Explosivo",
+      "pt": "Frasco Explosivo"
+    },
+    "description": {
+      "fr": "Le Pandawa lance une flasque remplie de Lait de Bambou qui explose sur ses adversaires.",
+      "en": "The Pandawa chucks a flask of Bamboo Milk which explodes all over his enemies.",
+      "es": "El pandawa lanza un frasco lleno de leche de bambú que explota sobre el adversario.",
+      "pt": "O Pandawa lança um frasco cheio de Leite de Bambu que explode sobre seus adversários."
+    }
+  },
+  {
+    "spellId": 4706,
+    "name": {
+      "fr": "Toilaitage",
+      "en": "Milking It",
+      "es": "Lactortazos",
+      "pt": "Puro Deleite"
+    },
+    "description": {
+      "fr": "Amateur de dégâts collatéraux, Toilaitage permet au Pandawa de nettoyer une grande zone. Si son Tonneau est dans la zone, il inflige plus de dommages.",
+      "en": "A big fan of collateral damage, Milking It lets the Pandawa clear a large area. If his Barrel is in the area, he inflicts even more damage.",
+      "es": "Especializado en daños colaterales, con Lactortazos el pandawa podrá barrer una gran zona. Si el tonel está en zona, inflige más daños.",
+      "pt": "Grande fã de danos colaterais, o Pandawa pode limpar uma grande zona com Puro Deleite. Se seu Barril estiver na zona, ele inflige ainda mais danos."
+    }
+  },
+  {
+    "spellId": 4707,
+    "name": {
+      "fr": "Souffle Laiteux",
+      "en": "Milky Breath",
+      "es": "Escupe Leches",
+      "pt": "Sopro Leitoso"
+    },
+    "description": {
+      "fr": "Le Pandawa souffle sur sa cible et lui inflige des dégâts d'Eau bien sentis. De plus, ce souffle imbibe la cible ! Si le Pandawa lance un allié avec ce sort, l'allié est soigné.",
+      "en": "The Pandawa blows on his target, inflicting a painful burst of Water-type damage. Moreover, the target will end up Dizzy! If the Pandawa throws an ally with this spell, the ally is healed.",
+      "es": "El pandawa sopla hacia sus adversarios y les causa fuertes daños de agua. Además, ¡este soplido achispa al objetivo! Si el pandawa lanza a un aliado con este hechizo, el aliado se cura.",
+      "pt": "O Pandawa sopra seu alvo e lhe inflige danos de Água consideráveis. Além disso, este sopro deixa o alvo tonto! Se o Pandawa lança um aliado com este feitiço, o aliado é curado."
+    }
+  },
+  {
+    "spellId": 4708,
+    "name": {
+      "fr": "Nuage Laiteux",
+      "en": "Splash of Milk",
+      "es": "Nube de Leche",
+      "pt": "Nuvem Leitosa"
+    },
+    "description": {
+      "fr": "Le Pandawa crée un Nuage Laiteux qui inflige des dégâts et imbibe les cibles ! Lancé sur le Tonneau, cela crée un Nuage de Lait qui soigne toutes les cibles présentes dessus à leur début de tour.",
+      "en": "The Pandawa creates a Splash of Milk which inflicts damage and makes targets Dizzy! Cast on the Barrel, this creates a Milk Cloud that heals all targets present on it at their start of turn.",
+      "es": "El pandawa crea una Nube Lechosa que causa daños y achispa a los objetivos. Si lo lanza sobre el tonel, crea una nube lechosa que cura a todos los objetivos presentes encima al principio de su turno.",
+      "pt": "O Pandawa cria uma Nuvem Leitosa que inflige danos e deixa os alvos tontos! Quando lançado no Barril, uma Nuvem de Leite se forma e cura todos os alvos que estiverem sobre ela no começo do turno deles."
+    }
+  },
+  {
+    "spellId": 4709,
+    "name": {
+      "fr": "Tekilait",
+      "en": "Bubble Trouble",
+      "es": "Tequileche",
+      "pt": "Tekileite"
+    },
+    "description": {
+      "fr": "Tekilait réalise un soin sur sa cible. Il permet également, si le Pandawa est aligné avec sa cible, de le pousser de deux cases.",
+      "en": "Bubble Trouble heals its target. If the Pandawa is in line with their target, it can also push the target two cells.",
+      "es": "Tequileche realiza una cura a su objetivo. Si el pandawa está alineado con su objetivo, también permite empujarlo dos casillas.",
+      "pt": "Tekileite cura o alvo. Se o Pandawa estiver alinhado com o alvo, também pode empurrá-lo por 2 células"
+    }
+  },
+  {
+    "spellId": 4710,
+    "name": {
+      "fr": "Vague de Lait",
+      "en": "Milk Wave",
+      "es": "Tsunami",
+      "pt": "Onda de Leite"
+    },
+    "description": {
+      "fr": "Créant une Vague de Lait, le Pandawa consomme l'Imbibé de son allié pour le soigner. Il peut aussi s'en servir pour faire des dégâts à un adversaire. Lancé sur le Tonneau, les dégâts passent en zone.",
+      "en": "Creating a Milk Wave, the Pandawa consumes their ally's Dizziness to heal them. They can also use it to inflict damage on an opponent. Cast on the Barrel, the damage becomes area damage.",
+      "es": "Al crear una ola de leche, el pandawa consume el estado Achispado de su aliado para curarlo. También puede usarlo para provocar daños a un adversario. Si lo lanza sobre el tonel, los daños son de zona.",
+      "pt": "Ao criar uma Onda de Leite, o Pandawa consome o estado Tonto de seu aliado para curá-lo. Ele também pode usá-la para infligir danos a um adversário. Quando lançado sobre o barril, os danos são transferidos para a zona de efeito."
+    }
+  },
+  {
+    "spellId": 4711,
+    "name": {
+      "fr": "Fontaine de Laiqueur",
+      "en": "Milk Fountain",
+      "es": "Fuente de Leches",
+      "pt": "Fonte de Leite"
+    },
+    "description": {
+      "fr": "Partageur, le Pandawa paie sa tournée, tout en blessant ses ennemis : si le sort est lancé sur le Tonneau, toutes les cibles seront irrésistiblement attirées vers lui !",
+      "en": "The playful Pandawa uses Milk Fountain to inflict damage on his enemies. If the spell is cast on the Barrel, all the targets will find themselves irresistibly attracted to it!",
+      "es": "El pandawa, generoso, paga una ronda y causa daños a sus enemigos. Si lanza el hechizo al tonel, ¡los objetivos serán atraídos irresistiblemente hacia él!",
+      "pt": "Generoso, o Pandawa paga uma rodada e causa danos em seus inimigos. Se o feitiço for lançado sobre o Barril, todos os alvos serão irresistivelmente atraídos por ele!"
+    }
+  },
+  {
+    "spellId": 4712,
+    "name": {
+      "fr": "Triple Karma Leet",
+      "en": "Triple Whammy",
+      "es": "Triple Karma Gnosborne",
+      "pt": "Triplo Karmalte"
+    },
+    "description": {
+      "fr": "Le Pandawa inflige des dégâts tout en repoussant son adversaire. S'il porte son Tonneau, il attirera son adversaire au lieu de le repousser !",
+      "en": "The Pandawa inflicts damage while pushing his enemy backwards. If he is carrying his Barrel, it will land on his opponent instead of pushing him back!",
+      "es": "El pandawa causa daños a la vez que empuja a su adversario. Si porta el tonel, atraerá a los adversarios en lugar de empujarlos.",
+      "pt": "O Pandawa inflige danos ao mesmo tempo em que empurra seu adversário. Se ele estiver carregando seu Barril, atrairá o adversário ao invés de empurrá-lo!"
+    }
+  },
+  {
+    "spellId": 4713,
+    "name": {
+      "fr": "Six Roses",
+      "en": "Six Roses",
+      "es": "Six Roses",
+      "pt": "Bêbambu"
+    },
+    "description": {
+      "fr": "Six Roses inflige de gros dégâts Terre, imbibe la cible et enflamme le Pandawa ! Si le Pandawa porte son Tonneau, il s'applique une Armure en fonction du niveau d'Imbibé de sa cible.",
+      "en": "Six Roses inflicts heavy Earth damage, makes the target Dizzy, and sets the Pandawa Flaming! If the Pandawa is carrying their Barrel, they increase their resistance based on how Dizzy the target is.",
+      "es": "Causa grandes daños de tierra y deja al objetivo en estado Achispado y al pandawa en estado Ardiente. Si el pandawa porta su tonel, aplica una armadura en función del nivel de Achispado de su objetivo.",
+      "pt": "Bêbambu inflige grandes danos de terra, deixa o alvo Tonto e deixa o Pandawa Flamejante! Se o Pandawa estiver carregando seu Barril, ele aplica a si mesmo uma armadura em função do nível de Tonto de seu alvo."
+    }
+  },
+  {
+    "spellId": 4714,
+    "name": {
+      "fr": "Frappe Fût",
+      "en": "Barrel Blow",
+      "es": "Golpe de Tonel",
+      "pt": "Golpe de Barril"
+    },
+    "description": {
+      "fr": "Le Pandawa inflige des dégâts et imbibe les cibles autour de lui. Si le Pandawa porte son Tonneau, il augmente son Tacle et ses résistances.",
+      "en": "The Pandawa inflicts damage and makes the surrounding targets dizzy. If the Pandawa is carrying their Barrel, they increase their Lock and resistances.",
+      "es": "El pandawa inflige daños y emborracha a los objetivos a su alrededor. Si el pandawa porta su tonel, aumenta su placaje y sus resistencias.",
+      "pt": "O Pandawa inflige danos e deixa tontos os alvos que estiverem ao redor dele. Se o Pandawa estiver carregando seu Barril, ele aumenta seu bloqueio e resistências."
+    }
+  },
+  {
+    "spellId": 4715,
+    "name": {
+      "fr": "Lucha L'ambrée",
+      "en": "Lactic Acid",
+      "es": "Lucha Cubalibre",
+      "pt": "Ácido Lático"
+    },
+    "description": {
+      "fr": "Le Pandawa utilise son Tonneau pour faire des dégâts à distance et imbiber les cibles ! Si le Pandawa porte un personnage, il le lance en infligeant des dégâts et en retirant des PM dans la zone.",
+      "en": "The furious Pandawa uses his Barrel to inflict long-distance damage, making targets Dizzy in the process! If the Pandawa is carrying a character, he throws him, inflicting damage and removing MP in the area.",
+      "es": "El pandawa usa su tonel para causar daños a distancia y achispar a sus víctimas. Si el pandawa porta a un personaje, lo lanza para infligir daños y retirar PM en la zona.",
+      "pt": "O Pandawa usa seu Barril para provocar danos a distância e deixar seus alvos tontos! Se o Pandawa estiver carregando um personagem, ele o lança, infligindo danos e retirando PM na zona."
+    }
+  },
+  {
+    "spellId": 4716,
+    "name": {
+      "fr": "Blitzkriek",
+      "en": "Blisskrieg",
+      "es": "Barriltzkrieg",
+      "pt": "Barriltzkrieg"
+    },
+    "description": {
+      "fr": "Le Pandawa inflige des dégâts en zone. Ses cibles ennemies sont échaudées, et le lanceur du sort se téléporte à la position ciblée s'il portait son Tonneau.",
+      "en": "The Pandawa inflicts damage in an area of effect. The targeted enemies are scalded, and the spell caster teleports to the targeted position if they are carrying their Barrel.",
+      "es": "El pandawa inflige daños en zona. Sus objetivos enemigos resultan escaldados, y el lanzador del hechizo se teletransporta a la posición seleccionada si portaba su tonel.",
+      "pt": "O Pandawa inflige danos em zona. Seus alvos inimigos ficam Escaldados, e o lançador do feitiço se teletransporta para a posição visada se ele estiver carregando seu Barril."
+    }
+  },
+  {
+    "spellId": 4717,
+    "name": {
+      "fr": "Coup de bambou",
+      "en": "Bamboo Blow",
+      "es": "Golpe de Bambú",
+      "pt": "Golpe de Bambu"
+    },
+    "description": {
+      "fr": "Coup de bambou retire des résistances, des coups critiques et de la parade à la cible pendant un tour.",
+      "en": "Bamboo Blow removes resistances, critical hits, and blocking from the target for one turn.",
+      "es": "Golpe de Bambú retira resistencias, golpes críticos y anticipación al objetivo durante un turno.",
+      "pt": "Golpe de Bambu retira resistências, golpes críticos e parada do alvo por um turno."
+    }
+  },
+  {
+    "spellId": 4719,
+    "name": {
+      "fr": "Ether",
+      "en": "Ether",
+      "es": "Éter",
+      "pt": "Éter"
+    },
+    "description": {
+      "fr": "La cible d'Ether devient stabilisée. Si la cible est un allié, celui-ci gagne des PM et devient intaclable. Si la cible est un adversaire, celui-ci ne peut plus tacler.",
+      "en": "The Ether target becomes stabilized. If the target is an ally, they gain MP and become Unlockable. If the target is an opponent, they can no longer lock.",
+      "es": "El objetivo de Éter se vuelve estabilizado. Al utilizarlo sobre un aliado, ganará PM y se volverá no placable. Al utilizarlo sobre un adversario, no podrá volver a placar.",
+      "pt": "O alvo de Éter fica estável. Se o alvo for um aliado, ele ganha PM e não pode ser bloqueado. Se for um adversário, fica impossibilitado de bloquear."
+    }
+  },
+  {
+    "spellId": 4720,
+    "name": {
+      "fr": "Téléportono",
+      "en": "Barrelhop",
+      "es": "Toneportación",
+      "pt": "Teleportonel"
+    },
+    "description": {
+      "fr": "Le Pandawa ne supporte pas d'être éloigné de son Lait de Bambou. La nature fait bien les choses, puisque Téléportono permet justement au Pandawa de se téléporter à côté de lui.",
+      "en": "The Pandawa can't bear to be too far away from his Bamboo Milk. Thankfully, nature has ways of taking care of this, as Barrelhop allows the Pandawa to teleport, ending up right next to his Barrel.",
+      "es": "El pandawa no sabe vivir sin su leche de bambú. La naturaleza es sabia y por eso, con Toneportación, puede teletransportarse al lado de su tonel.",
+      "pt": "O Pandawa não suporta ficar longe do seu Leite de Bambu. A natureza é sábia, porque o Teleportonel permite justamente que o Pandawa se teletransporte para perto do seu barril."
+    }
+  },
+  {
+    "spellId": 4721,
+    "name": {
+      "fr": "Happy Hour",
+      "en": "Bamboozle",
+      "es": "Happy Hour",
+      "pt": "Happy Hour"
+    },
+    "description": {
+      "fr": "Le Pandawa paie sa tournée et plonge ses cibles dans l'ivresse du combat. Lancé sur lui, il gagne une armure de mêlée. Sur ses alliés, un soin sur plusieurs tours. Sur le Tonneau, il repousse les cibles se trouvant autour.",
+      "en": "The Pandawa tricks any targets and makes them Merry. Cast on self, the Pandawa gains a melee armor. On allies, one heal over several turns. On the Barrel, pushes back any surrounding targets.",
+      "es": "El pandawa paga una ronda y sume a sus aliados en la embriaguez del combate. Si lo lanza sobre sí mismo, consigue una armadura de melé. Si lo lanza sobre sus aliados, consiguen una cura durante varios turnos. Si lo lanza sobre el tonel, empuja a los objetivos que lo rodean.",
+      "pt": "O Pandawa paga uma rodada e mergulha seus adversários na embriaguez do combate. Se for lançado sobre ele mesmo, ele ganha uma armadura de combate a curta distância. Sobre seus aliados, oferece uma cura em vários turnos. Sobre o Barril, ele empurra os alvos que estiverem ao seu redor."
+    }
+  },
+  {
+    "spellId": 6844,
+    "name": {
+      "fr": "Soif",
+      "en": "Thirst",
+      "es": "Sed",
+      "pt": "Sede"
+    },
+    "description": {
+      "fr": "Si le Pandawa porte son tonneau, il peut utiliser ce sort pour échanger de position avec un allié ou échauder un ennemi : il subira plus de dommages indirects, comme les poisons.",
+      "en": "If the Pandawa is carrying their barrel, they can use this spell to switch places with an ally or scald an enemy; the enemy will take more indirect damage, such as poison.",
+      "es": "Si el pandawa porta su tonel, puede utilizar este hechizo para intercambiar posición con un aliado o escaldar a un enemigo: sufrirá más daños indirectos, como pasa con los venenos.",
+      "pt": "Se o Pandawa estiver carregando seu Barril, ele pode usar este feitiço para trocar de lugar com um aliado ou escaldar um inimigo: ele sofrerá mais danos indiretos, como os venenos."
+    }
+  },
+  {
+    "spellId": 6845,
+    "name": {
+      "fr": "Ebriété",
+      "en": "Exhilaration",
+      "es": "Ebriedad",
+      "pt": "Sobriedade"
+    },
+    "description": {
+      "fr": "Ebriété permet de s'appliquer Ivresse ou de l'entretenir, pratique lorsqu'il n'y a pas de tonneau à proximité ! Ce sort applique 5 niveaux d'imbibé s'il est lancé sur une autre cible que le Pandawa lui-même.",
+      "en": "Exhilaration applies or maintains Merriment, which comes in handy when there aren't any barrels nearby. This spell applies 5 levels of Dizzy if it is cast on a target other than the Pandawa themself.",
+      "es": "Ebriedad permite aplicarse o mantener Embriaguez, ¡lo que resulta práctico cuando no hay un tonel cerca! Este hechizo aplica 5 niveles de Achispado si se lanza a otro objetivo que no sea el pandawa mismo.",
+      "pt": "Sobriedade permite manter ou aplicar Embriaguez a si mesmo. Muito prático quando não há nenhum barril por perto! Este feitiço aplica 5 níveis de Tonto se for lançado em um alvo que não seja o próprio Pandawa."
+    }
+  },
+  {
+    "spellId": 6463,
+    "name": {
+      "fr": "Barbrûlé",
+      "en": "Barbed Fire",
+      "es": "Llamambrada",
+      "pt": "Fogo Farpado"
+    },
+    "description": {
+      "fr": "Le Roublard peut lancer ce sort sur une bombe. De cette manière, les dommages sont répliqués au contact de sa bombe, et le Roublard gagne de la Poudre pour chaque cible touchée.",
+      "en": "The Rogue can cast this spell on a bomb. As a result, the damage is replicated adjacent to the bomb, and the Rogue gains Powder for each target hit.",
+      "es": "El tymador puede lanzar este hechizo sobre una bomba. Así, los daños se replican al contacto con su bomba y el tymador gana pólvora por cada objetivo alcanzado.",
+      "pt": "O Ladino usa um arame farpado mágico como chicote para roubar vida de um adversário ou curar e reforçar uma de suas bombas."
+    }
+  },
+  {
+    "spellId": 6464,
+    "name": {
+      "fr": "Bombe collante",
+      "en": "Sticky Bomb",
+      "es": "Bomba Pegajosa",
+      "pt": "Bomba Ofuscante"
+    },
+    "description": {
+      "fr": "Pose une bombe collante sur la cible. Lorsque la cible meurt ou que trois tours passent, une explosion se déclenche autour de la cible. Si la cible est une bombe, elle est stabilisée (ne peut plus être déplacée) et explose si elle subit des dommages.",
+      "en": "Places a sticky bomb on the target. When the target dies or three turns go by, an explosion is triggered around the target. If the target is a bomb, it is stabilized (can no longer be moved) and explodes if it suffers damage.",
+      "es": "Coloca una bomba pegajosa sobre el objetivo. Cuando el objetivo muere o pasan tres turnos, se produce una explosión alrededor del objetivo. Si el objetivo es una bomba, esta se estabiliza (no se puede volver a desplazar) y explota si sufre daños.",
+      "pt": "Coloca uma bomba no campo de batalha para deixar os adversários com os olhos arregalados de espanto! Quando explode, ela inflige danos e retira alcance."
+    }
+  },
+  {
+    "spellId": 6465,
+    "name": {
+      "fr": "Exécution",
+      "en": "Execution",
+      "es": "Ejecución",
+      "pt": "Execução"
+    },
+    "description": {
+      "fr": "Si le Roublard tue sa cible ennemie avec ce sort, il gagne de la Poudre.",
+      "en": "If the Rogue kills their enemy target with this spell, they gain Powder.",
+      "es": "Si el tymador mata a su objetivo enemigo con este hechizo, gana pólvora.",
+      "pt": "Os danos deste tiro aumentam a cada explosão de bomba, permitindo uma boa execução, de acordo com a tradição."
+    }
+  },
+  {
+    "spellId": 6466,
+    "name": {
+      "fr": "Croisement",
+      "en": "Crosswise",
+      "es": "Cruce",
+      "pt": "Tiro Cruzado"
+    },
+    "description": {
+      "fr": "Ce tir ne se lance qu'en diagonale mais à très longue portée. Il a pour objectif d'atteindre des cibles placées dans des angles morts pour en faire des cibles mortes.\\nLes bombes alignées avec la cible sont attirées vers le point d'impact.",
+      "en": "This shot can only be cast on the diagonal, but has very long range. It's ideal for those hard-to-reach places and can turn blind spots into dead targets.\\nBombs aligned with the target are pulled toward the point of impact.",
+      "es": "Este tiro solo se lanza en diagonal, pero desde muy larga distancia. Es capaz de alcanzar a los objetivos situados en los ángulos muertos para convertirlos en objetivos muertos.\\nLas bombas en línea con el objetivo son atraídas hacia el punto de impacto.",
+      "pt": "Este tiro só pode ser lançado em diagonal, mas é de longo alcance. Ele tem como objetivo alcançar alvos que se encontram em ângulos mortos para transformá-los em alvos mortos."
+    }
+  },
+  {
+    "spellId": 6467,
+    "name": {
+      "fr": "Perforation",
+      "en": "Perforation",
+      "es": "Perforación",
+      "pt": "Tiro Penetrante"
+    },
+    "description": {
+      "fr": "Ce tir permet au Roublard de briser l'armure de sa cible puis d'infliger des dommages colossaux. Un sort très précieux contre, entre autres, ces petits malins de Fécas.",
+      "en": "This shot lets the Rogue break its target's Armor and then inflict colossal damage. This spell is very useful for attacks on cocky Fecas, and others of course.",
+      "es": "Con este tiro, el tymador puede destrozar la armadura de su objetivo e infligirle daños enormes. Un hechizo muy útil contra, entre otros, esos taimados fecas.",
+      "pt": "Este tiro permite que o Ladino quebre a armadura de seu alvo e depois inflija danos colossais se tiver muitos pontos de Wakfu. Um feitiço excelente contra, entre outros, aqueles espertinhos dos Fecas."
+    }
+  },
+  {
+    "spellId": 6468,
+    "name": {
+      "fr": "Mitraille",
+      "en": "Machine Gun",
+      "es": "Metralla",
+      "pt": "Metralha"
+    },
+    "description": {
+      "fr": "Tout en s'éloignant, le Roublard assène un bon coup de Mitraille dans les entrailles des fous qui seraient dans sa ligne de mire. Si le sort est lancé sur une bombe, elle est téléportée 2 cases plus loin. Si la case est occupée, la bombe échange de position avec la cible.",
+      "en": "While keeping their distance, the Rogue can mow down anyone foolish enough to get in their crosshairs. If the spell is cast on a bomb, it is teleported 2 cells farther. If the cell is occupied, the bomb switches places with the target.",
+      "es": "El tymador, mientras se aleja, propina un buen golpe de metralla en las entrañas de aquellos insensatos que estén en su línea de visión. Si se lanza el hechizo sobre una bomba, esta se teletransporta 2 casillas más lejos. Si la casilla está ocupada, la bomba intercambia posición con el objetivo.",
+      "pt": "Ao mesmo tempo em que se afasta, o Ladino desfere um bom tiro de Metralha nas entranhas dos loucos que estiverem em sua mira."
+    }
+  },
+  {
+    "spellId": 6469,
+    "name": {
+      "fr": "Tromblon",
+      "en": "Blunderbuss",
+      "es": "Tromba",
+      "pt": "Mosquete"
+    },
+    "description": {
+      "fr": "Inflige des dommages et pousse la cible. Si le sort est lancé sur une bombe, les effets sont joués en croix autour d'elle.",
+      "en": "Inflicts damage and pushes the target. If the spell is cast on a bomb, the effects are applied in a cross around it.",
+      "es": "Inflige daños y empuja al objetivo. Si el hechizo se lanza sobre una bomba, los efectos se juegan en cruz a su alrededor.",
+      "pt": "\"Blam!!! Este certamente será o último barulho que ouvirão os cretinos que tentarem ficar no meu caminho\". \\n- Remington Smif"
+    }
+  },
+  {
+    "spellId": 6470,
+    "name": {
+      "fr": "Balle plombante",
+      "en": "Encumbering Shot",
+      "es": "Bala Emplomada",
+      "pt": "Bomba Paralisante"
+    },
+    "description": {
+      "fr": "Ce sort retire des PM aux cibles du Roublard en mode Fuyard, ou gagne des niveaux de Retour de dague en mode Fourbe. Si le sort est lancé sur une bombe, les effets sont joués en ligne.",
+      "en": "This spell removes MP from the Rogue's targets in Runaway mode, or gains levels of Dagger Return in Sneaky mode. If the spell is cast on a bomb, the effects are applied in a straight line.",
+      "es": "Este hechizo retira PM a los objetivos del tymador en modo Huidizo o hace ganar niveles de Vuelta de Daga en modo Ruin. Si el hechizo se lanza sobre una bomba, los efectos se juegan en línea.",
+      "pt": "Coloca uma bomba no campo de batalha para deixar os adversários paralisados de terror! Quando explode, ela inflige danos e retira pontos de movimento."
+    }
+  },
+  {
+    "spellId": 6471,
+    "name": {
+      "fr": "Dague boomerang",
+      "en": "Boomerang Dagger",
+      "es": "Daga Bumerán",
+      "pt": "Adaga Bumerangue"
+    },
+    "description": {
+      "fr": "En Fourbe, le Roublard inflige des dommages à sa cible et lui applique un état. En Fuyard, le Roublard fait des dommages en zone boomerang, et déclenche les états préalablement posés : il inflige ainsi des dommages en plus en croix autour de chaque cible concernée.",
+      "en": "In Sneaky mode, the Rogue inflicts damage on their target and applies a state. In Runaway mode, the Rogue does damage in a boomerang area of effect and triggers the previously applied states, inflicting extra damage in a cross around each target affected.",
+      "es": "En Ruin, el tymador inflige daños a su objetivo y le aplica un estado. En Huidizo, el tymador hace daños en zona bumerán y activa los estados puestos previamente: también inflige daños adicionales en cruz alrededor de cada objetivo afectado.",
+      "pt": "O Ladino usa sua adaga como bumerangue, atirando-a em seus adversários. Em golpe crítico, adiciona um tiro, infligindo bem mais danos que um golpe crítico clássico."
+    }
+  },
+  {
+    "spellId": 6472,
+    "name": {
+      "fr": "Pulsar",
+      "en": "Pulsar",
+      "es": "Púlsar",
+      "pt": "Pulsar"
+    },
+    "description": {
+      "fr": "Le Roublard peut charger son Pulsar pour faire des dommages dévastateurs.",
+      "en": "The Rogue can charge their Pulsar to deal devastating damage.",
+      "es": "El tymador puede cargar Púlsar para causar daños devastadores.",
+      "pt": "Com este disparo, seus adversários ficarão vermelhos de raiva. Se for bem ajustado, é devastador. Os danos de Pulsar aumentam com os combos das bombas em sua zona de efeito."
+    }
+  },
+  {
+    "spellId": 6473,
+    "name": {
+      "fr": "Coup rapide",
+      "en": "Slap Shot",
+      "es": "Golpe Rápido",
+      "pt": "Golpe Rápido"
+    },
+    "description": {
+      "fr": "\"Il vaut mieux un petit coup rapide bien placé qu'un gros coup à côté.\"\\n- Katsumimi la Roublarde",
+      "en": "\"An accurate slap shot is better than any inaccurate slop shot.\"\\n- Katsumimi the Rogue",
+      "es": "\"Más vale un golpecito rápido bien dado que cien golpes al aire\".\\n—Katsumimi la tymadora",
+      "pt": "\"Mais vale um golpe rápido na mão que dois golpes certeiros voando.\"\\n- Katsumimi, a Ladina."
+    }
+  },
+  {
+    "spellId": 6474,
+    "name": {
+      "fr": "Tricherie",
+      "en": "Cheating",
+      "es": "Trampa",
+      "pt": "Costelas Grelhadas"
+    },
+    "description": {
+      "fr": "Le Roublard vole de la vie à sa cible. Si le sort est lancé sur une bombe, le Roublard échange de position avec.",
+      "en": "The Rogue steals health from the target. If the spell is cast on a bomb, the Rogue switches places with it.",
+      "es": "El tymador roba vida a su objetivo. Si el hechizo se lanza sobre una bomba, el tymador intercambia de posición con ella.",
+      "pt": "Com este feitiço, o Ladino realizará um ataque habilidoso e sanguinário que, apesar do nome, a vítima pode não gostar muito."
+    }
+  },
+  {
+    "spellId": 6475,
+    "name": {
+      "fr": "Espingole",
+      "en": "Carbine",
+      "es": "Arcabuz",
+      "pt": "Gancho"
+    },
+    "description": {
+      "fr": "Ce tir rebondit d'un ennemi à l'autre, infligeant de plus en plus de dommages. Les bombes du Roublard sont concernées par les rebonds, mais ne subissent pas de dommages.",
+      "en": "This shot rebounds from one enemy to another, inflicting more and more damage. The Rogue's bombs are included in the rebounds, but do not take damage from them.",
+      "es": "Este tiro rebota de un enemigo a otro, infligiendo cada vez más daño. Los rebotes afectan a las bombas del tymador, pero no sufren daños.",
+      "pt": "Não há dúvidas, o Gancho Flamejante é diabolicamente infernal!\\n- Menino do inferno"
+    }
+  },
+  {
+    "spellId": 6476,
+    "name": {
+      "fr": "Oblitération",
+      "en": "Obliteration",
+      "es": "Obliteración",
+      "pt": "Bomba Asfixiante"
+    },
+    "description": {
+      "fr": "Inflige des dommages air sur une ligne de 3 cases. Les cibles touchées sont téléportées plus loin.",
+      "en": "Inflicts Air damage in a 3-cell line. Affected targets are teleported farther.",
+      "es": "Inflige daños de aire en una línea de 3 casillas. Los objetivos alcanzados se teletransportan más lejos.",
+      "pt": "Coloca uma bomba no campo de batalha para não deixar seus adversários respirarem. Quando explode, ela inflige danos e retira pontos de Wakfu temporariamente."
+    }
+  },
+  {
+    "spellId": 6478,
+    "name": {
+      "fr": "Longue lame",
+      "en": "Longsword",
+      "es": "Larga Hoja",
+      "pt": "Lâmina Longa"
+    },
+    "description": {
+      "fr": "Lorsqu'elle est entre de bonnes mains cette épée peut sembler magique. Si le Roublard est en Fourbe, il applique un état à la cible : à la fin du tour, s'il se situe à 6 cases ou plus, la cible subira des dommages en plus.",
+      "en": "In the right hands, this sword can seem magical. If the Rogue is in Sneaky mode, they apply a state to the target: at the end of the turn, if they're 6 or more cells away, the target will suffer extra damage.",
+      "es": "Si cae en buenas manos, esta espada puede parecer mágica. Si el tymador está en Ruin, aplica un estado al objetivo: al final del turno, si se sitúa a 6 casillas o más, el objetivo sufrirá daños adicionales.",
+      "pt": "Quando está em boas mãos, esta espada pode parecer mágica."
+    }
+  },
+  {
+    "spellId": 6489,
+    "name": {
+      "fr": "Défourailleur",
+      "en": "Fusillade",
+      "es": "Descargador",
+      "pt": "Fuzilaria"
+    },
+    "description": {
+      "fr": "Le Roublard entre en mode \"Défourailleur\" pendant 2 tours : il fait exploser toutes ses bombes et gagne des dommages infligés sur ses dommages directs et des PM.",
+      "en": "The Rogue enters Fusillade mode for 2 turns, making all their bombs explode and gaining a boost to their direct damage inflicted and their MP.",
+      "es": "El tymador entra en modo Descargador durante 2 turnos: explosiona todas sus bombas y gana daños infligidos sobre sus daños directos y PM.",
+      "pt": "O Ladino entra no modo \"Fuzilaria\" durante 2 turnos: ele explode todas as bombas dele e ganha danos infligidos nos seus danos diretos e PM."
+    }
+  },
+  {
+    "spellId": 6490,
+    "name": {
+      "fr": "Botte",
+      "en": "Boot",
+      "es": "Patada",
+      "pt": "Repelente"
+    },
+    "description": {
+      "fr": "Le Roublard attrape la bombe la plus proche de lui, dans la même ligne ou diagonale, pour la déplacer sur la case ciblée. Si le sort est lancé sur une bombe ou sur lui-même, les cibles autour sont repoussées d'une case.",
+      "en": "The Rogue grabs the closest bomb, in the same line or diagonally, and moves it to the targeted cell. If the spell is cast on a bomb or the caster, nearby targets are pushed back 1 cell.",
+      "es": "El tymador toma la bomba más próxima a él, en la misma línea o en diagonal, para desplazarla a la casilla objetivo. Si lanza el hechizo sobre una bomba o sobre sí mismo, los objetivos de alrededor son empujados una casilla.",
+      "pt": "O Ladino arremessa uma de suas bombas um pouco mais longe. Necessita de uma bomba no corpo a corpo do Ladino na mesma fileira ou na mesma diagonal que você visar."
+    }
+  },
+  {
+    "spellId": 6491,
+    "name": {
+      "fr": "Evanescence",
+      "en": "Evanescence",
+      "es": "Evanescencia",
+      "pt": "Muro de Pólvora"
+    },
+    "description": {
+      "fr": "Le Roublard se sert d'une bombe comme pivot pour se téléporter de l'autre côté.",
+      "en": "The Rogue uses a bomb as a pivot to teleport to the other side.",
+      "es": "El tymador usa una bomba como pivote para teletransportarse al otro lado.",
+      "pt": "Um Muro de Pólvora se forma entre todas as bombas presentes no terreno, infligindo enormes danos a quem tiver o azar de começar seu turno em cima dele."
+    }
+  },
+  {
+    "spellId": 6492,
+    "name": {
+      "fr": "Grappin",
+      "en": "Claw",
+      "es": "Gancho",
+      "pt": "Ladinobot"
+    },
+    "description": {
+      "fr": "En fuyard, le Roublard utilise son grappin pour se rapprocher d'un combattant. En fourbe, il attire sa cible puis passe dans son dos.",
+      "en": "In Runaway mode, the Rogue uses their claw to get close to a fighter. In Sneaky mode, the Rogue attracts the target, then moves behind them.",
+      "es": "En Huidizo, el tymador utiliza su gancho para acercarse a un luchador. En Ruin, atrae a su objetivo luego pasa a su espalda.",
+      "pt": "O Ladinobot é uma ferramenta engenhosa que o Ladino pode controlar para gerenciar melhor suas bombas e mover alvos."
+    }
+  },
+  {
+    "spellId": 6493,
+    "name": {
+      "fr": "Aimant",
+      "en": "Magnet",
+      "es": "Imán",
+      "pt": "Dinamite"
+    },
+    "description": {
+      "fr": "Ce sort doit cibler une bombe du Roublard. Il attire de deux cases tous les combattants alignés, sans limites de distance.",
+      "en": "This spell must target one of the Rogue's bombs. It pulls all aligned fighters 2 cells closer, with no distance limit.",
+      "es": "Este hechizo debe seleccionar una bomba del tymador. Atrae dos casillas a todos los combatientes alineados, sin límite de distancia.",
+      "pt": "Atenção, vai tudo voar pelos ares, proteja-se!"
+    }
+  },
+  {
+    "spellId": 6494,
+    "name": {
+      "fr": "Fumigènes",
+      "en": "Smoke Bombs",
+      "es": "Fumígenos",
+      "pt": "Enfumaçado"
+    },
+    "description": {
+      "fr": "Fumigènes réduit les dommages reçus à distance d'un allié, ou réduit les dommages infligés à distance d'un ennemi. En plus, la cible ne bloque plus la ligne de vue. Si la cible est un allié, elle est immunisée aux dommages des bombes du Roublard.",
+      "en": "Smoke Bombs reduces an ally's ranged damage received, or reduces an enemy's ranged damage inflicted. In addition, the target no longer blocks line of sight. If the target is an ally, they become immune to damage from the Rogue's bombs.",
+      "es": "Fumígenos reduce los daños recibidos a distancia de un aliado o reduce los daños infligidos a distancia de un enemigo. Además, ya no bloquea la línea de visión. Si el objetivo es un aliado, es inmune a los daños de las bombas del tymador.",
+      "pt": "Enfumaçado reduz os de danos recebidos a distância de um aliado, ou reduz os danos infligidos a distância de um inimigo. Além disso, o alvo não bloqueia mais a linha de visão. Se o alvo for um aliado, ele fica imunizado aos danos das bombas do Ladino."
+    }
+  },
+  {
+    "spellId": 7066,
+    "name": {
+      "fr": "Coup de pied fouetté",
+      "en": "Whipkick",
+      "es": "Patada Azotada",
+      "pt": "Chuticote"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages puis retourne la cible, de manière à donner son dos.",
+      "en": "This spell inflicts damage and turns the target around so that its back faces the caster.",
+      "es": "Este hechizo inflige daños y luego gira al objetivo de forma que quede de espaldas.",
+      "pt": "Este feitiço inflige danos e depois vira o alvo, que fica de costas."
+    }
+  },
+  {
+    "spellId": 7067,
+    "name": {
+      "fr": "Félure",
+      "en": "Fracture",
+      "es": "Hendidura",
+      "pt": "Fratura"
+    },
+    "description": {
+      "fr": "Un sort simple mais efficace, qui inflige des dégâts en zone et réduit les protections et soins reçus par les ennemis.",
+      "en": "A simple yet effective spell that causes damage in an area of effect and reduces the protection and heals received by enemies.",
+      "es": "Un hechizo simple pero eficaz que causa daños en zona y reduce las protecciones y curas que los enemigos reciben.",
+      "pt": "Um feitiço simples e eficaz que causa dano em zona e reduz as proteções e curas recebidas pelos inimigos."
+    }
+  },
+  {
+    "spellId": 7068,
+    "name": {
+      "fr": "Détraquage",
+      "en": "Unhinging",
+      "es": "Perturbación",
+      "pt": "Despistagem"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages aux ennemis en zone. Si des alliés sont dans la zone de dommages, ils gagnent un bonus de dommages.",
+      "en": "This spell inflicts damage on enemies in an area of effect. If there are allies in the damage area, they receive a damage bonus.",
+      "es": "Este hechizo inflige daños a los enemigos en zona. Si hay aliados en la zona de daños, estos ganan un bonus de daños.",
+      "pt": "Este feitiço inflige danos aos inimigos em zona. Se houver aliados na zona de danos, eles ganharão um bônus de danos."
+    }
+  },
+  {
+    "spellId": 7069,
+    "name": {
+      "fr": "Névrose",
+      "en": "Neurosis",
+      "es": "Neurosis",
+      "pt": "Neurose"
+    },
+    "description": {
+      "fr": "Ce sort permet d'attirer les ennemis autour d'un allié, ou d'infliger des dommages importants à un ennemi en monocible, selon la cible.",
+      "en": "Depending on the target, this spell can pull enemies in around an ally, or inflict considerable single-target damage on an enemy.",
+      "es": "Este hechizo permite atraer a los enemigos alrededor de un aliado o infligir importantes daños a un enemigo en objetivo único, según el objetivo.",
+      "pt": "Este feitiço permite atrair os inimigos ao redor de um aliado ou infligir danos consideráveis a um inimigo como alvo único, dependendo do alvo."
+    }
+  },
+  {
+    "spellId": 7070,
+    "name": {
+      "fr": "Cabriole",
+      "en": "Capering",
+      "es": "Cabriola",
+      "pt": "Cabriola"
+    },
+    "description": {
+      "fr": "Le Zobal se téléporte à plusieurs cases de distance tout en faisant des dommages sur son passage. Si des alliés sont sur son chemin, ils gagnent de l'armure.",
+      "en": "The Masqueraider teleports several cells away, dealing damage along the way. If any allies are in their path, those allies gain armor.",
+      "es": "El zobal se teletransporta varias casillas de distancia, causando daños a su paso. Si hay aliados en su camino, estos ganan armadura.",
+      "pt": "O Zobal se teletransporta a várias células de distância infligindo danos por onde passa. Se houver aliados no caminho, eles ganham armadura."
+    }
+  },
+  {
+    "spellId": 7071,
+    "name": {
+      "fr": "Signe",
+      "en": "Sign",
+      "es": "Señales",
+      "pt": "Sinal"
+    },
+    "description": {
+      "fr": "Ce sort flexible peut soigner un allié ou infliger des dommages à un ennemi.",
+      "en": "This flexible spell can heal an ally or inflict damage on an enemy.",
+      "es": "Este hechizo flexible puede curar a un aliado o infligir daños a un enemigo.",
+      "pt": "Este feitiço flexível pode curar um aliado ou infligir danos a um inimigo."
+    }
+  },
+  {
+    "spellId": 7072,
+    "name": {
+      "fr": "Armature",
+      "en": "Armature",
+      "es": "Armazón",
+      "pt": "Armadurecer"
+    },
+    "description": {
+      "fr": "Ce sort donne une bonne quantité d'Armure et de Tacle à un allié, afin de l'aider à apprécier les combats en mêlée.",
+      "en": "This spell gives a good amount of Armor and Lock to an ally to help them appreciate the joys of melee fighting.",
+      "es": "Este hechizo da una buena cantidad de armadura y de placaje a un aliado para que opte más por el combate de melé.",
+      "pt": "Este feitiço concede uma boa quantidade de armadura e bloqueio a um aliado para ajudá-lo a apreciar os combates a curta distância."
+    }
+  },
+  {
+    "spellId": 7073,
+    "name": {
+      "fr": "Rescousse",
+      "en": "Deliverance",
+      "es": "Salvamento",
+      "pt": "Socorro"
+    },
+    "description": {
+      "fr": "Rescousse est un sort de zone. Il inflige des dégâts aux ennemis touchés, et les alliés dans la zone sont soignés et gagnent de l'Esquive pendant un tour.",
+      "en": "Deliverance is an area-of-effect spell. It inflicts damage on enemies, and allies in the area of effect are healed and gain Dodge for one turn.",
+      "es": "Salvamento es un hechizo de zona. Inflige daños a los enemigos alcanzados, y los aliados en la zona se curan y ganan esquiva durante un turno.",
+      "pt": "Resgate é um feitiço de zona. Ele inflige danos aos inimigos atingidos, enquanto os aliados na zona são curados e ganham Esquiva por um turno."
+    }
+  },
+  {
+    "spellId": 7074,
+    "name": {
+      "fr": "Acharnement",
+      "en": "Manhunt",
+      "es": "Ensañamiento",
+      "pt": "Obstinação"
+    },
+    "description": {
+      "fr": "Ce sort possède un effet en zone : il inflige des dommages aux ennemis et soigne les alliés.",
+      "en": "This spell has an area of effect: It inflicts damage on enemies and heals allies.",
+      "es": "Este hechizo posee un efecto en zona: inflige daños a los enemigos y cura a los aliados.",
+      "pt": "Esse feitiço tem um efeito de zona: ele inflige danos aos inimigos e cura os aliados."
+    }
+  },
+  {
+    "spellId": 7075,
+    "name": {
+      "fr": "Sarabande",
+      "en": "Sarabande",
+      "es": "Zarabanda",
+      "pt": "Sarabanda"
+    },
+    "description": {
+      "fr": "Sur un ennemi, le Zobal inflige des dégâts et peut retirer un Point de Wakfu. Sur un allié, il le soigne.",
+      "en": "When cast on an enemy, the Masqueraider inflicts damage and may remove one Wakfu Point. On an ally, they heal him.",
+      "es": "En un enemigo, el zobal inflige daños y puede retirar un punto de Wakfu. Si lo lanza a un aliado, lo cura.",
+      "pt": "Em um inimigo, o Zobal inflige danos e pode retirar um Ponto de Wakfu. Em um aliado, ele cura"
+    }
+  },
+  {
+    "spellId": 7076,
+    "name": {
+      "fr": "Fugue",
+      "en": "Fugue",
+      "es": "Fuga",
+      "pt": "Fuga"
+    },
+    "description": {
+      "fr": "Le Zobal inflige des dommages à une cible avec lui, puis recule d'une case tout en le repoussant.",
+      "en": "The Masqueraider inflicts damage on a target, then moves back 1 cell while pushing it back.",
+      "es": "El zobal inflige daños a un objetivo, luego retrocede una casilla a la vez que le empuja.",
+      "pt": "O Zobal inflige danos a um alvo alinhado com ele e depois recua por uma célula ao mesmo tempo que o empurra."
+    }
+  },
+  {
+    "spellId": 7077,
+    "name": {
+      "fr": "Poursuite",
+      "en": "Pursuit",
+      "es": "Persecución",
+      "pt": "Perseguição"
+    },
+    "description": {
+      "fr": "Poursuite permet de faire reculer la cible, tout en la poursuivant pour qu'elle ne s'échappe pas.",
+      "en": "Pursuit is used to push the target back and chase after them so they can't get away.",
+      "es": "Persecución permite hacer retroceder al objetivo y lo persigue para que no escape.",
+      "pt": "Perseguição faz com que o alvo recue e o persegue para que ele não escape."
+    }
+  },
+  {
+    "spellId": 7078,
+    "name": {
+      "fr": "Culbute",
+      "en": "Somersault",
+      "es": "Brinco",
+      "pt": "Virada"
+    },
+    "description": {
+      "fr": "Le Zobal tire la cible puis passe dans son dos.",
+      "en": "The Masqueraider pulls the target and slips behind their back.",
+      "es": "El zobal tira de su objetivo y luego se pone detrás de él.",
+      "pt": "O Zobal puxa o alvo e se coloca atrás dele."
+    }
+  },
+  {
+    "spellId": 7079,
+    "name": {
+      "fr": "Cavalcade",
+      "en": "Cavalcade",
+      "es": "Cabalgata",
+      "pt": "Cavalgada"
+    },
+    "description": {
+      "fr": "Cavalcade permet de lier le Zobal à une cible. Il pourra ensuite la tirer avec lui.",
+      "en": "Cavalcade can link the Masqueraider to a target. They can then pull the target with them.",
+      "es": "Cabalgata permite vincular al zobal con un objetivo. Una vez vinculado, lo arrastrará con él.",
+      "pt": "Liga o Zobal a um alvo. Depois, ele pode arrastá-lo consigo."
+    }
+  },
+  {
+    "spellId": 7080,
+    "name": {
+      "fr": "Dislocation",
+      "en": "Dislocation",
+      "es": "Disyunción",
+      "pt": "Luxação"
+    },
+    "description": {
+      "fr": "Le Zobal effectue un saut vers sa cible, et échange de position avec celle-ci.",
+      "en": "The Masqueraider leaps toward their target and switches places with the target.",
+      "es": "El zobal efectúa un salto hacia su objetivo e intercambia la posición con él.",
+      "pt": "O Zobal dá um salto em direção ao alvo e troca de lugar com ele."
+    }
+  },
+  {
+    "spellId": 7084,
+    "name": {
+      "fr": "Entrechoquement",
+      "en": "Clashing",
+      "es": "Entrechoque",
+      "pt": "Entrechocamento"
+    },
+    "description": {
+      "fr": "Ce sort permet d'infliger plus de dommages à un ennemi. Si cet ennemi est ensuite ciblé par d'autres sorts de déplacement du Zobal, il subira toujours des collisions même si la cible est isolée ou stabilisée.",
+      "en": "This spell can be used to inflict more damage on an enemy. If the enemy is then targeted by the Masqueraider's other movement spells, they will still suffer collisions even if the target is isolated or stabilized.",
+      "es": "Este hechizo permite infligir más daños a un enemigo. Si seguidamente se selecciona a este enemigo con otros hechizos de desplazamiento del zobal, seguirá sufriendo colisiones incluso si el objetivo está aislado o estabilizado.",
+      "pt": "Este feitiço permite infligir mais danos a um inimigo. Se esse inimigo for alvo de outros feitiços de deslocamento do Zobal, ele ainda sofrerá colisões mesmo estando isolado ou estabilizado."
+    }
+  },
+  {
+    "spellId": 7085,
+    "name": {
+      "fr": "Danse motivante",
+      "en": "Inspiring Dance",
+      "es": "Danza Motivadora",
+      "pt": "Dança Motivadora"
+    },
+    "description": {
+      "fr": "Ce sort applique un état qui booste la mobilité et la protection d'un allié (ou du Zobal lui-même) pendant deux tours.",
+      "en": "This spell applies a state that boosts an ally's (or the Masqueraider's) mobility and protection for two turns.",
+      "es": "Este hechizo aplica un estado que potencia la movilidad y la protección de un aliado (o del propio zobal) durante dos turnos.",
+      "pt": "Este feitiço aplica um estado que fortalece a mobilidade e a proteção de um aliado (ou do próprio Zobal) por dois turnos."
+    }
+  },
+  {
+    "spellId": 7086,
+    "name": {
+      "fr": "Danse macabre",
+      "en": "Dance of Death",
+      "es": "Danza Macabra",
+      "pt": "Dança Macabra"
+    },
+    "description": {
+      "fr": "Est-ce une danse ou un rituel ? Nul ne le sait. Toujours est-il que la Danse Macabre du Zobal lui permet de ressusciter ses alliés.",
+      "en": "A simple dance, or a deadly ritual? Nobody knows for sure. Either way, the Masqueraider's Dance of Death can revive allies.",
+      "es": "¿Es una danza o un ritual? Nadie lo sabe. Con Danza Macabra, el zobal podrá resucitar a sus aliados.",
+      "pt": "É uma dança ou um ritual? Ninguém sabe. A questão é que a Dança Macabra do Zobal permite que ele ressuscite aliados."
+    }
+  },
+  {
+    "spellId": 7087,
+    "name": {
+      "fr": "Voltige",
+      "en": "Acrobatics",
+      "es": "Acrobatismo",
+      "pt": "Acrobacia"
+    },
+    "description": {
+      "fr": "Le Zobal se téléporte sur une case libre, à côté d'un combattant allié ou ennemi. Il gagne aussi des résistances jusqu'au prochain tour.",
+      "en": "The Masqueraider teleports to an empty cell next to an allied or enemy fighter. They also gain resistances until the next turn.",
+      "es": "El zobal se teletransporta a una casilla vacía, al lado de un luchador aliado o enemigo. También gana resistencias hasta el siguiente turno.",
+      "pt": "O Zobal se teletransporta para uma célula livre ao lado de um combatente aliado ou inimigo. Ele também ganha resistências até o próximo turno."
+    }
+  },
+  {
+    "spellId": 7088,
+    "name": {
+      "fr": "Aura de brutalité",
+      "en": "Brutality Aura",
+      "es": "Aura de Brutalidad",
+      "pt": "Aura de Brutalidade"
+    },
+    "description": {
+      "fr": "Le Zobal s'entoure d'une Aura de brutalité. Les alliés à son contact infligent plus de dommages à leurs adversaires.",
+      "en": "The Masqueraider is surrounded by a Brutality Aura. Adjacent allies inflict more damage on their opponents.",
+      "es": "El zobal se rodea de un aura de brutalidad. Los aliados en contacto infligen más daños a sus adversarios.",
+      "pt": "O Zobal se cerca de uma Aura de Brutalidade. Os aliados em contato com ele infligem mais danos aos adversários."
+    }
+  },
+  {
+    "spellId": 7089,
+    "name": {
+      "fr": "Solidité",
+      "en": "Solidity",
+      "es": "Solidez",
+      "pt": "Solidez"
+    },
+    "description": {
+      "fr": "Le Zobal stabilise sa cible. La cible ne peut plus subir d'effet de déplacement (téléportation, poussée, etc.) pendant 1 tour. De plus, le Zobal gagne de l'Armure.",
+      "en": "The Masqueraider stabilizes their target. The target is immune to all movement effects (teleportation, pushback, etc.) for 1 turn. Also, the Masqueraider gains Armor.",
+      "es": "El zobal estabiliza a su objetivo. El objetivo ya no puede sufrir efectos de desplazamiento (teletransportación, empuje, etc.) durante 1 turno. Además, el zobal gana armadura.",
+      "pt": "O Zobal estabiliza o alvo. Esse alvo não pode mais sofrer efeitos de deslocamento (teletransporte, empurrão, etc) durante 1 turno. Além disso, o Zobal ganha Armadura."
+    }
+  },
+  {
+    "spellId": 6256,
+    "name": {
+      "fr": "Plombage",
+      "en": "Weigh Down",
+      "es": "Emplomado",
+      "pt": "Rebaixamento"
+    },
+    "description": {
+      "fr": "Ce sort inflige de puissants dommages à ses adversaires en ligne. Les dommages sont augmentés si l'Ouginak possède beaucoup de PV.",
+      "en": "This spell inflicts powerful damage on opponents in a line. The damage is increased if the Ouginak has high HP.",
+      "es": "Este hechizo inflige potentes daños a los adversarios en línea. Los daños aumentan si el uginak tiene muchos PdV.",
+      "pt": "Este feitiço inflige danos potentes a seus adversários em linha reta. Os danos são aumentados se o Kilorf tiver muito PV."
+    }
+  },
+  {
+    "spellId": 6257,
+    "name": {
+      "fr": "Fléau",
+      "en": "Flail",
+      "es": "Plaga",
+      "pt": "Flagelo"
+    },
+    "description": {
+      "fr": "L'Ouginak crée un geyser sous ses cibles. Il récupère une partie de la vie qu'il leur retire.",
+      "en": "The Ouginak creates a geyser under their targets. They recover part of the HP removed from the targets.",
+      "es": "El uginak crea un géiser bajo sus objetivos. Recupera una parte de la vida que les retira.",
+      "pt": "O Kilorf cria um gêiser debaixo de seus alvos. Ele recupera uma parte da vida que tira deles."
+    }
+  },
+  {
+    "spellId": 6258,
+    "name": {
+      "fr": "Rupture",
+      "en": "Rupture",
+      "es": "Ruptura",
+      "pt": "Ruptura"
+    },
+    "description": {
+      "fr": "Les dommages de ce sort s'accompagnent d'un vol de vie. Le sort est plus puissant sur les invocations.",
+      "en": "This spell's damage comes with a health steal. The spell is more powerful on summons.",
+      "es": "Los daños de este hechizo incluyen un robo de vida. El hechizo es más potente en las invocaciones.",
+      "pt": "Os danos deste feitiço são acompanhados de um roubo de vida. O feitiço é mais potente nas invocações."
+    }
+  },
+  {
+    "spellId": 6259,
+    "name": {
+      "fr": "Balafre",
+      "en": "Gash",
+      "es": "Cuchillada",
+      "pt": "Cutilada"
+    },
+    "description": {
+      "fr": "L'Ouginak inflige de lourds dommages à la cible et lui applique un malus de soins et d'armure reçus. Le malus est plus grand si l'Ouginak possède beaucoup de PV.",
+      "en": "The Ouginak inflicts heavy damage on the target and applies a penalty on its healing and armor received. The penalty is larger if the Ouginak has high HP.",
+      "es": "El uginak inflige grandes daños al objetivo y le aplica un malus de curas y de armadura recibidos. El malus es mayor si el uginak posee muchos PdV.",
+      "pt": "O Kilorf inflige danos pesados ao alvo e aplica nele uma penalidade de armadura e de curas recebidas. A penalidade é maior quando o Kilorf tem muitos PV."
+    }
+  },
+  {
+    "spellId": 6260,
+    "name": {
+      "fr": "Emeute",
+      "en": "Ruckus",
+      "es": "Disturbio",
+      "pt": "Motim"
+    },
+    "description": {
+      "fr": "L'Ouginak vole un PM à sa cible. Le vol est plus élevé si l'Ouginak possède beaucoup de PV.",
+      "en": "The Ouginak steals an MP from their target. The theft is greater if the Ouginak has lots of HP.",
+      "es": "El uginak roba 1 PM a su objetivo. El robo es más elevado si el uginak tiene muchos PdV.",
+      "pt": "O Kilorf rouba um PM do alvo. O roubo é mais elevado quando o Kilorf tem muitos PV."
+    }
+  },
+  {
+    "spellId": 6261,
+    "name": {
+      "fr": "Croc-en-jambe",
+      "en": "Fang in the Works",
+      "es": "Zascadilla",
+      "pt": "Presa Rasteira"
+    },
+    "description": {
+      "fr": "C'est un des grands classiques de l'Ouginak. Sa morsure paralyse sa cible, l'empêchant de s'enfuir.",
+      "en": "A huge classic among Ouginaks. Their bite paralyzes their target, preventing it from fleeing.",
+      "es": "Es uno de los grandes clásicos del uginak. Su mordedura paraliza a su objetivo, impidiéndole escapar.",
+      "pt": "É um dos grandes clássicos do Kilorf. Sua mordida paralisa o alvo, impedindo-o de fugir."
+    }
+  },
+  {
+    "spellId": 6262,
+    "name": {
+      "fr": "Hachure",
+      "en": "Crosshatch",
+      "es": "Rayadura",
+      "pt": "Hachura"
+    },
+    "description": {
+      "fr": "Hachure fait des dommages en zone et marque les cibles : pendant un tour, elles subiront des dommages supplémentaires à chaque fois que l'Ouginak les attaque directement.",
+      "en": "Crosshatch does damage in an area of effect and marks the targets; for one turn, they will suffer additional damage each time the Ouginak attacks them directly.",
+      "es": "Rayadura causa daños en zona y marca a los objetivos: durante un turno, sufrirán daños adicionales cada vez que el uginak los ataque directamente.",
+      "pt": "Hachura causa danos em zona e marca os alvos: durante um turno, eles sofrerão danos adicionais toda vez que o Kilorf os atacar diretamente."
+    }
+  },
+  {
+    "spellId": 6263,
+    "name": {
+      "fr": "Bastonnade",
+      "en": "Brawl",
+      "es": "Apaleamiento",
+      "pt": "Quebra-Quebra"
+    },
+    "description": {
+      "fr": "Inflige des dommages terre à une cible. Au tour suivant, les dommages sont triplés sur les cibles ayant déjà subi le sort.",
+      "en": "Inflicts Earth damage on a target. On the following turn, damage is tripled on targets that have already been hit by the spell.",
+      "es": "Inflige daños de tierra a un objetivo. En el siguiente turno, los daños se triplican en los objetivos que ya hayan sufrido el hechizo.",
+      "pt": "Inflige danos de terra a um alvo. No turno seguinte, os danos são triplicados nos alvos que já tiverem recebido este feitiço."
+    }
+  },
+  {
+    "spellId": 6264,
+    "name": {
+      "fr": "Saccade",
+      "en": "Fits and Starts",
+      "es": "Tirón",
+      "pt": "Tranco"
+    },
+    "description": {
+      "fr": "L'Ouginak inflige des dommages supplémentaires sur l'Armure de la cible, en plus de se protéger à son tour.",
+      "en": "The Ouginak inflicts additional damage on the target's Armor, as well as protecting themself in turn.",
+      "es": "El uginak inflige daños adicionales sobre la armadura del objetivo, además de protegerse él mismo.",
+      "pt": "O Kilorf inflige danos adicionais à armadura do alvo, além de se proteger."
+    }
+  },
+  {
+    "spellId": 6265,
+    "name": {
+      "fr": "Molosse",
+      "en": "Watchdog",
+      "es": "Moloso",
+      "pt": "Molosso"
+    },
+    "description": {
+      "fr": "L'Ouginak inflige des dommages en zone et gagne de l'Armure en fonction du nombre d'ennemis qu'il touche.",
+      "en": "The Ouginak does damage in an area of effect and gains Armor depending on the number of enemies they hit.",
+      "es": "El uginak inflige daños en zona y gana armadura en función del número de enemigos a los que alcanza.",
+      "pt": "O kilorf inflige danos em zona e ganha armadura em função do número de inimigos que atingir."
+    }
+  },
+  {
+    "spellId": 6266,
+    "name": {
+      "fr": "Balayage",
+      "en": "Sweeping",
+      "es": "Barrido",
+      "pt": "Varredura"
+    },
+    "description": {
+      "fr": "L'Ouginak attire sa cible et lui inflige des dommages air. Les dommages sont plus élevés si la cible se retrouve à son contact.",
+      "en": "The Ouginak attracts their target and inflicts air damage on it. The damage is greater if the target is adjacent to them.",
+      "es": "El uginak atrae a su objetivo y le inflige daños de aire. Los daños son mayores si el objetivo se encuentra en su contacto.",
+      "pt": "O Kilorf atrai seu alvo e lhe inflige danos de ar. Os danos são mais elevados se o alvo estiver em contato com ele."
+    }
+  },
+  {
+    "spellId": 6267,
+    "name": {
+      "fr": "Contusion",
+      "en": "Contusion",
+      "es": "Contusión",
+      "pt": "Contusão"
+    },
+    "description": {
+      "fr": "L'Ouginak pousse les combattants autour de la cible en infligeant des dommages aux ennemis.",
+      "en": "The Ouginak pushes back fighters around the target and inflicts damage on enemies.",
+      "es": "El uginak empuja a los luchadores de alrededor del objetivo infligiéndoles daños a los enemigos.",
+      "pt": "O Kilorf empurra os combatentes ao redor do alvo infligindo danos aos inimigos."
+    }
+  },
+  {
+    "spellId": 6268,
+    "name": {
+      "fr": "Cador",
+      "en": "Big Dog",
+      "es": "Gran Can",
+      "pt": "Maioral"
+    },
+    "description": {
+      "fr": "L'Ouginak utilise son grappin pour blesser son ennemi ! Il en profite pour passer dans son dos.",
+      "en": "The Ouginak uses their grapple to injure their enemy! They use it to get behind them.",
+      "es": "¡El uginak utiliza su garra para herir a su enemigo! Aprovecha para ponerse a sus espaldas.",
+      "pt": "O Kilorf utiliza seu gancho para ferir seu inimigo! Ele aproveita para passar por trás dele."
+    }
+  },
+  {
+    "spellId": 6269,
+    "name": {
+      "fr": "Brise'Os",
+      "en": "Bone-Breaker",
+      "es": "Fracturahuesos",
+      "pt": "Quebra-Osso"
+    },
+    "description": {
+      "fr": "L'Ouginak applique un poison sur sa cible. Elle subira des dommages à chacun de ses déplacements pendant son tour.",
+      "en": "The Ouginak applies a poison on their target. The target will suffer damage on every movement during its turn.",
+      "es": "El uginak aplica un veneno sobre su objetivo. Sufrirá daños cada vez que se desplace durante su turno.",
+      "pt": "O Kilorf aplica um veneno ao alvo. Este último receberá danos toda vez que se deslocar durante seu turno."
+    }
+  },
+  {
+    "spellId": 6270,
+    "name": {
+      "fr": "Baroud",
+      "en": "Pugnacity",
+      "es": "Bulla",
+      "pt": "Briga Feia"
+    },
+    "description": {
+      "fr": "L'Ouginak applique son plus puissant poison sur son ennemi... Si la cible termine son tour au corps-à-corps de l'Ouginak, elle subit des dommages supplémentaires !",
+      "en": "The Ouginak applies their most powerful poison on their enemy... If the target ends its turn in close combat with the Ouginak, it suffers additional damage!",
+      "es": "El uginak aplica su veneno más potente a su enemigo... Si el objetivo termina su turno en cuerpo a cuerpo del uginak, ¡sufre daños adicionales!",
+      "pt": "O Kilorf aplica seu veneno mais potente em seu inimigo... Se o alvo terminar seu turno no corpo a corpo com o Kilorf, ele sofrerá danos adicionais!"
+    }
+  },
+  {
+    "spellId": 6284,
+    "name": {
+      "fr": "Chasseur",
+      "en": "Hunter",
+      "es": "Cazador",
+      "pt": "Caçador"
+    },
+    "description": {
+      "fr": "L'Ouginak peut se rapprocher de ses adversaires mais peut aussi attirer ses alliés grâce à ses capacités de Chasseur. Si la cible est sa Proie, le coût du sort est remboursé.",
+      "en": "The Ouginak can use their Hunter abilities to either get closer to opponents or attract allies. If the target is their Prey, the cost of the spell is reimbursed.",
+      "es": "El uginak puede acercarse a sus adversarios, pero también puede atraer a sus aliados gracias a sus habilidades de cazador. Si el objetivo es su presa, el coste del hechizo se devuelve.",
+      "pt": "O Kilorf pode se aproximar de seus adversários, mas também atrair seus aliados graças às suas habilidades de Caçador. Se o alvo for sua Presa, o custo do feitiço será reembolsado."
+    }
+  },
+  {
+    "spellId": 6285,
+    "name": {
+      "fr": "Poursuite",
+      "en": "Pursuit",
+      "es": "Persecución",
+      "pt": "Perseguição"
+    },
+    "description": {
+      "fr": "L'Ouginak est un maître dans l'art de traquer ses proies. Il prépare son attaque et bondit sur son adversaire.",
+      "en": "The Ouginak has mastered the art of tracking prey. It prepares to attack and pounces on its opponent.",
+      "es": "El uginak es un maestro del arte de rastrear a sus presas. Prepara su ataque y salta hacia su adversario.",
+      "pt": "O Kilorf é mestre na arte de rastrear suas presas. Ele prepara seu ataque e parte para cima de seu adversário."
+    }
+  },
+  {
+    "spellId": 6287,
+    "name": {
+      "fr": "Canine",
+      "en": "Canine",
+      "es": "Colmillo",
+      "pt": "Canino"
+    },
+    "description": {
+      "fr": "L'Ouginak pose un glyphe qui inflige des dommages et immobilise les cibles qui débutent leur tour dedans.",
+      "en": "The Ouginak places a glyph that inflicts damage on and immobilizes any targets that start their turn on it.",
+      "es": "El uginak coloca un glifo que inflige daños e inmoviliza a los objetivos que inician su turno dentro de él.",
+      "pt": "O Kilorf coloca um glifo que inflige danos e imobiliza os alvos que começarem seu turno dentro dele."
+    }
+  },
+  {
+    "spellId": 6288,
+    "name": {
+      "fr": "Apaisement",
+      "en": "Appeasement",
+      "es": "Amaine",
+      "pt": "Apaziguamento"
+    },
+    "description": {
+      "fr": "L'Ouginak se concentre pour donner des PM à sa cible. S'il possède suffisamment de Rage, il la consomme pour donner de l'Armure à sa cible.",
+      "en": "The Ouginak concentrates to give their MP to their target. If they have enough Fury, they consume it to give their target Armor.",
+      "es": "El uginak se concentra para dar PM a su objetivo. Si tiene la rabia suficiente, la consume para dar armadura a su objetivo.",
+      "pt": "O Kilorf se concentra para dar PM ao seu alvo. Se tiver Raiva suficiente, ele a consome para dar Armadura ao alvo."
+    }
+  },
+  {
+    "spellId": 7551,
+    "name": {
+      "fr": "Meute",
+      "en": "Pack",
+      "es": "Manada",
+      "pt": "Matilha"
+    },
+    "description": {
+      "fr": "L'Ouignak et ses alliés se renforcent en fonction du nombre d'alliés présents dans la zone d'effet au lancement du sort.",
+      "en": "The Ouginak and their allies are strengthened based on the number of allies present in the area of effect when the spell is cast.",
+      "es": "El uginak y sus aliados se refuerzan según el número de aliados que haya en la zona de efecto al lanzar el hechizo.",
+      "pt": "O Kilorf e seus aliados se reforçam em função do número de aliados presentes na zona de efeito na hora do lançamento do feitiço."
+    }
+  },
+  {
+    "spellId": 7552,
+    "name": {
+      "fr": "Élan",
+      "en": "Surge",
+      "es": "Bote",
+      "pt": "Impulsão"
+    },
+    "description": {
+      "fr": "L'Ouginak bondit sur la cellule visée. S'il vise le Chienchien ou sa Proie, il échange de position avec. Le coût du sort dépend du nombre de cases parcourues par l'Ouginak.",
+      "en": "The Ouginak jumps to the targeted cell. If they target their Bow Wow or their Prey, they switch places with it. The spell's cost depends on the number of cells the Ouginak has moved.",
+      "es": "El uginak salta a la casilla seleccionada. Si el objetivo es un wauwau o su presa, intercambia posición con él. El coste del hechizo depende del número de casillas que recorra el uginak.",
+      "pt": "O Kilorf pula para a célula visada. Se ele visar o Awaw ou sua Presa, trocará de lugar com eles. O custo do feitiço depende do número de células percorridas pelo Kilorf."
+    }
+  },
+  {
+    "spellId": 6902,
+    "name": {
+      "fr": "Feu ardent",
+      "en": "Blazing Fire",
+      "es": "Fuego Ardiente",
+      "pt": "Fogo Ardente"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone. Cette attaque à distance est souple d'utilisation.",
+      "en": "Inflicts damage in an area of effect. This ranged attack is versatile.",
+      "es": "Inflige daños en zona. Este ataca a distancia es fácil de utilizar.",
+      "pt": "Inflige danos em zona. A utilização deste ataque à distância é flexível."
+    }
+  },
+  {
+    "spellId": 6903,
+    "name": {
+      "fr": "Crache flammes",
+      "en": "Fire Thrower",
+      "es": "Escupellamas",
+      "pt": "Cospe-Fogo"
+    },
+    "description": {
+      "fr": "Inflige des dommages et retire de la portée sur la cible : ses sorts se lanceront moins loin.",
+      "en": "Inflicts damage and reduces the range over which the target can cast its spells.",
+      "es": "Inflige daños y retira alcance al objetivo: sus hechizos se lanzarán a menos distancia.",
+      "pt": "Inflige danos e retira alcance do alvo: os feitiços dele perderão distância."
+    }
+  },
+  {
+    "spellId": 6904,
+    "name": {
+      "fr": "Calcination",
+      "en": "Charring",
+      "es": "Calcinación",
+      "pt": "Calcinação"
+    },
+    "description": {
+      "fr": "Inflige des dommages élevés, mais ne peut pas être lancé sur des cibles étant déjà dans le champ de vision du Steamer. Il doit s'agir d'une cible qui est cachée derrière un obstacle ou un autre combattant.",
+      "en": "Inflicts high damage but cannot be cast on targets that are already in the Foggernaut's field of vision. Targets must be hidden behind an obstacle or another fighter.",
+      "es": "Inflige daños elevados, pero no puede lanzarse sobre objetivos que ya estén en el campo de visión del steamer. Debe ser un objetivo que esté escondido detrás de un obstáculo o de otro combatiente.",
+      "pt": "Inflige danos elevados, mas não pode ser lançado em alvos que já estiverem no campo de visão do Steamer. Deve ser um alvo que esteja escondido atrás de um obstáculo ou de outro combatente."
+    }
+  },
+  {
+    "spellId": 6905,
+    "name": {
+      "fr": "Flambage",
+      "en": "Flambé",
+      "es": "Flambeado",
+      "pt": "Flambado"
+    },
+    "description": {
+      "fr": "Inflige des dommages. Si le Steamer cible sa propre tourelle avec ce sort, il enflamme les cases autour. Ces cases infligent des dommages feu aux cibles commençant ou terminant leur tour dessus.",
+      "en": "Inflicts damage. If the Foggernaut targets their own turret with this spell, it sets the surrounding cells on fire. These cells inflict Fire damage on targets that start or end their turn on them.",
+      "es": "Inflige daños. Si el steamer selecciona su propia torreta con este hechizo, prende fuego a las casillas de alrededor. Estas casillas infligen daños de fuego a los objetivos que empiecen o terminen su turno encima.",
+      "pt": "Inflige danos. Se o Steamer visar sua própria torre com este feitiço, ele coloca fogo nas células ao redor dela. Essas células infligem danos de fogo aos alvos que começam ou terminam seu turno em cima delas."
+    }
+  },
+  {
+    "spellId": 6906,
+    "name": {
+      "fr": "Sabordage",
+      "en": "Scuttle",
+      "es": "Desfonde",
+      "pt": "Sabotagem"
+    },
+    "description": {
+      "fr": "Inflige des dommages Feu. Les dommages sont plus importants si la cible est au contact d'une tourelle du Steamer.",
+      "en": "Inflicts Fire damage. The damage is greater if the target is adjacent to one of the Foggernaut's turrets.",
+      "es": "Inflige daños de fuego. Los daños son mayores si el objetivo está en contacto con una torreta steamer.",
+      "pt": "Inflige danos de fogo. Os danos são maiores se o alvo estiver em contato com uma torre do Steamer."
+    }
+  },
+  {
+    "spellId": 6907,
+    "name": {
+      "fr": "Courant",
+      "en": "Current",
+      "es": "Corriente",
+      "pt": "Corrente"
+    },
+    "description": {
+      "fr": "Inflige des dommages et pousse la cible. Si la cible percute un autre combattant ou un obstacle, alors la cible subit des dommages de collision. Si le Steamer a deux niveaux de Surpression, les cibles sont poussées plus loin.",
+      "en": "Inflicts damage and pushes the target. If the target hits another fighter or an obstacle, then the target suffers collision damage. If the Foggernaut has two levels of High Pressure, targets are pushed farther.",
+      "es": "Inflige daños y empuja al objetivo. Si el objetivo golpea a otro combatiente o un obstáculo, el objetivo sufre daños de colisión. Si el steamer tiene dos niveles de sobrepresión, los objetivos son empujados más lejos.",
+      "pt": "Inflige danos e empurra o alvo. Se o alvo atingir outro combatente ou um obstáculo, ele sofre danos de colisão. Se o Steamer tiver dois níveis de Sobrepressão, os alvos serão empurrados para mais longe."
+    }
+  },
+  {
+    "spellId": 6908,
+    "name": {
+      "fr": "Évaporation",
+      "en": "Evaporation",
+      "es": "Evaporación",
+      "pt": "Evaporação"
+    },
+    "description": {
+      "fr": "Le Steamer saute sur la cellule ciblée. Il inflige des dommages eau sur les ennemis qu'il survole de cette manière. Si le Steamer a deux niveaux de Surpression, il peut se déplacer plus loin.",
+      "en": "The Foggernaut jumps on the targeted cell. Water damage is inflicted on the enemies that they fly over on their way there. If the Foggernaut has two levels of High Pressure, they can move farther.",
+      "es": "El steamer salta a una casilla objetivo. Inflige daños de agua a los enemigos que sobrevuela de esta forma. Si el steamer tiene dos niveles de sobrepresión, puede desplazarse más lejos.",
+      "pt": "O Steamer pula para a célula visada. Inflige danos de água aos inimigos sobre os quais passa ao pular. Se o Steamer tiver dois níveis de Sobrepressão, ele poderá se deslocar para mais longe."
+    }
+  },
+  {
+    "spellId": 6909,
+    "name": {
+      "fr": "Ecume",
+      "en": "Froth",
+      "es": "Espuma de Mar",
+      "pt": "Espuma"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone. Si le Steamer a deux niveaux de Surpression, il regagne les PA dépensés pour le sort.",
+      "en": "Inflicts damage in an area of effect. If the Foggernaut has two levels of High Pressure, they recover the AP spent on the spell.",
+      "es": "Inflige daños en zona. Si el steamer tiene dos niveles de sobrepresión, recupera los PA que cuesta el hechizo.",
+      "pt": "Inflige danos em zona. Se o Steamer tiver dois níveis de Sobrepressão, ele ganhará os PA gastos no feitiço."
+    }
+  },
+  {
+    "spellId": 6910,
+    "name": {
+      "fr": "Flibuste",
+      "en": "Pilfer",
+      "es": "Piratería",
+      "pt": "Pirataria"
+    },
+    "description": {
+      "fr": "Inflige des dommages sans ligne de vue. Si le Steamer a deux niveaux de Surpression, il peut réduire les coups critiques et la parade de la cible.",
+      "en": "Inflicts damage without line of sight. If the Foggernaut has two levels of High Pressure, they can reduce the target's Critical Hits and Block.",
+      "es": "Inflige daños sin línea de visión. Si el steamer tiene dos niveles de sobrepresión, puede reducir los golpes críticos y la anticipación del objetivo.",
+      "pt": "Inflige danos sem linha de visão. Se o Steamer tiver dois níveis de Sobrepressão, ele poderá reduzir os golpes críticos e a parada do alvo."
+    }
+  },
+  {
+    "spellId": 6911,
+    "name": {
+      "fr": "Dissolution",
+      "en": "Dissolution",
+      "es": "Disolución",
+      "pt": "Dissolução"
+    },
+    "description": {
+      "fr": "Inflige des dommages en ligne et à portée restreinte. Si le Steamer a deux niveaux de Surpression, il peut appliquer un puissant poison qui inflige des dommages à la fin du tour de la cible pendant deux tours. À chaque fois que le poison est déclenché, le Steamer regagne un niveau de Surpression.",
+      "en": "Inflicts damage in a straight line and with limited range. If the Foggernaut has two levels of High Pressure, they can apply a powerful poison that inflicts damage at the end of the target's turn for two turns. Each time the poison is triggered, the Foggernaut recovers a level of High Pressure.",
+      "es": "Inflige daños en línea y de alcance limitado. Si el steamer tiene dos niveles de sobrepresión, puede aplicar un poderoso veneno que inflige daños al final del turno del objetivo durante dos turnos. Cada vez que se activa el veneno, el steamer recupera un nivel de sobrepresión.",
+      "pt": "Inflige danos em linha reta e com alcance restrito. Se o Steamer tiver dois níveis de Sobrepressão, ele poderá aplicar um poderoso veneno que inflige danos no fim do turno do alvo durante dois turnos. Toda vez que o veneno for acionado, o Steamer ganhará um nível de Sobrepressão."
+    }
+  },
+  {
+    "spellId": 6912,
+    "name": {
+      "fr": "À la masse",
+      "en": "Pummel",
+      "es": "Steamaza",
+      "pt": "Steamarreta"
+    },
+    "description": {
+      "fr": "Génère de l'Armure sur le Steamer, le montant d'Armure absorbera les prochains dommages subis. Si le sort est lancé sur un allié, l'allié gagne aussi de l'Armure.",
+      "en": "Adds Armor to the Foggernaut; the amount of Armor will absorb subsequent damage suffered. If the spell is cast on an ally, the ally also gains Armor.",
+      "es": "Genera armadura en el steamer, la cantidad de armadura absorbe los próximos daños sufridos. Si el hechizo se lanza sobre un aliado, el aliado también gana armadura.",
+      "pt": "Gera armadura no Steamer. A quantidade de armadura absorverá os próximos danos sofridos. Se o feitiço for lançado em um aliado, ele também ganha armadura."
+    }
+  },
+  {
+    "spellId": 6913,
+    "name": {
+      "fr": "Piétinement",
+      "en": "Trampling",
+      "es": "Pisoteo",
+      "pt": "Espezinhamento"
+    },
+    "description": {
+      "fr": "Lancé sur un ennemi, inflige des dommages et retire des Points de Mouvement à la cible. Lancé sur un allié, le stabilise.",
+      "en": "When cast on an enemy, inflicts damage and removes Movement Points from the target. When cast on an ally, stabilizes them.",
+      "es": "Lanzado sobre un enemigo, inflige daños y retira puntos de movimiento al objetivo. Lanzado sobre un aliado, lo estabiliza.",
+      "pt": "Quando lançado em um inimigo, inflige danos e retira PM do alvo. Quando lançado em um aliado, o estabiliza."
+    }
+  },
+  {
+    "spellId": 6914,
+    "name": {
+      "fr": "Pilonnage",
+      "en": "Bombardment",
+      "es": "Machacado",
+      "pt": "Bombardeio"
+    },
+    "description": {
+      "fr": "Inflige des dommages en croix. La puissance des dommages du sort augmente à chaque utilisation.",
+      "en": "Inflicts damage in a cross-shaped area of effect. The power of the spell's damage increases with each use.",
+      "es": "Inflige daños en cruz. La potencia de los daños del hechizo aumenta con cada utilización.",
+      "pt": "Inflige danos em cruz. A potência dos danos do feitiço aumenta toda vez que ele é usado."
+    }
+  },
+  {
+    "spellId": 6915,
+    "name": {
+      "fr": "Marteau aimant",
+      "en": "Hammer Claw",
+      "es": "Martillo Imán",
+      "pt": "Martelo Ímã"
+    },
+    "description": {
+      "fr": "Lancé sur un combattant, celui-ci est attiré près du Steamer. Si la cible est ennemie, le Steamer lui inflige des dommages. Si la cible est alliée, le Steamer la protège en lui donnant un montant d'Armure.",
+      "en": "When cast on a fighter, the target is attracted close to the Foggernaut. If the target is an enemy, the Foggernaut inflicts damage on them. If the target is an ally, the Foggernaut protects them by giving them a certain amount of Armor.",
+      "es": "Lanzado sobre un combatiente, es atraído cerca del steamer. Si el objetivo es enemigo, el steamer le inflige daños. Si el objetivo es aliado, el steamer lo protege dándole una cantidad de armadura.",
+      "pt": "Quando lançado em um combatente, ele é atraído para perto do Steamer. Se o alvo for um inimigo, o Steamer inflige danos a ele. Se o alvo for um aliado, o Steamer o protege dando a ele uma quantidade de Armadura."
+    }
+  },
+  {
+    "spellId": 6916,
+    "name": {
+      "fr": "Choc",
+      "en": "Shebang",
+      "es": "Shock",
+      "pt": "Choque"
+    },
+    "description": {
+      "fr": "Inflige des dommages plus élevés pour chaque Point de Stasis possédé par le Steamer au moment de lancer le sort.",
+      "en": "Inflicts greater damage for each Stasis Point that the Foggernaut has at the time when they cast the spell.",
+      "es": "Inflige mayores daños por cada punto de Stasis que tenga el steamer en el momento de lanzar el hechizo.",
+      "pt": "Inflige danos mais elevados por ponto de Stasis possuído pelo Steamer no momento do lançamento do feitiço."
+    }
+  },
+  {
+    "spellId": 6917,
+    "name": {
+      "fr": "Blindage",
+      "en": "Armor Plating",
+      "es": "Blindaje",
+      "pt": "Blindagem"
+    },
+    "description": {
+      "fr": "Le Steamer applique de l'armure à un allié. La valeur d'armure donnée est augmentée sur ses mécanismes (blocs et tourelle).",
+      "en": "The Foggernaut applies armor to an ally. The amount of armor given is increased on the Foggernaut's mechanisms (blocks and turret).",
+      "es": "El steamer aplica armadura a un aliado. El valor de armadura dado aumenta en sus mecanismos (bloque y torreta).",
+      "pt": "O Steamer aplica armadura a um aliado. O valor de armadura concedida é aumentado em seus mecanismos (blocos e torre)."
+    }
+  },
+  {
+    "spellId": 6918,
+    "name": {
+      "fr": "Surtension",
+      "en": "Hypertension",
+      "es": "Sobretensión",
+      "pt": "Sobretensão"
+    },
+    "description": {
+      "fr": "Ce sort permet de sacrifier une tourelle pour récupérer des PV et des PW, ou bien d'infliger des dommages sur un ennemi. Dans ce dernier cas, la cible du sort subit davantage de dommages de la tourelle pendant 1 tour.",
+      "en": "This spell allows the caster to sacrifice a turret to recover HP and WP, or to inflict damage on an enemy. In the latter case, the spell's target takes more damage from the turret for 1 turn.",
+      "es": "Este hechizo permite sacrificar una torreta para recuperar PdV y PW, o bien causar daños a un enemigo. En este último caso, el objetivo del hechizo sufre mayores daños de la torreta durante 1 turno.",
+      "pt": "Este feitiço permite sacrificar uma torre para recuperar PV e PW ou para infligir danos a um inimigo. No segundo caso, o alvo do feitiço sofre mais danos da torre durante 1 turno."
+    }
+  },
+  {
+    "spellId": 6919,
+    "name": {
+      "fr": "Machinerie",
+      "en": "Machinery",
+      "es": "Maquinaria",
+      "pt": "Maquinário"
+    },
+    "description": {
+      "fr": "En utilisant ce sort, le Steamer peut stabiliser un ennemi ou améliorer la mobilité d'un allié s'il utilise les rails.",
+      "en": "By using this spell, the Foggernaut can stabilize an enemy or improve an ally's mobility if using rails.",
+      "es": "Al usar este hechizo, el steamer puede estabilizar a un enemigo o mejorar la movilidad de un aliado si usa los ríeles.",
+      "pt": "Ao usar este feitiço, o Steamer pode estabilizar um inimigo ou melhorar a mobilidade de um aliado se ele usar os trilhos."
+    }
+  },
+  {
+    "spellId": 6920,
+    "name": {
+      "fr": "Embuscade",
+      "en": "Ambush",
+      "es": "Emboscada",
+      "pt": "Emboscada"
+    },
+    "description": {
+      "fr": "Si le Steamer cible une case libre, il pose un glyphe sur lequel se téléportera la Tourelle au début de son prochain tour. Si le Steamer cible un combattant, la Tourelle échange de position avec la cible (7 cases max). Dans les deux cas, la Tourelle s'active instantanément après son déplacement.",
+      "en": "If the Foggernaut targets an empty cell, they place a glyph to which the Turret will teleport at the start of its next turn. If the Foggernaut targets a fighter, the Turret switches places with the target (7 cells max). In either case, the Turret activates immediately after it moves.",
+      "es": "Si el steamer selecciona una casilla libre, pone un glifo al que la torreta se teletransportará al inicio de su próximo turno. Si el steamer selecciona a un luchador, la torreta intercambia posición con el objetivo (7 casillas como máximo). En ambos casos, la torreta se activa al momento tras el desplazamiento.",
+      "pt": "Se o Steamer visar uma célula livre, ele coloca um glifo para onde a Torre será teletransportada no início de seu próximo turno. Se o Steamer visar um combatente, a Torre troca de posição com o alvo (7 células no máximo). Nos dois casos, a Torre é ativada instantaneamente após seu deslocamento."
+    }
+  },
+  {
+    "spellId": 6921,
+    "name": {
+      "fr": "Transition",
+      "en": "Transition",
+      "es": "Transición",
+      "pt": "Transição"
+    },
+    "description": {
+      "fr": "Ce sort de mobilité envoie la cible sur le microbot libre le plus proche, dans un rayon de quatre cases. Lancé directement sur un microbot, il permet de téléporter la Tourelle du Steamer dessus.",
+      "en": "This mobility spell sends the target to the closest free microbot in a four-cell radius. Cast directly on a microbot, it teleports the Foggernaut Turret onto it.",
+      "es": "Este hechizo de movilidad envía al objetivo al microbot libre más cercano, en un radio de cuatro casillas. Lanzado directamente sobre un microbot, permite teletransportar la torreta del steamer encima.",
+      "pt": "Este feitiço de mobilidade envia o alvo para o Microbot livre mais próximo em um raio de quatro células. Quando lançado diretamente em um Microbot, ele permite teletransportar a Torre do Steamer para cima dele."
+    }
+  },
+  {
+    "spellId": 6922,
+    "name": {
+      "fr": "Flux de Stasis",
+      "en": "Stasis Flux",
+      "es": "Flujo de Stasis",
+      "pt": "Fluxo de Stasis"
+    },
+    "description": {
+      "fr": "Ce sort renforce le potentiel offensif de l'équipe, soit en augmentant les dommages d'un allié, soit en affaiblissant les résistances d'un ennemi.",
+      "en": "This spell strengthens the team's offensive potential, either by increasing an ally's damage or by weakening an enemy's resistances.",
+      "es": "Este hechizo refuerza el potencial ofensivo del equipo, bien aumentando los daños de un aliado, bien debilitando las resistencias de un enemigo.",
+      "pt": "Este feitiço reforça o potencial ofensivo da equipe, seja aumentando os danos de um aliado ou enfraquecendo as resistências de um inimigo."
+    }
+  },
+  {
+    "spellId": 4668,
+    "name": {
+      "fr": "Egide ardente",
+      "en": "Ardent Aegis",
+      "es": "Égida Ardiente",
+      "pt": "Égide Ardente"
+    },
+    "description": {
+      "fr": "Ce sort permet de replacer un portail sur une cible ou à travers un autre portail. Si l'Eliotrope possède le Don céleste au moment de lancer le sort, le coût en PW est remboursé.",
+      "en": "This spells repositions a portal on a target or through another portal. If the Eliotrope has Celestial Gift when they cast the spell, the WP cost is refunded.",
+      "es": "Este hechizo permite sustituir un portal en un objetivo o a través de otro portal. Si el selotrop tiene Don Celestial cuando lanza el hechizo, se le devuelve el coste en PW.",
+      "pt": "Este feitiço permite reposicionar um portal sobre um alvo ou através de outro portal. Se o Eliotrope possuir Dádiva Celeste no lançamento do feitiço, o custo em PW será restituído."
+    }
+  },
+  {
+    "spellId": 4669,
+    "name": {
+      "fr": "Targe fracassante",
+      "en": "Deafening Targe",
+      "es": "Escudo Quebrantador",
+      "pt": "Escudo Devastador"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages Terre et entrave la cible en fonction du mode actif de l'Eliotrope. Si l'Eliotrope consomme le Don céleste sur le sort, les retraits sont doublés.",
+      "en": "This spell inflicts Earth damage and debuffs the target based on the Eliotrope's active mode. If the Eliotrope consumes the Celestial Gift on the spell, removal effects are doubled.",
+      "es": "Este hechizo inflige daños de tierra y traba al objetivo según el modo activo del selotrop. Si el selotrop consume el don celestial con el hechizo, las retiradas se duplican.",
+      "pt": "Este feitiço inflige danos de terra e entrava o alvo em função do modo ativo do Eliotrope. Se o Eliotrope consumir a Dádiva Celeste no feitiço, as retiradas dobrarão."
+    }
+  },
+  {
+    "spellId": 4670,
+    "name": {
+      "fr": "Séisme",
+      "en": "Earthquake",
+      "es": "Seísmo",
+      "pt": "Terremoto"
+    },
+    "description": {
+      "fr": "Si l'Eliotrope se cible, il Inflige des dommages autour de lui. S'il cible un ennemi, il marque l'ennemi : au prochain lancer d'Exaltation, ce dernier subira des dommages indirects.",
+      "en": "If the Eliotrope targets themself, they inflict damage around them. If they target an enemy, they mark the enemy; the next time they cast Exaltation, the marked enemy will take indirect damage.",
+      "es": "Si el selotrop se selecciona, inflige daños a su alrededor. Si selecciona un enemigo, lo marca: en el próximo lanzamiento de Exaltación, este sufrirá daños indirectos.",
+      "pt": "Se o Eliotrope visar a si mesmo, ele inflige danos ao seu redor. Se visar um inimigo, ele o marca: no próximo lançamento de Exaltação, o inimigo sofrerá danos indiretos."
+    }
+  },
+  {
+    "spellId": 4671,
+    "name": {
+      "fr": "Raclée",
+      "en": "Hiding",
+      "es": "Tunda",
+      "pt": "Surra"
+    },
+    "description": {
+      "fr": "Inflige des dommages terre. Si la cible se trouve sur un portail, l'Eliotrope se soigne d'un montant égal aux dommages qu'il inflige s'il est en serein, et les dommages sont augmentés s'il est en exalté.",
+      "en": "Inflicts Earth damage. If the target is on a portal, the Eliotrope is healed for the amount of damage they deal if in calm mode; their damage is increased if in exalted mode.",
+      "es": "Inflige daños de tierra. Si el objetivo está en un portal, el selotrop se cura una cantidad equivalente a los daños que inflige si está en Sereno, y los daños aumentan si está en Exaltado.",
+      "pt": "Inflige danos de terra. Se o alvo estiver em um portal, o Eliotrope se cura de uma quantidade igual aos danos que ele inflige se estiver no modo sereno, e os danos são aumentados se ele estiver no modo exaltado."
+    }
+  },
+  {
+    "spellId": 4680,
+    "name": {
+      "fr": "Tourbillon",
+      "en": "Whirlwind",
+      "es": "Torbellino",
+      "pt": "Turbilhão"
+    },
+    "description": {
+      "fr": "Ce sort ne peut être lancé que si la cible est un portail allié. En plus d'infliger des dommages et de soigner en zone, il pousse en zone autour du portail en mode serein, et attire autour du portail en mode exalté.",
+      "en": "This spell can only be cast on an allied portal. Besides dealing damage and healing in an area of effect, it pushes targets in an area of effect around the portal (in calm mode) and attracts targets around the portal (in exalted mode).",
+      "es": "Este hechizo solo puede lanzarse si el objetivo es un portal aliado. Además de infligir daños y curar en zona, empuja en zona alrededor del portal en sereno y atrae alrededor del portal en exaltado.",
+      "pt": "Este feitiço só pode ser lançado se o alvo for um portal aliado. Além de infligir danos e curar em zona, ele empurra em zona ao redor do portal no modo sereno e atrai ao redor do portal no modo exaltado."
+    }
+  },
+  {
+    "spellId": 4683,
+    "name": {
+      "fr": "Brèche temporaire",
+      "en": "Time Breach",
+      "es": "Brecha Temporal",
+      "pt": "Brecha Temporária"
+    },
+    "description": {
+      "fr": "L'Eliotrope peut se téléporter sur la case ciblée s'il est en serein. En exalté, la cible est téléportée sur le portail le plus proche.",
+      "en": "The Eliotrope can teleport to the targeted cell if they are in Calm mode. In Exalted mode, the target is teleported to the closest portal.",
+      "es": "El selotrop puede teletransportarse a la casilla objetivo si está en Sereno. En Exaltado, el objetivo se teletransporta al portal más cercano.",
+      "pt": "O Eliotrope pode se teletransportar para a célula visada se estiver no modo Sereno. No modo Exaltado, o alvo é teletransportado para o portal mais próximo."
+    }
+  },
+  {
+    "spellId": 4684,
+    "name": {
+      "fr": "Exode",
+      "en": "Exodus",
+      "es": "Éxodo",
+      "pt": "Êxodo"
+    },
+    "description": {
+      "fr": "Lancé sur une case inoccupée, ce sort permet de replacer un Portail proche sur la case ciblée. Lancé sur une cible, celle-ci échange de position avec le portail libre le plus proche.",
+      "en": "When cast on an empty cell, this spell moves a nearby portal to the targeted cell. Cast on a target, the target switches places with the nearest free portal.",
+      "es": "Si se lanza a una casilla sin ocupar, este hechizo permite colocar un portal cercano en la casilla objetivo. Si se lanza a un objetivo, este cambia de posición con el portal libre más cercano.",
+      "pt": "Lançado em uma célula vazia, este feitiço permite reposicionar um portal próximo na célula visada. Quando lançado em um alvo, este último troca de lugar com o portal livre mais próximo."
+    }
+  },
+  {
+    "spellId": 4685,
+    "name": {
+      "fr": "Incandescence",
+      "en": "Incandescence",
+      "es": "Incandescencia",
+      "pt": "Incandescência"
+    },
+    "description": {
+      "fr": "Stabilise la cible. Si la cible est un adversaire, alors il subit des dommages d'une valeur dépendant du nombre de portails à proximité de la cible.",
+      "en": "Stabilizes the target. If the target is an opponent, they suffer damage based on the number of portals near the target.",
+      "es": "Estabiliza al objetivo. Si el objetivo es un adversario, sufre daños cuyo valor depende del número de portales que haya cerca del objetivo.",
+      "pt": "Estabiliza o alvo. Se o alvo for um adversário, ele sofrerá danos em função do número de portais próximos."
+    }
+  },
+  {
+    "spellId": 4691,
+    "name": {
+      "fr": "Wakméha",
+      "en": "Wakmeha",
+      "es": "Wakmeha",
+      "pt": "Wakmeha"
+    },
+    "description": {
+      "fr": "En serein, ce sort inflige de lourds dommages s'il est lancé à travers un portail. En exalté, il inflige des dommages sur et sous l'armure d'une cible simultanément.",
+      "en": "In calm mode, this spell deals heavy damage if cast through a portal. In exalted mode, it deals damage both on and under a target's armor at the same time.",
+      "es": "En Sereno, este hechizo inflige grandes daños si se lanza a través de un portal. En Exaltado, inflige a la vez daños sobre y bajo la armadura de un objetivo.",
+      "pt": "No modo sereno, este feitiço inflige graves danos se for lançado através de um portal. No modo exaltado, ele inflige danos sobre e sob a armadura de um alvo simultaneamente."
+    }
+  },
+  {
+    "spellId": 4692,
+    "name": {
+      "fr": "Pulsation",
+      "en": "Pulsation",
+      "es": "Pulsación",
+      "pt": "Pulsação"
+    },
+    "description": {
+      "fr": "Ce sort permet d'infliger des dommages monocible ou de soigner un allié à travers les portails de manière souple. Si aucun portail se situe à 3 cases ou moins de la cible, les dommages et les soins sont augmentés.",
+      "en": "This spell inflicts single-target damage or heals an ally through portals in a flexible way. If no portals are within 3 cells or less of the target, the damage and healing are increased.",
+      "es": "Este hechizo permite infligir daños monobjetivo o curar a un aliado a través de los portales de manera ligera. Si ningún portal se sitúa a 3 casillas o menos del objetivo, los daños y las curas aumentan.",
+      "pt": "Este feitiço permite infligir danos de alvo único ou curar um aliado através dos portais de maneira flexível. Se não houver nenhum portal a até 3 células do alvo, as curas e os danos aumentam."
+    }
+  },
+  {
+    "spellId": 4693,
+    "name": {
+      "fr": "Déluge",
+      "en": "Flood",
+      "es": "Diluvio",
+      "pt": "Dilúvio"
+    },
+    "description": {
+      "fr": "En serein, l'Eliotrope échange de position avec sa cible. En exalté, l'Eliotrope se téléporte symétriquement à sa cible. Si ce sort est lancé à travers les portails, seuls les dommages ou les soins sont effectués.",
+      "en": "In calm mode, the Eliotrope switches places with their target. In exalted mode, the Eliotrope teleports symmetrically to their target. If this spell is cast through a portal, only the damage or healing is applied.",
+      "es": "En Sereno, el selotrop intercambia de posición con su objetivo. En Exaltado, el selotrop se teletransporta simétricamente respecto a su objetivo. Si el hechizo se lanza a través de los portales, solo se aplican los daños o las curas.",
+      "pt": "No modo sereno, o Eliotrope troca de lugar com seu alvo. No modo exaltado, o Eliotrope se teletransporta simetricamente ao alvo. Se este feitiço for lançado através dos portais, apenas as curas ou os danos serão efetuados."
+    }
+  },
+  {
+    "spellId": 4694,
+    "name": {
+      "fr": "Cataclysme",
+      "en": "Cataclysm",
+      "es": "Cataclismo",
+      "pt": "Cataclismo"
+    },
+    "description": {
+      "fr": "Serein, l'Eliotrope déploie une zone d'effet Cataclysme sur le terrain. Au prochain lancer d'Exaltation, il se téléporte sur la zone, puis inflige de gros dommages autour de lui. En exalté, l'Eliotrope inflige de lourds dommages à la cible.",
+      "en": "In Calm mode, the Eliotrope deploys a Cataclysm area of effect on the field. The next time Exaltation is cast, they teleport to the area and then deal huge damage around them. In Exalted mode, the Eliotrope inflicts heavy damage on the target.",
+      "es": "En Sereno, el selotrop despliega una zona de efecto Cataclismo sobre el terreno. En el próximo lanzamiento de Exaltación, se teletransporta a la zona y luego inflige grandes daños a su alrededor. En Exaltado, el selotrop inflige grandes daños al objetivo.",
+      "pt": "Sereno, o Eliotrope gera uma zona de efeito de Cataclismo no campo de batalha. No próximo lançamento de Exaltação, ele se teletransporta para a zona e inflige grandes danos ao redor de si mesmo. No modo Exaltado, o Eliotrope inflige danos pesados ao alvo."
+    }
+  },
+  {
+    "spellId": 4695,
+    "name": {
+      "fr": "Heurt",
+      "en": "Clash",
+      "es": "Colisión",
+      "pt": "Conflito"
+    },
+    "description": {
+      "fr": "Inflige des dommages en croix. En exalté, la zone d'effet change en croix diagonale. Si l'Eliotrope consomme Don céleste sur ce sort, il regagne 1 PA par cible tuée.",
+      "en": "Inflicts damage in a cross-shaped area of effect. In exalted mode, the area of effect is a diagonal cross. If the Eliotrope consumes Celestial Gift on this spell, they regain 1 AP for each target killed.",
+      "es": "Inflige daños en cruz. En Exaltado, la zona de efecto pasa a ser en cruz diagonal. Si el selotrop consume Don Celestial en este hechizo, recupera 1 PA por cada objetivo que mate.",
+      "pt": "Inflige danos em cruz. Estando exaltado, a zona de efeito muda para cruz diagonal. Se o Eliotrope consumir Dádiva Celeste para este feitiço, ele recuperará 1 PA por alvo morto."
+    }
+  },
+  {
+    "spellId": 4697,
+    "name": {
+      "fr": "Flux torrentiel",
+      "en": "Torrential Flux",
+      "es": "Flujo Torrencial",
+      "pt": "Fluxo Torrencial"
+    },
+    "description": {
+      "fr": "Inflige des dommages en ligne. Les ennemis qui commencent ou terminent leur tour sur la zone où a été lancé le sort subissent des dommages supplémentaires. Lancé à travers un portail, l'Eliotrope inflige des dommages importants à la cible mais le portail d'arrivée est détruit.",
+      "en": "Inflicts damage in a line. Enemies starting or ending their turn in the area where the spell was cast take extra damage. When cast through a portal, the Eliotrope inflicts major damage on the target, but the destination portal is destroyed.",
+      "es": "Inflige daños en línea. Los enemigos que empiezan o terminan su turno en la zona donde se ha lanzado el hechizo sufren daños adicionales. Lanzado a través de un portal, el selotrop inflige importantes daños al objetivo, pero el portal de llegada queda destruido.",
+      "pt": "Inflige danos em linha. Os inimigos que começarem ou terminarem o turno na zona de lançamento do feitiço sofrerão danos extras. Quando lançado através de um portal, o Eliotrope inflige bastante dano ao alvo, mas o portal de chegada é destruído."
+    }
+  },
+  {
+    "spellId": 4698,
+    "name": {
+      "fr": "Siphon",
+      "en": "Siphon",
+      "es": "Sifón",
+      "pt": "Sifão"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages Air aux ennemis et soigne les alliés en plus de pousser ou attirer selon le mode de l'Eliotrope.",
+      "en": "This spell inflicts Air damage on enemies and heals allies, in addition to pushing or attracting (based on what mode the Eliotrope is in).",
+      "es": "Este hechizo inflige daños de aire a los enemigos y cura a los aliados, además de empujar o atraer según el modo del selotrop.",
+      "pt": "Este feitiço inflige danos de ar aos inimigos e cura os aliados, além de empurrar ou atrair em função do modo do Eliotrope."
+    }
+  },
+  {
+    "spellId": 4699,
+    "name": {
+      "fr": "Salve éthérée",
+      "en": "Ethereal Burst",
+      "es": "Salva Etérea",
+      "pt": "Salva Etérea"
+    },
+    "description": {
+      "fr": "Inflige des dommages air et applique un malus aux soins reçus sur la cible en serein et un malus aux armures reçues en exalté.",
+      "en": "Inflicts Air damage and gives the target a healing received penalty (in calm mode) or an armor received penalty (in exalted mode).",
+      "es": "Inflige daños de aire y aplica un malus a las curas que recibe el objetivo en Sereno y un malus a las armaduras recibidas en Exaltado.",
+      "pt": "Inflige danos de ar e aplica uma penalidade à cura recebida pelo alvo no modo sereno, e uma penalidade às armaduras no modo exaltado."
+    }
+  },
+  {
+    "spellId": 4700,
+    "name": {
+      "fr": "Tempête",
+      "en": "Tempest",
+      "es": "Tormenta",
+      "pt": "Tempestade"
+    },
+    "description": {
+      "fr": "Inflige des dommages en zone. Si ce sort est lancé sur un portail, les dommages en zone sont infligés autour de chaque portail actuellement sur le terrain et les portails sont détruits.",
+      "en": "Inflicts damage in an area of effect. If this spell is cast on a portal, the area-of-effect damage is dealt around each portal currently on the field, and the portals are destroyed.",
+      "es": "Inflige daños en zona. Si este hechizo se lanza a un portal, los daños en zona se infligen alrededor de cada portal que haya en el terreno y los portales se destruyen.",
+      "pt": "Inflige danos em zona. Se este feitiço for lançado em um portal, os danos em zona serão infligidos ao redor de cada portal presente no campo de batalha e os portais serão destruídos."
+    }
+  },
+  {
+    "spellId": 4701,
+    "name": {
+      "fr": "Lame déchaînée",
+      "en": "Unleashed Blade",
+      "es": "Hoja Desencadenada",
+      "pt": "Lâmina Desenfreada"
+    },
+    "description": {
+      "fr": "Ce sort inflige des dommages élevés à la cible, mais ne peut se lancer qu'au contact. Si la cible est sur un portail, elle subira plus de dommages.",
+      "en": "This spell inflicts heavy damage on the target, but can only be cast on an adjacent target. The target will take greater damage if it is on a portal.",
+      "es": "Este hechizo inflige daños elevados al objetivo, pero solo puede lanzarse en contacto con él. Si el objetivo está sobre un portal, sufrirá más daños.",
+      "pt": "Este feitiço inflige grandes danos ao alvo, mas só pode ser lançado em contato. Se o alvo estiver sobre um portal, ele sofrerá mais danos."
+    }
+  },
+  {
+    "spellId": 7198,
+    "name": {
+      "fr": "Empreinte de Wakfu",
+      "en": "Wakfu Imprint",
+      "es": "Huella de Wakfu",
+      "pt": "Marca de Wakfu"
+    },
+    "description": {
+      "fr": "Sur un allié, applique de l'Armure qui absorbe les prochaines attaques reçues. Sur un ennemi, retire de l'Armure. Les effets sont doublés si le sort passe à travers un portail.",
+      "en": "On an ally, applies Armor that absorbs the next attacks received. On an enemy, removes Armor. The effects are doubled if the spell goes through a portal.",
+      "es": "En un aliado, aplica armadura a quien absorbe los próximos ataques recibidos. En un enemigo, retira armadura. Los efectos se duplican si el hechizo pasa a través de un portal.",
+      "pt": "Em um aliado, aplica Armadura que absorve os próximos ataques recebidos. Em um inimigo, retira Armadura. Os efeitos são dobrados se o feitiço passar através de um portal."
+    }
+  },
+  {
+    "spellId": 7199,
+    "name": {
+      "fr": "Coalition",
+      "en": "Coalition",
+      "es": "Coalición",
+      "pt": "Coalizão"
+    },
+    "description": {
+      "fr": "Permet à l'Eliotrope de détruire tous les portails alliés présents sur le terrain et d'en replacer un instantanément sur la cellule visée, afin de replacer son jeu de portails plus efficacement.",
+      "en": "Enables the Eliotrope to destroy all allied portals on the field and instantly place a new one on the targeted cell, in order to more efficiently change how their portals are set up.",
+      "es": "El selotrop puede destruir todos los portales aliados que hay en el terreno y recolocar uno al momento en la casilla objetivo, para replantear el juego de portales con mayor eficacia.",
+      "pt": "Permite que o Eliotrope destrua todos os portais aliados presentes no campo de batalha e coloque um deles instantaneamente na célula visada para reposicionar seu jogo de portais com mais eficiência."
+    }
+  },
+  {
+    "spellId": 7200,
+    "name": {
+      "fr": "Barrière",
+      "en": "Barrier",
+      "es": "Parapeto",
+      "pt": "Barreira"
+    },
+    "description": {
+      "fr": "Ce sort, lancé sur un portail, pose une barrière qui protège les alliés dessus et entrave les ennemis qui la pénètre.",
+      "en": "When cast on a portal, this spell places a barrier that shields any allies standing on it and debuffs any enemies that pass through it.",
+      "es": "Lanzado a un portal, este hechizo coloca una barrera que protege a los aliados y traba a los enemigos que estén en ella.",
+      "pt": "Este feitiço, quando lançado em um portal, levanta uma barreira que protege os aliados nela, entravando os inimigos que a atravessam."
+    }
+  },
+  {
+    "spellId": 5561,
+    "name": {
+      "fr": "Résonance",
+      "en": "Resonance",
+      "es": "Resonancia",
+      "pt": "Ressonância"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Il tend la main et une onde de choc se propage en cône devant lui. Des effets supplémentaires sont joués selon les runes possédées par l'Huppermage.",
+      "en": "It's one of Huppermages' unique spells. They extend their hand and a conical shockwave spreads out in front of them. There are additional effects depending on what runes the Huppermage has.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Extiende la mano y propaga una onda de choque en cono delante de él. Se aplican efectos adicionales según las runas que tenga el hipermago.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. Ele estende a mão e uma onda de choque se propaga em cone diante dele. Efeitos adicionais são acrescidos de acordo com as runas possuídas pelo Huppermago."
+    }
+  },
+  {
+    "spellId": 5562,
+    "name": {
+      "fr": "Flux d'énergie",
+      "en": "Energy Flux",
+      "es": "Flujo de Energía",
+      "pt": "Fluxo de Energia"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Il inflige des dommages aux ennemis et peut leur appliquer un malus de Parade s'il porte la bonne rune. Les alliés peuvent gagner des Coups critiques.",
+      "en": "It's one of Huppermages' unique spells. It inflicts damage on enemies and can apply a Block penalty on them if the Huppermage has the right rune. Allies can gain Critical Hits.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Inflige daños a los enemigos y puede aplicarles un malus de anticipación si lleva la runa adecuada. Los aliados pueden ganar golpes críticos.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. Ele inflige danos aos inimigos e pode lhes aplicar uma penalidade de Parada se estiver com a runa certa. Os aliados podem ganhar golpes críticos."
+    }
+  },
+  {
+    "spellId": 5563,
+    "name": {
+      "fr": "Lueur de l'aube",
+      "en": "Light of Dawn",
+      "es": "Luz del Alba",
+      "pt": "Luz da Alvorada"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Il crée une boule de feu mineure et l'envoie sur la cible, qui subira des dommages supplémentaires dans l'élément de la dernière rune générée.",
+      "en": "It's one of Huppermages' unique spells. It creates a minor fireball that is launched at the target, which suffers extra damage in the element of the last rune generated.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Crea una bola de fuego menor y la envía al objetivo, que sufrirá daños adicionales en el elemento de la última runa generada.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. Ele cria uma bola de fogo menor e a lança sobre o alvo, que sofre danos adicionais no elemento da última runa gerada."
+    }
+  },
+  {
+    "spellId": 5564,
+    "name": {
+      "fr": "Averse",
+      "en": "Downpour",
+      "es": "Aguacero",
+      "pt": "Aguaceiro"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Goutte\" qu'il a emprunté à la classe Féca. L'Huppermage crée une bulle d'eau, la soulève et l'envoie sur sa cible pour la soigner si c'est un allié et lui infliger des dommages si c'est un ennemi.",
+      "en": "It's the \"Drip\" spell, borrowed from the Feca class. The Huppermage creates a water bubble, raises it, and launches at the target it to heal it if it is an ally or inflict damage on it if it is an enemy.",
+      "es": "Se trata del hechizo Gota, que ha tomado prestado de los fecas. El hipermago crea una burbuja de agua, la eleva y la envía a su objetivo para curarlo si es un aliado y para infligirle daños si es un enemigo.",
+      "pt": "Trata-se do feitiço \"Gota\", emprestado da classe Feca. O Huppermago cria uma bolha de água, a levanta e a lança sobre seu alvo para curá-lo, se for um aliado, ou lhe infligir danos, se for um inimigo."
+    }
+  },
+  {
+    "spellId": 5565,
+    "name": {
+      "fr": "Débâcle",
+      "en": "Walloping",
+      "es": "Deshielo",
+      "pt": "Vertedouro"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Epuration\" qu'il a emprunté à la classe Enutrof. L'Huppermage matérialise une pelle qui tombe sur la cible et inflige des dommages aux ennemis. SI l'Huppermage possède la rune eau, la cible devient transparente pendant 1 tour : elle ne bloque plus les lignes de vue.",
+      "en": "It's the \"Refinement\" spell, borrowed from the Enutrof class. The Huppermage conjures a shovel that falls on the target and inflicts damage on enemies. If the Huppermage has the water rune, the target becomes transparent for 1 turn, no longer blocking line of sight.",
+      "es": "Se trata del hechizo Depuración, que ha tomado prestado de los anutrofs. El hipermago materializa una pala que cae sobre el objetivo e inflige daños a los enemigos. Si el hipermago tiene la runa de agua, el objetivo se vuelve transparente durante 1 turno y no bloquea las líneas de visión.",
+      "pt": "Trata-se do feitiço \"Refinamento\", emprestado da classe Enutrof. O Huppermago materializa uma pá que cai em cima do alvo e inflige danos aos inimigos. Se o Huppermago possuir a runa água, o alvo fica transparente durante 1 turno: ele não bloqueia mais as linhas de visão."
+    }
+  },
+  {
+    "spellId": 5566,
+    "name": {
+      "fr": "Vestige",
+      "en": "Vestige",
+      "es": "Vestigio",
+      "pt": "Vestígio"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Horloge\" qu'il a emprunté à la classe Xélor. L'Huppermage invoque une Horloge au-dessus de la cible, qui la foudroie. Les ennemis dans la zone perdent des dommages infligés, tandis que les alliés en gagnent.",
+      "en": "It's the \"Clock\" spell, borrowed from the Xelor class. Huppermages summon a clock over the target, which strikes them with lightning. Enemies in the area of effect lose damage inflicted, while allies gain some.",
+      "es": "Se trata del hechizo Reloj, que ha tomado prestado de los xelors. El hipermago invoca un reloj sobre el objetivo para fulminarlo. Los enemigos en la zona pierden daños infligidos, mientras que los aliados los ganan.",
+      "pt": "Trata-se do feitiço \"Relógio\", emprestado da classe Xelor. O Huppermago invoca um Relógio sobre o alvo, fulminando-o. Os inimigos na zona perdem danos infligidos, enquanto os aliados ganham."
+    }
+  },
+  {
+    "spellId": 5567,
+    "name": {
+      "fr": "Éboulement",
+      "en": "Rock Slide",
+      "es": "Desprendimiento",
+      "pt": "Desmoronamento"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Roknocerok\" qu'il a emprunté à la classe Iop. D'un geste rapide, l'Huppermage invoque des cailloux qui tombent sur la cible et lui infligent des dommages. La cible subira également des retraits selon les runes possédées par l'Huppermage.",
+      "en": "It's the \"Rocknoceros\" spell, borrowed from the Iop class. In one quick movement, the Huppermage summons stones that fall on the target, inflicting damage on it. The target will also have reduced stats depending on what runes the Huppermage has.",
+      "es": "Se trata del hechizo Lanza Rocas, que ha tomado prestado de los yopukas. Con un rápido gesto, el hipermago invoca pedruscos que caen sobre el objetivo y le infligen daños. El objetivo también sufrirá retiradas según las runas que tenga el hipermago.",
+      "pt": "Trata-se do feitiço \"Roknocerrok\", emprestado da classe Iop. Com um gesto rápido, o Huppermago invoca seixos que caem no alvo e infligem danos. O alvo também sofrerá retiradas de acordo com as runas possuídas pelo Huppermago."
+    }
+  },
+  {
+    "spellId": 5568,
+    "name": {
+      "fr": "Feuillure",
+      "en": "Backband",
+      "es": "Ranura",
+      "pt": "Entalhe"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Pelle Sismique\" qu'il a emprunté à la classe Enutrof. L'Huppermage inflige des dommages aux ennemis face à lui et leur retire des PM. Il gagne un bonus de Volonté la durée du sort selon le nombre de runes possédées.",
+      "en": "This is the \"Shovel Shaker\" spell, borrowed from the Enutrof class. The Huppermage inflicts damage on enemies in front of them and removes MP from them. They gain a Force of Will bonus for the duration of the spell, based on the number of runes they have.",
+      "es": "Se trata del hechizo Pala Sísmica, que ha tomado prestado de los anutrofs. El hipermago inflige daños a los enemigos frente a él y les retira PM. Gana un bonus de voluntad lo que dura el hechizo según el número de runas poseídas.",
+      "pt": "Trata-se do feitiço \"Pá Sísmica\", emprestado da classe Enutrof. O Huppermago inflige danos aos inimigos na frente dele e retira PM. Ele ganha um bônus de vontade por toda a duração do feitiço de acordo com o número de runas possuídas."
+    }
+  },
+  {
+    "spellId": 5569,
+    "name": {
+      "fr": "Faille",
+      "en": "Rift",
+      "es": "Falla",
+      "pt": "Falha"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Le sort permet de générer une armure sur l'Huppermage tout en donnant de l'armure à un allié ou en infligeant des dommages à un ennemi.",
+      "en": "It's one of Huppermages' unique spells. The spell lets you generate armor for Huppermages while giving armor to an ally or inflicting damage on an enemy.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. El hechizo permite al hipermago generar armadura para sí mismo, y dársela también a un aliado o infligirle daños a un enemigo.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. Este feitiço permite gerar uma armadura no Huppermago, ao mesmo tempo em que concede armadura a um aliado ou inflige danos a um inimigo."
+    }
+  },
+  {
+    "spellId": 5570,
+    "name": {
+      "fr": "Papillons diurnes",
+      "en": "Diurnal Butterflies",
+      "es": "Mariposas Diurnas",
+      "pt": "Borboletas Diurnas"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Ailes de Scarafeuille\" qu'il a emprunté à la classe Osamodas. Il écarte les bras comme pour battre des ailes puis, en joignant les mains, concentre cette force sur sa cible, pour lui voler de la maîtrise air tout en lui infligeant des dégâts et la déplaçant.",
+      "en": "It's the \"Scaraleaf Wing\" spell, borrowed from the Osamodas class. They spread their arms as if to beat their wings, then they bring their hands together and focus this force on their target to steal Air Mastery from it, inflict damage on it, and move it.",
+      "es": "Se trata del hechizo Alas de Escarahoja, que ha tomado prestado de los osamodas. Extiende los brazos como si quisiera batir las alas y, a continuación, junta las manos y concentra esa fuerza en su objetivo para robarle dominio de aire al mismo tiempo que le inflige daños y lo desplaza.",
+      "pt": "Trata-se do feitiço \"Asa de Scarafolha\", emprestado da classe Osamodas. Ele abre os braços como se fosse bater asas e, ao juntar as mãos, concentra essa força em seu alvo para roubar domínio de ar, infligir danos e deslocá-lo."
+    }
+  },
+  {
+    "spellId": 5571,
+    "name": {
+      "fr": "Disque luminescent",
+      "en": "Luminescent Disc",
+      "es": "Disco Luminiscente",
+      "pt": "Disco Luminescente"
+    },
+    "description": {
+      "fr": "Il s'agit d'un sort propre à l'Huppermage. D'un revers de la main, L'Huppermage envoie un disque sur la cible pour lui infliger des dommages. S'il possède exactement 3 runes à ce moment-là, la cible subira des dommages supplémentaires pendant 2 tours.",
+      "en": "It's one of Huppermages' unique spells. The Huppermage sends a disc flying at the target, inflicting damage on it. If the Huppermage has exactly 3 runes at that time, the target will suffer extra damage for 2 turns.",
+      "es": "Se trata de un hechizo propio del hipermago. Con un revés de la mano, el hipermago envía un disco que inflige daños en el objetivo. Si tiene exactamente 3 runas en ese momento, el objetivo sufrirá daños adicionales durante 2 turnos.",
+      "pt": "Trata-se de um feitiço exclusivo do Huppermago. Com um movimento da mão, o Huppermago lança um disco no alvo para infligir danos a ele. Se ele possuir exatamente 3 runas neste momento, o alvo sofrerá danos adicionais durante 2 turnos."
+    }
+  },
+  {
+    "spellId": 5572,
+    "name": {
+      "fr": "Ombres dansantes",
+      "en": "Dancing Shadows",
+      "es": "Sombras Danzantes",
+      "pt": "Sombras Dançantes"
+    },
+    "description": {
+      "fr": "Il s'agit d'une technique empruntée à un Sram. L'Huppermage crée un tourbillon de vents qui entourent la cible et la téléportent plus loin.",
+      "en": "It's a technique borrowed from Srams. The Huppermage creates a whirlwind that surrounds the target and teleports it farther away.",
+      "es": "Se trata de una técnica tomada prestada de un sram. El hipermago crea un torbellino de viento alrededor del objetivo y lo teletransporta más lejos.",
+      "pt": "Trata-se de uma técnica emprestada do Sram. O Huppermago cria um turbilhão de vento que cerca o alvo e o teletransporta para longe."
+    }
+  },
+  {
+    "spellId": 5575,
+    "name": {
+      "fr": "Forteresse solaire",
+      "en": "Solar Stronghold",
+      "es": "Fortaleza Solar",
+      "pt": "Fortaleza Solar"
+    },
+    "description": {
+      "fr": "L'Huppermage protège un allié grâce à la Forteresse Solaire. Lorsque le porteur de la Forteresse subit des dommages, l'Huppermage à l'origine de la Forteresse génère la rune liée à l'élément des dommages, contre un peu de BQ.",
+      "en": "The Huppermage protects an ally with the Solar Stronghold. When the bearer of the Stronghold suffers damage, the Huppermage who initiated the Stronghold generates the rune linked to the damage element in exchange for a bit of QB.",
+      "es": "El hipermago protege a un aliado con Fortaleza Solar. Cuando el portador de la fortaleza sufre daños, el hipermago que la lanzó genera la runa vinculada al elemento de los daños a cambio de un poco de BC.",
+      "pt": "O Huppermago protege um aliado graças à Fortaleza Solar. Quando o portador de Fortaleza sofre danos, o Huppermago que lançou o feitiço gera uma runa ligada ao elemento dos danos em troca de um pouco de BQ."
+    }
+  },
+  {
+    "spellId": 5576,
+    "name": {
+      "fr": "Mur d'énergie",
+      "en": "Wall of Energy",
+      "es": "Pared de Energía",
+      "pt": "Muro de Energia"
+    },
+    "description": {
+      "fr": "S'isolant au plus profond de lui-même, l'Huppermage matérialise un mur d'énergie qui ne laisse plus passer les attaques nécessitant une ligne de vue. Les personnages peuvent traverser la barrière mais perdent des points de mouvement.",
+      "en": "To isolate themselves fully, Huppermages can conjure a wall of energy that blocks out spells that require line of sight. Characters can pass through the barrier but lose movement points.",
+      "es": "Aislándose en lo más profundo de sí mismo, el hipermago materializa un muro de energía que no deja pasar los ataques que requieran línea de visión. Los personajes pueden atravesar la barrera, pero pierden puntos de movimiento.",
+      "pt": "Ao se isolar em seu âmago, o Huppermago materializa um muro de energia que não deixa passar os ataques que necessitam de uma linha de visão. Os personagens podem atravessar a barreira, mas perderão pontos de movimento."
+    }
+  },
+  {
+    "spellId": 5577,
+    "name": {
+      "fr": "Principio Valere",
+      "en": "Principio Valere",
+      "es": "Principio Valere",
+      "pt": "Principio Valere"
+    },
+    "description": {
+      "fr": "Principio Valere est un sort qui joue un effet de déplacement différent selon la dernière Rune générée par l'Huppermage. ",
+      "en": "The movement effect of the Principio Valere spell varies depending on the last rune generated by the Huppermage. ",
+      "es": "Principio Valere es un hechizo que aplica un efecto de desplazamiento diferente según la última runa que el hipermago ha generado. ",
+      "pt": "Principio Valere é um feitiço que joga um efeito de deslocamento de acordo com a última runa gerada pelo Huppermago. "
+    }
+  },
+  {
+    "spellId": 5590,
+    "name": {
+      "fr": "Orbes luisants",
+      "en": "Shiny Orbs",
+      "es": "Orbes Relucientes",
+      "pt": "Orbes Brilhantes"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Il crée un Orbe Luisant dans chaque main puis les projete successivement sur sa cible, infligeant deux lignes de dommages aux ennemis et de soin aux alliés. La zone d'impact est étendue lorsque le sort est lancé sur son propre Feu-Follet.",
+      "en": "It's one of Huppermages' unique spells. They create a Shiny Orb in each hand and then successively launch them at the target, inflicting two lines of damage on enemies and healing allies. The impact zone is extended when the spell is cast on one's own Will-o'-the-Wisp.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Crea un orbe reluciente en cada mano y a continuación los proyecta de forma sucesiva hacia su objetivo, infligiendo dos líneas de daños a los enemigos y de cura a los aliados. La zona de impacto se extiende cuando lanza el hechizo sobre su propio fuego fatuo.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. Ele cria um Orbe Brilhante em cada mão e os projeta sucessivamente sobre o alvo, infligindo duas linhas de dano aos inimigos e de cura aos aliados. A zona de impacto se estende quando o feitiço é lançado sobre seu próprio Fogo-Fátuo."
+    }
+  },
+  {
+    "spellId": 5591,
+    "name": {
+      "fr": "Rayon crépusculaire",
+      "en": "Twilight Beam",
+      "es": "Rayo Crepuscular",
+      "pt": "Raio Crepuscular"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Le Rayon Crépusculaire inflige des dommages Lumière de manière souple. Si l'Huppermage possède une Rune Feu, les dommages dépendront de sa jauge de BQ restante.",
+      "en": "It's one of Huppermages' unique spells. The Twilight Beam inflicts Light damage flexibly. If the Huppermage has a Fire rune, the damage will depend on their remaining QB gauge.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Rayo Crepuscular inflige daños de luz de manera ligera. Si el hipermago posee una runa de fuego, los daños dependerán de su indicador de BC restante.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. O Raio Crepuscular inflige danos Luz de maneira flexível. Se o Huppermago tiver uma runa de fogo, os danos dependerão da quantidade de BQ restante."
+    }
+  },
+  {
+    "spellId": 5592,
+    "name": {
+      "fr": "Halo Chatoyant",
+      "en": "Glistening Halo",
+      "es": "Halo Tornasolado",
+      "pt": "Halo Cintilante"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Marque Itsade\" qu'il a emprunté à la classe Eniripsa. L'Huppermage pose une Marque sur la cible. Si l'Huppermage relance le sort sur une cible marquée, la marque explose en zone et fait exploser les autres marques qu'elle touche. S'il possède une Rune Air, la marque posée se déclenche instantanément. La marque ne peut pas être posée sur une invocation.",
+      "en": "This is the \"Sadist Mark\" spell, borrowed from the Eniripsa class. The Huppermage places a mark on their target. If the Huppermage casts the spell again on a marked target, the mark explodes in an area of effect, causing other marks in the AoE to explode. If the Huppermage has an Air rune, the mark placed is immediately triggered. The mark can't be placed on a summons.",
+      "es": "Se trata del hechizo Marca Sdesade, que ha tomado prestado de los aniripsas. El hipermago coloca una marca sobre su objetivo. Si el hipermago vuelve a lanzar el hechizo sobre un objetivo marcado, la marca explota en zona y hace que exploten las demás marcas que alcanza. Si posee una runa de aire, la marca colocada se activa instantáneamente. No se puede poner la marca en una invocación.",
+      "pt": "Trata-se do feitiço \"Marca Dessade\", emprestado da classe Eniripsa. O Huppermago coloca uma marca em seu alvo. Se o Huppermago lançar novamente o feitiço em um alvo marcado, a marca explode em zona e faz explodir as outras marcas que ela toca. Se ele tiver uma runa de ar, a marca colocada é acionada instantaneamente. A marca não pode ser colocada sobre uma invocação."
+    }
+  },
+  {
+    "spellId": 5593,
+    "name": {
+      "fr": "Larmes scintillantes",
+      "en": "Glistening Tears",
+      "es": "Lágrimas Centelleantes",
+      "pt": "Lágrimas Cintilantes"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Larme du Sadida\" qu'il a emprunté à la classe Sadida. Une énorme larme de lumière tombe sur la cible pour lui infliger des dommages si c'est un ennemi et la soigner si c'est un allié. Si l'Huppermage possède une Rune Eau, il se soigne en même temps.",
+      "en": "It's the \"Sadida's Tear\" spell, borrowed from the Sadida class. An enormous tear of light falls onto the target, inflicting damage on it if it is an enemy, and healing it if it is an ally. If the Huppermage has a Water rune, they heal themself at the same time.",
+      "es": "Se trata del hechizo Lágrima de Sadida, que ha tomado prestado de los sadidas. Una enorme lágrima de luz cae sobre el objetivo para infligirle daños si es un enemigo, y curarlo si es un aliado. Si el hipermago posee una runa de agua, se cura a la vez.",
+      "pt": "Trata-se do feitiço \"Lágrima do Sadida\", emprestado da classe Sadida. Uma enorme lágrima de luz cai no alvo para causar danos se for inimigo ou curá-lo se for aliado. Se o Huppermago tiver uma runa de água, ele se cura ao mesmo tempo."
+    }
+  },
+  {
+    "spellId": 5594,
+    "name": {
+      "fr": "Flèche de lumière",
+      "en": "Light Arrow",
+      "es": "Flecha de Luz",
+      "pt": "Flecha de Luz"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Flèche Destructrice\" qu'il a emprunté à la classe Crâ. L'Huppermage brandit une flèche de lumière majestueuse, qu'il envoie percuter sa cible de plein fouet. Le sort possède des effets supplémentaires selon la dernière Rune générée.",
+      "en": "It's the \"Destructive Arrow\" spell, borrowed from the Cra class. The Huppermage brandishes a majestic light arrow, which they loose to strike their target with full force. The spell has additional effects depending on the last rune generated.",
+      "es": "Se trata del hechizo Flecha Destructiva, que ha tomado prestado de los ocras. El hipermago blande una flecha de luz majestuosa y la envía con toda su fuerza contra el objetivo. El hechizo tiene efectos adicionales según la última runa generada.",
+      "pt": "Trata-se do feitiço \"Flecha Destrutiva\", emprestado da classe Cra. O Huppermago brande uma Flecha de Luz majestosa, que ele envia para atingir seu alvo em cheio. O feitiço possui efeitos adicionais de acordo com a última runa gerada."
+    }
+  },
+  {
+    "spellId": 5595,
+    "name": {
+      "fr": "Épée de lumière",
+      "en": "Light Sword",
+      "es": "Espada de Luz",
+      "pt": "Espada de Luz"
+    },
+    "description": {
+      "fr": "Il s'agit d'une technique empruntée à un Iop. L'Huppermage dégaine magistralement son épée de lumière et assène un coup, infligeant des dégâts en cône devant lui. Il vole une partie des dégâts infligés, dépendant du nombre de Runes portées.",
+      "en": "It's a technique borrowed from Iops. The Huppermage gracefully unsheathes their light sword and strikes a blow, inflicting damage in a cone shape in front of them. They steal some of the damage inflicted, depending on the number of runes carried.",
+      "es": "Se trata de una técnica tomada prestada de un yopuka. El hipermago desenvaina su espada de luz de forma magistral y asesta un golpe que inflige daños en cono delante de él. Según el número de runas que se lleve, roba una parte de los daños infligidos.",
+      "pt": "Trata-se de uma técnica emprestada dos Iops. O Huppermago desembainha magistralmente sua Espada de Luz e dá um golpe, infligindo danos em uma zona em forma de cone na frente dele. Ele rouba parte dos danos infligidos em função do número de runas carregadas."
+    }
+  },
+  {
+    "spellId": 5596,
+    "name": {
+      "fr": "Mirage",
+      "en": "Mirage",
+      "es": "Espejismo",
+      "pt": "Miragem"
+    },
+    "description": {
+      "fr": "Il s'agit du sort \"Assaut\" qu'il a emprunté à la classe Sacrieur. L'Huppermage échange de position avec sa cible, lui infligeant des dommages si c'est un ennemi. Si l'Huppermage possède une Rune air, la portée de ce sort est modifiée.",
+      "en": "It's the \"Assault\" spell that's been borrowed from the Sacrier class. The Huppermage switches places with the target, inflicting damage on it if it is an enemy. If the Huppermage has an Air rune, this spell's range is modified.",
+      "es": "Se trata del hechizo Asalto, que ha tomado prestado de los sacrógritos. El hipermago cambia su posición con la de su objetivo y le inflige daños si se trata de un enemigo. Si el hipermago tiene una runa de aire, se modifica el alcance de este hechizo.",
+      "pt": "Trata-se do feitiço \"Agressão\", emprestado da classe Sacrier. O Huppermago troca de lugar com o alvo e inflige danos a ele se for um inimigo. Se o Huppermago possuir uma runa de ar, o alcance deste feitiço é modificado."
+    }
+  },
+  {
+    "spellId": 5597,
+    "name": {
+      "fr": "Faisceau de lune",
+      "en": "Moonbeam",
+      "es": "Resplandor de Luna",
+      "pt": "Feixe de Lua"
+    },
+    "description": {
+      "fr": "Il s'agit d'un des sorts propres à l'Huppermage. Il joint les deux mains pour projeter un faisceau lumineux ravageur. Le rayon se propage horizontalement sur les Feu follet.",
+      "en": "It's one of Huppermages' unique spells. They bring their hands together to project a devastating beam of light. The beam spreads horizontally over Will-o'-the-Wisps.",
+      "es": "Se trata de uno de los hechizos propios del hipermago. Une ambas manos para proyectar un resplandor luminoso devastador. El rayo se propaga horizontalmente por los fuegos fatuos.",
+      "pt": "É um dos feitiços exclusivos dos Huppermagos. O Huppermago junta as duas mãos para projetar um feixe de luz devastador. O raio se propaga horizontalmente sobre os Fogos-Fátuos."
+    }
+  },
+  {
+    "spellId": 7754,
+    "name": {
+      "fr": "Visio Imperum",
+      "en": "Visio Imperum",
+      "es": "Visio Imperum",
+      "pt": "Visio Imperum"
+    },
+    "description": {
+      "fr": "Visio Imperum est un sort qui applique divers malus selon la dernière Rune générée par l'Huppermage.",
+      "en": "Visio Imperum is a spell that applies different penalties based on the last rune the Huppermage generated.",
+      "es": "Visio Imperum es un hechizo que aplica distintos malus según la última runa generada por el hipermago.",
+      "pt": "Visio Imperum é um feitiço que aplica diversas penalidades de acordo com a última runa gerada pelo Huppermago."
+    }
+  },
+  {
+    "spellId": 7755,
+    "name": {
+      "fr": "Surcharge runique",
+      "en": "Runic Overcharge",
+      "es": "Sobrecarga Rúnica",
+      "pt": "Sobrecarga Rúnica"
+    },
+    "description": {
+      "fr": "L'Huppermage concentre toute la puissance de ses runes élémentaires pour soigner un allié en plus de lui offrir des bonus. Les runes sont consommées.",
+      "en": "The Huppermage focuses all the power of their elemental runes to heal an ally, in addition to granting the ally bonuses. The runes are consumed.",
+      "es": "El hipermago concentra toda la potencia de sus runas elementales para curar a un aliado, además de ofrecerle bonus. Las runas se consumen.",
+      "pt": "O Huppermago concentra toda a potência de suas runas elementares para curar um aliado além de oferecer bônus a ele. As runas são consumidas."
+    }
+  },
+  {
+    "spellId": 7809,
+    "name": {
+      "fr": "Runification",
+      "en": "Runification",
+      "es": "Runificación",
+      "pt": "Runificação"
+    },
+    "description": {
+      "fr": "L'Huppermage concentre le pouvoir de ses runes élémentaires pour donner un bonus significatif de dommages infligés et de soins réalisés à lui-même ou un allié.",
+      "en": "The Huppermage concentrates the power of their elemental runes to give themself or an ally a significant bonus to damage inflicted or heals performed.",
+      "es": "El hipermago concentra el poder de sus runas elementales para dar un bonus importante de daños infligidos y de curas realizadas a un aliado o a sí mismo.",
+      "pt": "O Huppermago concentra o poder de suas runas elementares para dar um bônus significativo de danos infligidos e curas a si mesmo ou a um aliado."
+    }
+  }
+]

--- a/autobuilder/src/main/resources/spell-passives.json
+++ b/autobuilder/src/main/resources/spell-passives.json
@@ -1,11 +1,21 @@
 [
   {
     "spellId": 6988,
-    "name": "Glyphe augmenté",
+    "name": {
+      "fr": "Glyphe augmenté",
+      "en": "Increased Glyph",
+      "es": "Glifo Aumentado",
+      "pt": "Glifo Aumentado"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 5244,
-    "description": "Glyphs now have a \"2-cell circle\" size, but cost the Feca 1 additional WP to summon.",
+    "description": {
+      "fr": "Les glyphes ont désormais une taille \"cercle de taille 2\", mais coûtent 1 PW de plus au Féca pour être invoqués.",
+      "en": "Glyphs now have a \"2-cell circle\" size, but cost the Feca 1 additional WP to summon.",
+      "es": "Los glifos ahora tienen una dimensión de círculo de tamaño 2, pero cuestan 1 PW más al feca para invocarlos.",
+      "pt": "Os glifos passam a ter uma zona círculo de tamanho 2, mas custam 1 PW a mais ao Feca para serem invocados."
+    },
     "effectIds": [
       299519
     ],
@@ -22,11 +32,21 @@
   },
   {
     "spellId": 6989,
-    "name": "Ligne",
+    "name": {
+      "fr": "Ligne",
+      "en": "Line",
+      "es": "Línea",
+      "pt": "Linha"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 6989,
-    "description": "Initially, the Range of Fire spells is not variable. This passive removes this constraint but adds a straight-line casting requirement.",
+    "description": {
+      "fr": "La Portée des sorts Feu n'est pas modifiable à l'origine. Ce passif permet de retirer cette contrainte, mais ajoute une contrepartie de lancer en ligne.",
+      "en": "Initially, the Range of Fire spells is not variable. This passive removes this constraint but adds a straight-line casting requirement.",
+      "es": "El alcance de los hechizos de fuego no es modificable de por sí. Este pasivo permite eliminar esta restricción, pero añade la condición del lanzamiento en línea.",
+      "pt": "Normalmente, o alcance dos feitiços de fogo não pode ser modificado. Este passivo retira essa restrição, mas, em contrapartida, requer um lançamento em linha reta."
+    },
     "effectIds": [
       299772
     ],
@@ -55,11 +75,21 @@
   },
   {
     "spellId": 6990,
-    "name": "Un pour tous",
+    "name": {
+      "fr": "Un pour tous",
+      "en": "One for All",
+      "es": "Uno para Todos",
+      "pt": "Um Por Todos"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 2269,
-    "description": "The Feca protects their allies at the expense of the Feca's own protection. Useful for team game configurations in which the Feca is rarely hit.",
+    "description": {
+      "fr": "Le Féca protège ses alliés au détriment de sa propre protection. Utile dans les configurations de jeu en équipe où le Féca est rarement touché.",
+      "en": "The Feca protects their allies at the expense of the Feca's own protection. Useful for team game configurations in which the Feca is rarely hit.",
+      "es": "El feca protege a sus aliados en detrimento de su propia protección. Útil en las configuraciones de juego en equipo en las que el feca apenas es alcanzado.",
+      "pt": "O Feca protege seus aliados em detrimento de sua própria proteção. Útil nas configurações de jogo em equipe em que o Feca é raramente atingido."
+    },
     "effectIds": [
       299774
     ],
@@ -74,11 +104,21 @@
   },
   {
     "spellId": 6991,
-    "name": "Maître des boucliers",
+    "name": {
+      "fr": "Maître des boucliers",
+      "en": "Master of Shields",
+      "es": "Maestro de los Escudos",
+      "pt": "Mestre dos Escudos"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 6691,
-    "description": "The Feca can apply the effects of their shields instantly. However, they must wait to use them again.",
+    "description": {
+      "fr": "Le Féca parvient à appliquer les effets de ses boucliers instantanément. En revanche, il doit attendre afin de les utiliser à nouveau.",
+      "en": "The Feca can apply the effects of their shields instantly. However, they must wait to use them again.",
+      "es": "El feca consigue aplicar los efectos de sus escudos instantáneamente. En cambio, debe esperar para usarlos de nuevo.",
+      "pt": "O Feca consegue aplicar os efeitos de seus escudos instantaneamente. Por outro lado, ele deve esperar antes de poder usá-los novamente."
+    },
     "effectIds": [
       299806
     ],
@@ -95,11 +135,21 @@
   },
   {
     "spellId": 6992,
-    "name": "Qui veut la paix prépare la guerre",
+    "name": {
+      "fr": "Qui veut la paix prépare la guerre",
+      "en": "If You Want Peace, Prepare for War",
+      "es": "Quien Quiere la Paz Prepara la Guerra",
+      "pt": "Se Quer Paz, Prepare-se Para a Guerra"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 2295,
-    "description": "Limits the Feca's ability to give their allies Armor, while improving the Feca's damage, thereby adopting a purely offensive role.",
+    "description": {
+      "fr": "Bride la capacité du Féca à donner de l'Armure à ses alliés, tout en améliorant ses dommages, afin d'adopter un rôle purement offensif.",
+      "en": "Limits the Feca's ability to give their allies Armor, while improving the Feca's damage, thereby adopting a purely offensive role.",
+      "es": "Reduce la capacidad del feca de dar armadura a sus aliados y mejora sus daños, así puede adoptar un papel puramente ofensivo.",
+      "pt": "Reduz a habilidade do Feca de conceder Armadura a seus aliados ao mesmo tempo que melhora os danos dele, a fim de assumir um papel puramente ofensivo."
+    },
     "effectIds": [
       299809
     ],
@@ -126,11 +176,21 @@
   },
   {
     "spellId": 6993,
-    "name": "Marché pacifiste",
+    "name": {
+      "fr": "Marché pacifiste",
+      "en": "Pacifist Pact",
+      "es": "Trato Pacifista",
+      "pt": "Mercado Pacifista"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 866,
-    "description": "Improves the Feca's capability to give Armor while reducing the Feca's likelihood of performing Blocks.",
+    "description": {
+      "fr": "Améliore la capacité du Féca à donner des Armures au détriment de ses chances d'effectuer des Parades.",
+      "en": "Improves the Feca's capability to give Armor while reducing the Feca's likelihood of performing Blocks.",
+      "es": "Mejora la capacidad del feca de dar armaduras en detrimento de sus probabilidades de efectuar anticipaciones.",
+      "pt": "Melhora a habilidade do Feca de conceder Armadura, mas prejudica suas chances de efetuar Paradas."
+    },
     "effectIds": [
       299812
     ],
@@ -190,11 +250,21 @@
   },
   {
     "spellId": 6994,
-    "name": "Connaissance de la carte",
+    "name": {
+      "fr": "Connaissance de la carte",
+      "en": "Map Mastery",
+      "es": "Conocimiento del Mapa",
+      "pt": "Conhecimento do Mapa"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 5104,
-    "description": "This passive makes glyphs much less expensive to use, while restricting the damage they inflict.",
+    "description": {
+      "fr": "Ce passif rend les glyphes beaucoup moins coûteux à utiliser, en bridant leurs dommages.",
+      "en": "This passive makes glyphs much less expensive to use, while restricting the damage they inflict.",
+      "es": "Este pasivo hace que los glifos sean mucho menos costosos, pero limita sus daños.",
+      "pt": "Este passivo reduz consideravelmente o custo dos glifos ao limitar os danos deles."
+    },
     "effectIds": [
       299845
     ],
@@ -221,11 +291,21 @@
   },
   {
     "spellId": 6995,
-    "name": "La meilleure défense est l'attaque",
+    "name": {
+      "fr": "La meilleure défense est l'attaque",
+      "en": "The Best Defense Is an Attack",
+      "es": "La Mejor Defensa es el Ataque",
+      "pt": "A Melhor Defesa é o Ataque"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 5245,
-    "description": "This passive rewards the Feca if they attack their targets using classic damage.",
+    "description": {
+      "fr": "Ce passif récompense le Féca s'il attaque ses cibles à l'aide de dommages classiques.",
+      "en": "This passive rewards the Feca if they attack their targets using classic damage.",
+      "es": "Este pasivo recompensa al feca si ataca a sus objetivos con ayuda de daños clásicos.",
+      "pt": "Este passivo recompensa o Feca quando ele ataca seus alvos usando danos clássicos."
+    },
     "effectIds": [
       303113,
       309826
@@ -243,11 +323,21 @@
   },
   {
     "spellId": 6996,
-    "name": "Armure de combat",
+    "name": {
+      "fr": "Armure de combat",
+      "en": "Combat Armor",
+      "es": "Armadura de Combate",
+      "pt": "Armadura de Combate"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 2374,
-    "description": "Transforms the Feca's damage into protection for allies. The Feca receives less Armor for themselves.",
+    "description": {
+      "fr": "Transforme les dommages du Féca en protections pour les alliés. Le Féca lui-même reçoit moins d'Armure.",
+      "en": "Transforms the Feca's damage into protection for allies. The Feca receives less Armor for themselves.",
+      "es": "Transforma los daños del feca en protecciones para los aliados. El propio feca recibe menos armadura.",
+      "pt": "Transforma os danos do Feca em proteções para os aliados. Já o Feca recebe menos Armadura."
+    },
     "effectIds": [
       299862,
       383716
@@ -275,11 +365,21 @@
   },
   {
     "spellId": 6997,
-    "name": "Peau rocheuse",
+    "name": {
+      "fr": "Peau rocheuse",
+      "en": "Rocky Skin",
+      "es": "Piel Rocosa",
+      "pt": "Pele Rochosa"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 6997,
-    "description": "The Feca limits their ability to provide support and decides to set off for the front to take hits.",
+    "description": {
+      "fr": "Le Féca limite l'importance de ses capacités de support et décide de partir au front prendre des coups.",
+      "en": "The Feca limits their ability to provide support and decides to set off for the front to take hits.",
+      "es": "El feca limita la importancia de sus capacidades de apoyo y decide ir al frente para recibir ataques.",
+      "pt": "O Feca limita a importância de suas habilidades de apoio e decide ir para a linha de frente para receber golpes."
+    },
     "effectIds": [
       303105,
       303106
@@ -311,11 +411,21 @@
   },
   {
     "spellId": 6998,
-    "name": "Oeil pour oeil",
+    "name": {
+      "fr": "Oeil pour oeil",
+      "en": "Eye for Eye",
+      "es": "Ojo por Ojo",
+      "pt": "Olho por Olho"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 2324,
-    "description": "The Feca increases their offensive and protective potential when the situation so requires and their allies are in danger.",
+    "description": {
+      "fr": "Le Féca renforce son potentiel offensif et protecteur lorsque la situation l'exige et que ses alliés sont en danger.",
+      "en": "The Feca increases their offensive and protective potential when the situation so requires and their allies are in danger.",
+      "es": "El feca refuerza su potencial ofensivo y protector cuando la situación lo exige y sus aliados están en peligro.",
+      "pt": "O Feca reforça seu potencial ofensivo e protetor quando houver necessidade e seus aliados estiverem em perigo."
+    },
     "effectIds": [
       303705
     ],
@@ -332,11 +442,21 @@
   },
   {
     "spellId": 6999,
-    "name": "Glyphes persistants",
+    "name": {
+      "fr": "Glyphes persistants",
+      "en": "Persistent Glyphs",
+      "es": "Glifos Persistentes",
+      "pt": "Glifos Persistentes"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 6999,
-    "description": "Glyphs now last two turns, but they can no longer be merged. This passive is useful in fixed locations, or when glyph damage is not a priority.",
+    "description": {
+      "fr": "Les glyphes durent désormais deux tours, mais ils ne peuvent plus être fusionnés. Ce passif est utile lors de situations fixes, où lorsque les dommages des glyphes ne sont pas une priorité.",
+      "en": "Glyphs now last two turns, but they can no longer be merged. This passive is useful in fixed locations, or when glyph damage is not a priority.",
+      "es": "Los glifos ahora duran dos turnos, pero ya no pueden fusionarse. Este pasivo es útil en situaciones fijas o cuando los daños de los glifos no son una prioridad.",
+      "pt": "Os glifos passam a durar dois turnos, mas não podem mais ser fusionados. Este passivo é útil em situações fixas ou quando os danos dos glifos não são uma prioridade."
+    },
     "effectIds": [
       300080
     ],
@@ -351,11 +471,21 @@
   },
   {
     "spellId": 7000,
-    "name": "Berger",
+    "name": {
+      "fr": "Berger",
+      "en": "Shepherd",
+      "es": "Pastor",
+      "pt": "Pastor"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 7000,
-    "description": "The Feca increases the effectiveness of a single shield by concentrating all their attention on it. A true guide needs little guidance to show the way.",
+    "description": {
+      "fr": "Le Féca renforce l'efficacité d'un seul bouclier, en dévouant toute son attention dessus. Un vrai guide n'a pas besoin de beaucoup de consignes pour montrer la voie.",
+      "en": "The Feca increases the effectiveness of a single shield by concentrating all their attention on it. A true guide needs little guidance to show the way.",
+      "es": "El feca refuerza la eficacia de un único escudo, dedicándole toda su atención. Un auténtico guía no necesita muchas instrucciones para enseñar el camino.",
+      "pt": "O Feca reforça a eficácia de um único escudo ao dedicar toda a sua atenção a ele. Um verdadeiro guia não precisa de muitas instruções para mostrar o caminho."
+    },
     "effectIds": [
       300000
     ],
@@ -370,11 +500,21 @@
   },
   {
     "spellId": 7001,
-    "name": "Expérience du terrain",
+    "name": {
+      "fr": "Expérience du terrain",
+      "en": "Field Experience",
+      "es": "Experiencia del Terreno",
+      "pt": "Experiência do Terreno"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 2272,
-    "description": "The Feca increases their resistance to attacks received at the expense of their ability to protect allies. Very useful for solo Fecas!",
+    "description": {
+      "fr": "Le Féca améliore sa résistance aux attaques reçues au détriment de ses capacités de protection de ses alliés. Utile pour les Fécas solitaires !",
+      "en": "The Feca increases their resistance to attacks received at the expense of their ability to protect allies. Very useful for solo Fecas!",
+      "es": "El feca mejora su resistencia a los ataques recibidos en detrimento de sus capacidades de protección de sus aliados. ¡Útil para los fecas solitarios!",
+      "pt": "O Feca melhora sua resistência aos ataques recebidos em detrimento de suas habilidades de proteção dos aliados. Muito útil para os Fecas solitários!"
+    },
     "effectIds": [
       303142
     ],
@@ -391,11 +531,21 @@
   },
   {
     "spellId": 7002,
-    "name": "Boucliers élémentaires",
+    "name": {
+      "fr": "Boucliers élémentaires",
+      "en": "Elemental Shields",
+      "es": "Escudos Elementales",
+      "pt": "Escudos Elementares"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 7002,
-    "description": "Fire shields help allies inflict more damage. Earth shields increase their mobility. Water shields increase their range. Each bonus cannot be stacked with itself and lasts 1 turn from when the shield is applied.",
+    "description": {
+      "fr": "Les boucliers Feu aident les alliés à infliger plus de dommages. Les boucliers Terre augmentent leur mobilité. Les boucliers Eau augmentent leur portée. Chaque bonus n'est pas cumulable avec lui-même et dure 1 tour à partir de l'application du bouclier.",
+      "en": "Fire shields help allies inflict more damage. Earth shields increase their mobility. Water shields increase their range. Each bonus cannot be stacked with itself and lasts 1 turn from when the shield is applied.",
+      "es": "Los escudos de fuego ayudan a los aliados a infligir más daños. Los escudos de tierra aumentan su movilidad. Los escudos de agua aumentan su alcance. Cada bonus no es acumulable consigo mismo y dura 1 turno a partir de la aplicación del escudo.",
+      "pt": "Os escudos de fogo ajudam os aliados a infligir mais danos. Os escudos de terra aumentam a mobilidade deles. Os escudos de água aumentam o alcance deles. Um bônus não pode ser acumulado consigo mesmo e dura 1 turno a partir da aplicação do escudo."
+    },
     "effectIds": [
       303146
     ],
@@ -410,11 +560,21 @@
   },
   {
     "spellId": 7003,
-    "name": "Carapace d'épines",
+    "name": {
+      "fr": "Carapace d'épines",
+      "en": "Spiny Carapace",
+      "es": "Caparazón de Espinas",
+      "pt": "Carapaça de Espinhos"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 685,
-    "description": "On each turn, the Feca transforms their favorite form of protection into damage inflicted.",
+    "description": {
+      "fr": "Le Féca transforme à chaque tour son moyen de protection fétiche en dommages infligés.",
+      "en": "On each turn, the Feca transforms their favorite form of protection into damage inflicted.",
+      "es": "El feca transforma, en cada turno, su medio de protección fetiche en daños infligidos.",
+      "pt": "A cada turno, o Feca transforma seu meio de proteção preferido em danos infligidos."
+    },
     "effectIds": [
       303554
     ],
@@ -432,11 +592,21 @@
   },
   {
     "spellId": 7004,
-    "name": "Compréhension du Wakfu",
+    "name": {
+      "fr": "Compréhension du Wakfu",
+      "en": "Wakfu Comprehension",
+      "es": "Comprensión del Wakfu",
+      "pt": "Compreensão do Wakfu"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 7004,
-    "description": "This passive improves the Armors that a Feca gives to their allies or themselves, but the Feca loses one WP each time they do this.",
+    "description": {
+      "fr": "Ce passif permet d'améliorer les Armures que le Féca donne à ses alliés ou à lui-même, mais à chaque fois qu'il fait cela, il perd un PW.",
+      "en": "This passive improves the Armors that a Feca gives to their allies or themselves, but the Feca loses one WP each time they do this.",
+      "es": "Este pasivo permite mejorar las armaduras que el feca da a sus aliados o a sí mismo, pero pierde 1 PW cada vez que lo hace.",
+      "pt": "Este passivo permite melhorar as Armaduras que o Feca concede a seus aliados ou a si mesmo, mas, toda vez que faz isso, ele perde um PW."
+    },
     "effectIds": [
       305198
     ],
@@ -477,11 +647,21 @@
   },
   {
     "spellId": 7005,
-    "name": "Protecteur du troupeau",
+    "name": {
+      "fr": "Protecteur du troupeau",
+      "en": "Herd Protector",
+      "es": "Protector del Rebaño",
+      "pt": "Protetor do Rebanho"
+    },
     "breedId": 1,
     "class": "FECA",
     "gfxId": 7005,
-    "description": "This passive reinforces the Feca's tank aspect, and rewards them by regenerating HP for successfully filling that role.",
+    "description": {
+      "fr": "Ce passif renforce le côté tank du Féca, et le récompense en lui offrant une régénération de ses PV s'il accomplit son rôle.",
+      "en": "This passive reinforces the Feca's tank aspect, and rewards them by regenerating HP for successfully filling that role.",
+      "es": "Este pasivo refuerza la función de tanque del feca, y lo recompensa ofreciéndole una regeneración de sus PdV si cumple con ella.",
+      "pt": "Este passivo reforça o lado \"tanque\" do Feca e o recompensa com uma regeneração dos PV se ele cumprir seu papel."
+    },
     "effectIds": [
       305214
     ],
@@ -510,11 +690,21 @@
   },
   {
     "spellId": 7328,
-    "name": "Rage du Mulou",
+    "name": {
+      "fr": "Rage du Mulou",
+      "en": "Boowolf Fury",
+      "es": "Rabia de Milubo",
+      "pt": "Fúria do Milobo"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7328,
-    "description": "The summons is harder to keep alive but gains bonuses for turns passed on the field.",
+    "description": {
+      "fr": "L'invocation est plus difficile à maintenir en vie mais gagne des bonus au fil des tours passés sur le terrain.",
+      "en": "The summons is harder to keep alive but gains bonuses for turns passed on the field.",
+      "es": "Es más difícil de mantener con vida a la invocación, pero gana bonus con los turnos pasados en terreno.",
+      "pt": "A dificuldade para manter a invocação viva é maior, mas ela ganha bônus com o passar dos turnos no campo de batalha."
+    },
     "effectIds": [
       326755
     ],
@@ -531,11 +721,21 @@
   },
   {
     "spellId": 7329,
-    "name": "Don animal",
+    "name": {
+      "fr": "Don animal",
+      "en": "Animal Gift",
+      "es": "Don Animal",
+      "pt": "Dádiva Animal"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7329,
-    "description": "The Osamodas regains 1 WP at the start of the turn if their summons is on the field. On the other hand, summoning the same entity again is more difficult.",
+    "description": {
+      "fr": "L'Osamodas regagne 1 PW en début de tour si son invocation est sur le terrain. En contrepartie, réinvoquer une même invocation devient plus difficile.",
+      "en": "The Osamodas regains 1 WP at the start of the turn if their summons is on the field. On the other hand, summoning the same entity again is more difficult.",
+      "es": "El osamodas recobra 1 PW al inicio del turno si su invocación está en el terreno. La desventaja es que resulta más difícil volver a invocar una misma invocación.",
+      "pt": "O Osamodas recuperará 1 PW no começo do turno se sua invocação estiver no campo de batalha. Por outro lado, invocar novamente uma mesma invocação fica mais difícil."
+    },
     "effectIds": [
       326766,
       345818
@@ -563,11 +763,21 @@
   },
   {
     "spellId": 7330,
-    "name": "Vision du Corbac",
+    "name": {
+      "fr": "Vision du Corbac",
+      "en": "Crobak Vision",
+      "es": "Vista de Cuerbok",
+      "pt": "Visão do Corvoc"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7330,
-    "description": "Summons no longer hinder line of sight. The Osamodas gains range to better take advantage of this.",
+    "description": {
+      "fr": "Les invocations ne gênent plus la ligne de vue. L'Osamodas gagne en portée afin d'en profiter au mieux.",
+      "en": "Summons no longer hinder line of sight. The Osamodas gains range to better take advantage of this.",
+      "es": "Las invocaciones ya no bloquean la línea de visión. El osamodas gana alcance para aprovecharse todo lo posible.",
+      "pt": "As invocações não interferem mais na linha de visão. O Osamodas ganha Alcance para aproveitar ainda mais."
+    },
     "effectIds": [
       326770,
       326769
@@ -597,11 +807,21 @@
   },
   {
     "spellId": 7331,
-    "name": "Guerrier invocateur",
+    "name": {
+      "fr": "Guerrier invocateur",
+      "en": "Summoning Warrior",
+      "es": "Guerrero Invocador",
+      "pt": "Guerreiro Invocador"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7331,
-    "description": "The Osamodas sacrifices some of their summons's power to become stronger.",
+    "description": {
+      "fr": "L'Osamodas sacrifie une partie de la puissance de son invocation pour devenir plus fort.",
+      "en": "The Osamodas sacrifices some of their summons's power to become stronger.",
+      "es": "El osamodas sacrifica una parte de la potencia de su invocación para volverse más fuerte.",
+      "pt": "O Osamodas sacrifica uma parte da potência de sua invocação para ficar mais forte."
+    },
     "effectIds": [
       326771,
       326772
@@ -617,11 +837,21 @@
   },
   {
     "spellId": 7332,
-    "name": "Invocateur solitaire",
+    "name": {
+      "fr": "Invocateur solitaire",
+      "en": "Solitary Summoner",
+      "es": "Invocador Solitario",
+      "pt": "Invocador Solitário"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7332,
-    "description": "At the end of the turn, the Osamodas gains AP for the next turn if their summons isn't on the field.",
+    "description": {
+      "fr": "En fin de tour, l'Osamodas gagne des PA pour le prochain tour si son invocation n'est pas sur le terrain.",
+      "en": "At the end of the turn, the Osamodas gains AP for the next turn if their summons isn't on the field.",
+      "es": "Al final del turno, el osamodas gana PA para el próximo turno si su invocación no está en terreno.",
+      "pt": "No fim do turno, o Osamodas ganhará PA para o próximo turno se sua invocação não estiver no campo de batalha."
+    },
     "effectIds": [
       326777
     ],
@@ -648,11 +878,21 @@
   },
   {
     "spellId": 7333,
-    "name": "Transcendance draconique",
+    "name": {
+      "fr": "Transcendance draconique",
+      "en": "Dragonic Transcendence",
+      "es": "Trascendencia Dracónica",
+      "pt": "Transcendência Dragontina"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7338,
-    "description": "In dragon form, the first elemental spell cast on the Osamodas or their summons has its area of effect increased.",
+    "description": {
+      "fr": "En forme draconique, le premier sort élémentaire lancé sur l'Osamodas ou son invocation voit sa zone d'effet augmentée.",
+      "en": "In dragon form, the first elemental spell cast on the Osamodas or their summons has its area of effect increased.",
+      "es": "En forma dracónica, el primer hechizo elemental lanzado sobre el osamodas o su invocación aumenta su zona de efecto.",
+      "pt": "Na forma dragontina, o primeiro feitiço elementar lançado no Osamodas ou na invocação dele tem sua zona de efeito aumentada."
+    },
     "effectIds": [
       326802,
       395978
@@ -670,11 +910,21 @@
   },
   {
     "spellId": 7334,
-    "name": "Esprit du phénix",
+    "name": {
+      "fr": "Esprit du phénix",
+      "en": "Phoenix Spirit",
+      "es": "Espíritu de Fénix",
+      "pt": "Espírito da Fênix"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7334,
-    "description": "The Osamodas can more quickly re-summmon a creature that has come back in their Gobgob. However, their summons have less HP.",
+    "description": {
+      "fr": "L'Osamodas peut réinvoquer plus rapidement une créature revenue dans son Gobgob. En contrepartie, ses invocations possèdent moins de PV.",
+      "en": "The Osamodas can more quickly re-summmon a creature that has come back in their Gobgob. However, their summons have less HP.",
+      "es": "El osamodas puede volver a invocar más rápidamente una criatura que ha vuelto a su jamajam. La desventaja es que sus invocaciones tienen menos PdV.",
+      "pt": "O Osamodas pode reinvocar mais rapidamente uma criatura que retornou ao Komekom. Em contrapartida, suas invocações têm menos PV."
+    },
     "effectIds": [
       326788
     ],
@@ -701,11 +951,21 @@
   },
   {
     "spellId": 7335,
-    "name": "Force-Taure",
+    "name": {
+      "fr": "Force-Taure",
+      "en": "Taur Strength",
+      "es": "Fuerza de Toro",
+      "pt": "Força de Tauro"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7335,
-    "description": "The Osamodas and their summons inflict more single-target damage at the expense of their Dodge.",
+    "description": {
+      "fr": "L'Osamodas et son invocation infligent davantage de dommages Monocible au détriment de leur esquive.",
+      "en": "The Osamodas and their summons inflict more single-target damage at the expense of their Dodge.",
+      "es": "El osamodas y su invocación infligen más daños objetivo único en detrimento de su esquiva.",
+      "pt": "O Osamodas e a invocação dele infligem mais danos de alvo único em detrimento da esquiva deles."
+    },
     "effectIds": [
       326806,
       326808
@@ -733,11 +993,21 @@
   },
   {
     "spellId": 7336,
-    "name": "Synergie animale",
+    "name": {
+      "fr": "Synergie animale",
+      "en": "Animal Synergy",
+      "es": "Sinergia Animal",
+      "pt": "Sinergia Animal"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7336,
-    "description": "The Osamodas sacrifices some of their power and transfers it to their summons. When a summons kills an enemy, the Osamodas regenerates WP.",
+    "description": {
+      "fr": "L'Osamodas sacrifie une partie de sa puissance pour la transmettre à ses invocations. Lorsqu'une invocation tue un ennemi, l'Osamodas régénère des PW.",
+      "en": "The Osamodas sacrifices some of their power and transfers it to their summons. When a summons kills an enemy, the Osamodas regenerates WP.",
+      "es": "El osamodas sacrifica una parte de su potencia para transmitirla a sus invocaciones. Cuando una invocación mata a un enemigo, el osamodas regenera PW.",
+      "pt": "O Osamodas sacrifica uma parte de sua potência para transmiti-la a suas invocações. Quando uma invocação mata um inimigo, o Osamodas regenera PW."
+    },
     "effectIds": [
       326790,
       327809
@@ -753,11 +1023,21 @@
   },
   {
     "spellId": 7337,
-    "name": "Symbiose",
+    "name": {
+      "fr": "Symbiose",
+      "en": "Symbiosa",
+      "es": "Simbiosis",
+      "pt": "Simbiose"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7337,
-    "description": "The Osamodas gains a melee-combat damage bonus in exchange for some of their resistances when their summons returns to the Gobgob.",
+    "description": {
+      "fr": "L'Osamodas gagne un bonus de dommages en mêlée en échange d'une partie de ses résistances lorsque son invocation revient dans le Gobgob.",
+      "en": "The Osamodas gains a melee-combat damage bonus in exchange for some of their resistances when their summons returns to the Gobgob.",
+      "es": "El osamodas gana un bonus de daños en melé a cambio de una parte de sus resistencias cuando su invocación vuelve al jamajam.",
+      "pt": "O Osamodas ganha um bônus de danos a curta distância em troca de parte de suas resistências quando sua invocação retorna ao Komekom."
+    },
     "effectIds": [
       326795
     ],
@@ -774,11 +1054,21 @@
   },
   {
     "spellId": 7338,
-    "name": "Puissance draconique",
+    "name": {
+      "fr": "Puissance draconique",
+      "en": "Dragonic Power",
+      "es": "Potencia Dracónica",
+      "pt": "Potência Dragontina"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7333,
-    "description": "The Osamodas becomes more powerful in dragon form but has more difficulty regenerating WP.",
+    "description": {
+      "fr": "L'Osamodas devient plus puissant en forme draconique mais régénère plus difficilement ses PW.",
+      "en": "The Osamodas becomes more powerful in dragon form but has more difficulty regenerating WP.",
+      "es": "El osamodas se vuelve más potente en forma dracónica, pero regenera más difícilmente sus PW.",
+      "pt": "O Osamodas fica mais potente na forma dragontina, mas regenera seus PW com dificuldade."
+    },
     "effectIds": [
       326785
     ],
@@ -793,11 +1083,21 @@
   },
   {
     "spellId": 7339,
-    "name": "Étoile du Sud",
+    "name": {
+      "fr": "Étoile du Sud",
+      "en": "South Star",
+      "es": "Estrella de Sur",
+      "pt": "Estrela do Sul"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7339,
-    "description": "The Gobgob's auras apply an effect on fighters while they are in the aura.",
+    "description": {
+      "fr": "Les auras du Gobgob appliquent un effet aux combattants tant qu'ils sont dans l'aura.",
+      "en": "The Gobgob's auras apply an effect on fighters while they are in the aura.",
+      "es": "Las auras del jamajam aplican un efecto a los luchadores mientras estos estén en el aura.",
+      "pt": "As auras do Komekom aplicam um efeito aos combatentes na aura."
+    },
     "effectIds": [
       327664
     ],
@@ -812,11 +1112,21 @@
   },
   {
     "spellId": 7340,
-    "name": "Sacrifice animal",
+    "name": {
+      "fr": "Sacrifice animal",
+      "en": "Animal Sacrifice",
+      "es": "Sacrificio Animal",
+      "pt": "Sacrifício Animal"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7340,
-    "description": "The Osamodas gains max WP but loses flexibility in managing their summons.",
+    "description": {
+      "fr": "L'Osamodas gagne des PW max mais perd en souplesse dans sa gestion de l'invocation.",
+      "en": "The Osamodas gains max WP but loses flexibility in managing their summons.",
+      "es": "El osamodas gana PW máx., pero pierde en flexibilidad en su gestión de la invocación.",
+      "pt": "O Osamodas ganha PW máx. mas perde em flexibilidade na gestão da invocação."
+    },
     "effectIds": [
       327755
     ],
@@ -845,11 +1155,21 @@
   },
   {
     "spellId": 7341,
-    "name": "Étoile de l'Est",
+    "name": {
+      "fr": "Étoile de l'Est",
+      "en": "Eastern Star",
+      "es": "Estrella del Este",
+      "pt": "Estrela do Leste"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7341,
-    "description": "The Gobgob's auras can be applied on the Osamodas but last for less time.",
+    "description": {
+      "fr": "Les auras du Gobgob peuvent être appliquées sur l'Osamodas mais durent moins longtemps.",
+      "en": "The Gobgob's auras can be applied on the Osamodas but last for less time.",
+      "es": "Las auras del jamajam pueden aplicarse al osamodas, pero duran menos tiempo.",
+      "pt": "As auras do Komekom podem ser aplicadas ao Osamodas, mas duram menos tempo."
+    },
     "effectIds": [
       326815
     ],
@@ -864,11 +1184,21 @@
   },
   {
     "spellId": 7342,
-    "name": "Dévouement animal",
+    "name": {
+      "fr": "Dévouement animal",
+      "en": "Animal Devotion",
+      "es": "Devoción Animal",
+      "pt": "Devoção Animal"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7342,
-    "description": "The Osamodas gains support abilities in exchange for some of their damage.",
+    "description": {
+      "fr": "L'Osamodas gagne des capacités de soutien en échange d'une partie de ses dégâts.",
+      "en": "The Osamodas gains support abilities in exchange for some of their damage.",
+      "es": "El osamodas gana capacidad de apoyo a cambio de una parte de sus daños.",
+      "pt": "O Osamodas ganha habilidades de apoio em troca de parte dos seus danos."
+    },
     "effectIds": [
       326816,
       328022,
@@ -889,11 +1219,21 @@
   },
   {
     "spellId": 7343,
-    "name": "Art du dressage",
+    "name": {
+      "fr": "Art du dressage",
+      "en": "The Art of Taming",
+      "es": "Arte del Adiestramiento",
+      "pt": "Arte do Adestramento"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7343,
-    "description": "Two creatures from the Gobgob can be summoned on the field at the same time. In exchange, damage they suffer is transferred to the Osamodas. You cannot summon the same creature twice on the field, but two Osamodas can each summon a different creature.",
+    "description": {
+      "fr": "Deux créatures du Gobgob peuvent être invoquées sur le terrain en même temps. En contrepartie, les dommages qu'elles subissent sont transmis à l'Osamodas.\\nIl est impossible d'invoquer deux fois la même créature sur le terrain, mais il est possible pour deux Osamodas d'invoquer chacun une créature différente.",
+      "en": "Two creatures from the Gobgob can be summoned on the field at the same time. In exchange, damage they suffer is transferred to the Osamodas.\\nYou cannot summon the same creature twice on the field, but two Osamodas can each summon a different creature.",
+      "es": "Se pueden invocar dos criaturas del jamajam en el terreno al mismo tiempo. A cambio, los daños que sufren se transfieren al osamodas.\\nEs imposible invocar dos veces la misma criatura en el terreno, pero dos osamodas sí pueden invocar cada uno una criatura diferente.",
+      "pt": "Duas criaturas do Komekom podem ser invocadas no terreno ao mesmo tempo. Em compensação, os danos que elas sofrem são transmitidos ao Osamodas.\\nÉ impossível invocar duas vezes a mesma criatura no terreno, mas é possível que dois Osamodas invoquem uma criatura diferente cada um."
+    },
     "effectIds": [
       326837
     ],
@@ -908,11 +1248,21 @@
   },
   {
     "spellId": 7344,
-    "name": "Partage animal",
+    "name": {
+      "fr": "Partage animal",
+      "en": "Animal Sharing",
+      "es": "Reparto Animal",
+      "pt": "Partilha Animal"
+    },
     "breedId": 2,
     "class": "OSAMODAS",
     "gfxId": 7344,
-    "description": "The Osamodas sacrifices some of their resistances and gives them to their summons. When the Osamodas is attacked, their summons gain bonuses.",
+    "description": {
+      "fr": "L'Osamodas sacrifie une partie de ses résistances pour les donner à ses invocations. Lorsqu'il est attaqué, ses invocations gagnent des bonus.",
+      "en": "The Osamodas sacrifices some of their resistances and gives them to their summons. When the Osamodas is attacked, their summons gain bonuses.",
+      "es": "El osamodas sacrifica una parte de sus resistencias para dárselas a sus invocaciones. Cuando es atacado, sus invocaciones ganan bonus.",
+      "pt": "O Osamodas sacrifica uma parte de suas resistências para dá-las a suas invocações. Quando ele é atacado, as invocações dele ganham bônus."
+    },
     "effectIds": [
       328015,
       328030,
@@ -943,11 +1293,21 @@
   },
   {
     "spellId": 2009,
-    "name": "Géologie avancée",
+    "name": {
+      "fr": "Géologie avancée",
+      "en": "Advanced Geology",
+      "es": "Geología Avanzada",
+      "pt": "Geologia Avançada"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 2028,
-    "description": "The Excavation spell's range is no longer modifiable. In exchange, when the Enutrof moves a Mine, they recover 1 AP if they are in normal form and heal themself if they are in Drhellzerker form.",
+    "description": {
+      "fr": "La portée du sort Excavation n'est plus modifiable. En échange, lorsqu'il déplace un Gisement, l'Enutrof regagne un PA s'il est en forme normale et se soigne s'il est en Phorzeker.",
+      "en": "The Excavation spell's range is no longer modifiable. In exchange, when the Enutrof moves a Mine, they recover 1 AP if they are in normal form and heal themself if they are in Drhellzerker form.",
+      "es": "El alcance del hechizo Excavación ya no es modificable. A cambio, cuando desplaza un filón, el anutrof recupera un PA si está en forma normal y se cura si está en perfórserker.",
+      "pt": "O alcance do feitiço Escavação não pode mais ser modificado. Em troca, quando ele deslocar uma Mina, o Enutrof ganhará um PA se ele estiver na forma normal e se curará se estiver como Perforzerker."
+    },
     "effectIds": [
       385818
     ],
@@ -962,11 +1322,21 @@
   },
   {
     "spellId": 2028,
-    "name": "Art des marcheurs",
+    "name": {
+      "fr": "Art des marcheurs",
+      "en": "Treasure Tracker",
+      "es": "Arte de los Caminantes",
+      "pt": "Arte Improfética"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 7093,
-    "description": "The Enutrof uses their MP instead of their AP to move their Mines.",
+    "description": {
+      "fr": "L'Enutrof utilise ses PM pour déplacer ses Gisements à la place de ses PA.",
+      "en": "The Enutrof uses their MP instead of their AP to move their Mines.",
+      "es": "El anutrof utiliza sus PM para desplazar sus filones en lugar de sus PA.",
+      "pt": "O Enutrof usa seus PM para deslocar suas Minas, em vez de seus PA."
+    },
     "effectIds": [
       386210
     ],
@@ -981,11 +1351,21 @@
   },
   {
     "spellId": 2039,
-    "name": "Bénédiction Enutrof",
+    "name": {
+      "fr": "Bénédiction Enutrof",
+      "en": "Enutrof's Blessing",
+      "es": "Bendición Anutrof",
+      "pt": "Bênção de Enutrof"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 2039,
-    "description": "The Enutrof gains 1 Treasures at start of turn, but can only accumulate up to a maximum of 2 instead of 3.",
+    "description": {
+      "fr": "L'Enutrof gagne 1 Trésors en début de tour, mais il ne peut en cumuler plus que 2 maximum au lieu de 3.",
+      "en": "The Enutrof gains 1 Treasures at start of turn, but can only accumulate up to a maximum of 2 instead of 3.",
+      "es": "El anutrof gana 1 Tesoros al principio del turno, pero ya solo puede acumular 2 como máximo, en lugar de 3.",
+      "pt": "O Enutrof ganha 1 de Tesouros no começo do turno, mas não pode acumular mais do que 2, em vez do máximo de 3."
+    },
     "effectIds": [
       386011
     ],
@@ -1002,11 +1382,21 @@
   },
   {
     "spellId": 5059,
-    "name": "Placements boursiers",
+    "name": {
+      "fr": "Placements boursiers",
+      "en": "Market Investments",
+      "es": "Colocaciones Bursátiles",
+      "pt": "Posicionamentos Bolseiros"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 5059,
-    "description": "Purses apply their effects 1 turn after being picked up. They can stack up to 6 levels in this way.",
+    "description": {
+      "fr": "Les Bourses appliquent leurs effets 1 tour après les avoir ramassées. Elles peuvent ainsi se cumuler jusqu'à 6 niveaux.",
+      "en": "Purses apply their effects 1 turn after being picked up. They can stack up to 6 levels in this way.",
+      "es": "Las bolsas aplican sus efectos 1 turno después de que las recojan. Así se pueden acumular hasta 6 niveles.",
+      "pt": "As Bolsas aplicam seus efeitos 1 turno após serem coletadas. Com isso, elas podem acumular até 6 níveis."
+    },
     "effectIds": [
       386179
     ],
@@ -1021,11 +1411,21 @@
   },
   {
     "spellId": 5071,
-    "name": "Cupidité",
+    "name": {
+      "fr": "Cupidité",
+      "en": "Greed",
+      "es": "Codicia",
+      "pt": "Cupidez"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 5071,
-    "description": "The Enutrof can no longer pick up Purses by walking on them, but collects them directly with the Excavation spell.",
+    "description": {
+      "fr": "L'Enutrof ne peut plus ramasser de Bourse en marchant dessus, mais il les récupère directement grâce au sort Excavation.",
+      "en": "The Enutrof can no longer pick up Purses by walking on them, but collects them directly with the Excavation spell.",
+      "es": "El anutrof ya no puede recoger las bolsas al pisarlas, pero las consigue directamente gracias al hechizo Excavación.",
+      "pt": "O Enutrof não pode mais recolher uma Bolsa ao passar sobre ela, mas as obtém diretamente graças ao feitiço Escavação."
+    },
     "effectIds": [
       386178
     ],
@@ -1040,11 +1440,21 @@
   },
   {
     "spellId": 5075,
-    "name": "Phorzertanker",
+    "name": {
+      "fr": "Phorzertanker",
+      "en": "Drhellzertank",
+      "es": "Perfórtanker",
+      "pt": "Perforzertanque"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 5075,
-    "description": "The Enutrof exchanges the offensive bonuses of their Drhellzerker form for defensive bonuses.",
+    "description": {
+      "fr": "L'Enutrof échange les bonus offensifs de la forme Phorzerker contre des bonus défensifs.",
+      "en": "The Enutrof exchanges the offensive bonuses of their Drhellzerker form for defensive bonuses.",
+      "es": "El anutrof cambia los bonus ofensivos de la forma perfórserker por bonus defensivos.",
+      "pt": "O Enutrof troca os bônus ofensivos da forma Perforzerker por bônus defensivos."
+    },
     "effectIds": [
       386207
     ],
@@ -1059,11 +1469,21 @@
   },
   {
     "spellId": 5076,
-    "name": "Côté en bourse",
+    "name": {
+      "fr": "Côté en bourse",
+      "en": "Trade Secrets",
+      "es": "Cotización en Bolsa",
+      "pt": "Cotação na Bolsa"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 5076,
-    "description": "Purses summoned by the Enutrof instantly appear as Fat Pouches. However, they can be picked up by enemies.",
+    "description": {
+      "fr": "Les Bourses invoquées par l'Enutrof sont directement des Big bourses. En revanche, ces dernières peuvent être ramassées par les ennemis.",
+      "en": "Purses summoned by the Enutrof instantly appear as Fat Pouches. However, they can be picked up by enemies.",
+      "es": "Las bolsas invocadas por el anutrof son, directamente, bolsas grandes. En cambio, los enemigos pueden recogerlas.",
+      "pt": "As Bolsas invocadas pelo Enutrof são diretamente Bolsas Grandes. Por outro lado, elas podem ser recolhidas pelos inimigos."
+    },
     "effectIds": [
       385994
     ],
@@ -1078,11 +1498,21 @@
   },
   {
     "spellId": 6326,
-    "name": "Intérêts créditeurs",
+    "name": {
+      "fr": "Intérêts créditeurs",
+      "en": "Credit Interest",
+      "es": "Intereses Acreedores",
+      "pt": "Juros dos Credores"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 6326,
-    "description": "With this passive, the Enutrof acquires Treasures from the targets they've left broke. In exchange, the Enutrof can't put them in debt as often.",
+    "description": {
+      "fr": "Avec ce passif, l'Enutrof récupère des Trésors grâce aux cibles qu'il a fauchées. En revanche il ne peut plus les endetter aussi souvent.",
+      "en": "With this passive, the Enutrof acquires Treasures from the targets they've left broke. In exchange, the Enutrof can't put them in debt as often.",
+      "es": "Con este pasivo, el anutrof consigue tesoros dejando pobretones a sus objetivos. En cambio, ya no puede endeudarlos.",
+      "pt": "Com este passivo, o Enutrof obtém Tesouros graças aos alvos que deixou falidos. Em compensação, ele não pode mais endividá-los com tanta frequência."
+    },
     "effectIds": [
       386078
     ],
@@ -1097,11 +1527,21 @@
   },
   {
     "spellId": 8272,
-    "name": "Échange asynchrone",
+    "name": {
+      "fr": "Échange asynchrone",
+      "en": "Asynchronous Swap",
+      "es": "Intercambio Asíncrono",
+      "pt": "Troca Assíncrona"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 4300,
-    "description": "The Enutrof copies their distance mastery to melee mastery by switching to Drhellzerker mode. Their elemental spells in Drhellzerker mode lose 2 max Range.",
+    "description": {
+      "fr": "L'Enutrof copie sa maîtrise distance en maîtrise mêlée lorsqu'il passe en Phorzerker. Ses sorts élémentaires en Phorzerker perdent 2 Portée maximum.",
+      "en": "The Enutrof copies their distance mastery to melee mastery by switching to Drhellzerker mode. Their elemental spells in Drhellzerker mode lose 2 max Range.",
+      "es": "El anutrof copia su dominio distancia como dominio de melé cuando pasa a perfórserker. Sus hechizos elementales como perfórserker pierden 2 de alcance máximo.",
+      "pt": "O Enutrof copia seu domínio de distância para domínio de curta distância quando passa para Perforzerker. Seus feitiços elementares na forma de Perforzerker perdem 2 de alcance máximo."
+    },
     "effectIds": [
       385985
     ],
@@ -1116,11 +1556,21 @@
   },
   {
     "spellId": 8273,
-    "name": "Marchepied",
+    "name": {
+      "fr": "Marchepied",
+      "en": "Springboard",
+      "es": "Estribo",
+      "pt": "Estepe"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 7596,
-    "description": "In Drhellzerker mode, the first dodge of the turn is always 100% guaranteed. In exchange, the Enutrof's Dodge is reduced to 0 at the start of the fight.",
+    "description": {
+      "fr": "En Phorzerker, la première esquive du tour est toujours garantie à 100 %. En contrepartie, l'Esquive de l'Enutrof est réduite à 0 au début du combat.",
+      "en": "In Drhellzerker mode, the first dodge of the turn is always 100% guaranteed. In exchange, the Enutrof's Dodge is reduced to 0 at the start of the fight.",
+      "es": "Como perfórserker, la primera esquiva del turno está siempre garantizada al 100%. A cambio, la esquiva del anutrof se reduce a 0 al principio del combate.",
+      "pt": "Na forma de Perforzerker, a primeira esquiva do turno é sempre 100% garantida. Em compensação, a esquiva do Enutrof é reduzida a 0 no início do combate."
+    },
     "effectIds": [
       385992
     ],
@@ -1147,11 +1597,21 @@
   },
   {
     "spellId": 8274,
-    "name": "Marchand d'âge",
+    "name": {
+      "fr": "Marchand d'âge",
+      "en": "Age Merchant",
+      "es": "Provectrato",
+      "pt": "Mercantilização"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 5126,
-    "description": "In Drhellzerker mode, the Enutrof's neutral spells are also limited in Range, but they cost 1 MP less.",
+    "description": {
+      "fr": "En Phorzerker les sorts neutres de l'Enutrof sont aussi limités en Portée mais coûtent 1 PM en moins.",
+      "en": "In Drhellzerker mode, the Enutrof's neutral spells are also limited in Range, but they cost 1 MP less.",
+      "es": "Como perfórserker, los hechizos neutrales del anutrof también tienen alcance limitado, pero cuestan 1 PM menos.",
+      "pt": "Na forma de Perforzerker, os feitiços neutros do Enutrof também são limitados em alcance, mas custam 1 PM a menos."
+    },
     "effectIds": [
       385794
     ],
@@ -1166,11 +1626,21 @@
   },
   {
     "spellId": 8275,
-    "name": "La binocle",
+    "name": {
+      "fr": "La binocle",
+      "en": "Pince-Nez",
+      "es": "La Binocular",
+      "pt": "Binóculo"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 7330,
-    "description": "When the Enutrof is in Drhellzerker mode, Treasures no longer gives them WP at end of turn, but their elemental spells have a Range bonus.",
+    "description": {
+      "fr": "Lorsque l'Enutrof est en Phorzerker, Trésors ne lui donne plus de PW en fin de tour, mais ses sorts élémentaires possèdent un bonus de Portée.",
+      "en": "When the Enutrof is in Drhellzerker mode, Treasures no longer gives them WP at end of turn, but their elemental spells have a Range bonus.",
+      "es": "Cuando el anutrof está como perfórserker, Tesoros ya no le da PW al final del turno, pero sus hechizos elementales tienen un bonus de alcance.",
+      "pt": "Quando o Enutrof estiver na forma de Perforzerker, Tesouros não lhe concedem mais PW no final do turno, mas seus feitiços elementares têm um bônus de alcance."
+    },
     "effectIds": [
       386077
     ],
@@ -1185,11 +1655,21 @@
   },
   {
     "spellId": 8276,
-    "name": "Assurance tous risques",
+    "name": {
+      "fr": "Assurance tous risques",
+      "en": "Comprehensive Insurance",
+      "es": "Seguro a Todo Riesgo",
+      "pt": "Seguro Compreensivo"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 845,
-    "description": "The Enutrof consumes their Treasures at end of turn to gain Armor.",
+    "description": {
+      "fr": "L'Enutrof consomme ses Trésors en fin de tour pour gagner de l'Armure.",
+      "en": "The Enutrof consumes their Treasures at end of turn to gain Armor.",
+      "es": "El anutrof consume sus Tesoros al final del turno para ganar armadura.",
+      "pt": "O Enutrof consome seus Tesouros no fim do turno para ganhar armadura."
+    },
     "effectIds": [
       386082
     ],
@@ -1204,11 +1684,21 @@
   },
   {
     "spellId": 8277,
-    "name": "Protection minérale",
+    "name": {
+      "fr": "Protection minérale",
+      "en": "Mineral Protection",
+      "es": "Protección Mineral",
+      "pt": "Proteção Mineral"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 2009,
-    "description": "If the Enutrof finishes their turn on a Mine, they destroy it to gain elemental resistances for 1 turn. The destroyed Mine cannot be dug up for 1 full turn.",
+    "description": {
+      "fr": "Si l'Enutrof finit son tour sur un Gisement, il le détruit pour gagner des résistances élémentaires pendant 1 tour. Le Gisement détruit ne pourra plus être excavé pendant 1 tour complet.",
+      "en": "If the Enutrof finishes their turn on a Mine, they destroy it to gain elemental resistances for 1 turn. The destroyed Mine cannot be dug up for 1 full turn.",
+      "es": "Si el anutrof termina el turno en un filón, lo destruye para ganar resistencias elementales durante 1 turno. El filón destruido ya no podrá ser excavado durante 1 turno completo.",
+      "pt": "Se o Enutrof terminar seu turno sobre uma Mina, ele a destrói para ganhar resistências elementares durante 1 turno. A Mina destruída não poderá mais ser escavada durante 1 turno completo."
+    },
     "effectIds": [
       386097
     ],
@@ -1240,11 +1730,21 @@
   },
   {
     "spellId": 8278,
-    "name": "Optimisation focale",
+    "name": {
+      "fr": "Optimisation focale",
+      "en": "Optimal Focus",
+      "es": "Optimización Focal",
+      "pt": "Otimização Focal"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 1420,
-    "description": "The Excavation spell has greater maximum range, but also greater minimum range, preventing the Enutrof from manipulating their Mines at very short range.",
+    "description": {
+      "fr": "Le sort Excavation possède plus de portée maximale, mais aussi plus de portée minimale, empêchant l'Enutrof de manipuler des Gisements à très courte portée.",
+      "en": "The Excavation spell has greater maximum range, but also greater minimum range, preventing the Enutrof from manipulating their Mines at very short range.",
+      "es": "El hechizo Excavación tiene un mayor alcance máximo, pero también un mayor alcance mínimo, impidiendo que el anutrof manipule filones a muy corto alcance.",
+      "pt": "O feitiço Escavação tem mais alcance máximo, mas também não tem mínimo, impedindo que o Enutrof manipule as Minas a uma distância muito curta."
+    },
     "effectIds": [
       386104
     ],
@@ -1259,11 +1759,21 @@
   },
   {
     "spellId": 8279,
-    "name": "Tunnelier",
+    "name": {
+      "fr": "Tunnelier",
+      "en": "Tunneler",
+      "es": "Tuneladora",
+      "pt": "Escavador"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 7184,
-    "description": "The Drheller has less MP, but when it digs up a Mine, it teleports onto it.",
+    "description": {
+      "fr": "Le Phorreur a moins de PM, mais lorsqu'il excave un Gisement, il se téléporte dessus.",
+      "en": "The Drheller has less MP, but when it digs up a Mine, it teleports onto it.",
+      "es": "El perforatroz tiene menos PM, pero cuando excava un filón se teletransporta hasta él.",
+      "pt": "O Perfuratroz tem menos PM, mas, quando escava uma Mina, se teletransporta para ela."
+    },
     "effectIds": [
       386132
     ],
@@ -1278,11 +1788,21 @@
   },
   {
     "spellId": 8280,
-    "name": "Héritage",
+    "name": {
+      "fr": "Héritage",
+      "en": "Inheritance",
+      "es": "Herencia",
+      "pt": "Herança"
+    },
     "breedId": 3,
     "class": "ENUTROF",
     "gfxId": 727,
-    "description": "The Drheller gains AP and MP based on the level of Treasures that the Enutrof has at end of turn. In exchange, the Drheller dies if it ends its turn in melee range of an enemy.",
+    "description": {
+      "fr": "Le Phorreur gagne des PA et des PM en fonction du niveau de Trésors que possède l'Enutrof en fin de tour. En contrepartie, le Phorreur meurt s'il termine son tour en mêlée d'un ennemi.",
+      "en": "The Drheller gains AP and MP based on the level of Treasures that the Enutrof has at end of turn. In exchange, the Drheller dies if it ends its turn in melee range of an enemy.",
+      "es": "El perforatroz gana PA y PM en función del nivel de Tesoros que tenga el anutrof al final del turno. A cambio, el perforatroz muere si termina su turno en melé con un enemigo.",
+      "pt": "O Perfuratroz ganha PA e PM em função do nível de Tesouros que o Enutrof tiver no fim do turno. Em compensação, o Perfuratroz morre se terminar seu turno a curta distância de um inimigo."
+    },
     "effectIds": [
       386211
     ],
@@ -1297,11 +1817,21 @@
   },
   {
     "spellId": 4606,
-    "name": "Assaut Brutal",
+    "name": {
+      "fr": "Assaut Brutal",
+      "en": "Brutal Assault",
+      "es": "Asalto Brutal",
+      "pt": "Agressão Brutal"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2440,
-    "description": "The Sram's costly spells do more damage but no longer generate Weak Point. The Execution and Trauma spells are no longer affected by this passive's effects.",
+    "description": {
+      "fr": "Les sorts coûteux du Sram font davantage de dommages mais ne génèrent plus de Point faible. Les sorts Mise à mort et Traumatisme ne sont pas concernés par les effets de ce passif.",
+      "en": "The Sram's costly spells do more damage but no longer generate Weak Point. The Execution and Trauma spells are no longer affected by this passive's effects.",
+      "es": "Los hechizos costosos del sram hacen más daños, pero no generan Punto Débil. Los hechizos Ejecución y Traumatismo no se ven afectados por los efectos de este pasivo.",
+      "pt": "Os feitiços mais caros do Sram causam mais danos, mas não geram mais Ponto Fraco. Os feitiços Execução e Trauma não são afetados pelos efeitos desse passivo."
+    },
     "effectIds": [
       411209,
       411210
@@ -1317,11 +1847,21 @@
   },
   {
     "spellId": 4607,
-    "name": "Passe-passe",
+    "name": {
+      "fr": "Passe-passe",
+      "en": "Hocus Pocus",
+      "es": "Juego de Manos",
+      "pt": "Passe de Mágica"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 5103,
-    "description": "When summoning the Double, the Sram switches places with it, before switching places with it again at the end of their turn.",
+    "description": {
+      "fr": "En invoquant le Double, le Sram échange de position avec, avant d'échanger à nouveau de position avec à la fin de son tour.",
+      "en": "When summoning the Double, the Sram switches places with it, before switching places with it again at the end of their turn.",
+      "es": "Al invocar al doble, el sram intercambia de posición con él, antes de volver a intercambiar de posición con él al final de su turno.",
+      "pt": "Ao invocar o Dublê, o Sram troca de lugar com ele, e depois troca novamente no fim de seu turno."
+    },
     "effectIds": [
       410875
     ],
@@ -1336,11 +1876,21 @@
   },
   {
     "spellId": 4608,
-    "name": "Assassin",
+    "name": {
+      "fr": "Assassin",
+      "en": "Murderer",
+      "es": "Asesino",
+      "pt": "Assassino"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2439,
-    "description": "The Sram no longer gains Weak Point upon killing an enemy but immediately regains 1 AP, 1 MP, 1 WP, and 20% of max HP instead.",
+    "description": {
+      "fr": "Le Sram ne gagne plus de Point faible en tuant un ennemi mais regagne directement 1 PA 1 PM 1 PW et 20 % de ses PV max à la place.",
+      "en": "The Sram no longer gains Weak Point upon killing an enemy but immediately regains 1 AP, 1 MP, 1 WP, and 20% of max HP instead.",
+      "es": "Al matar a un enemigo, el sram ya no gana Punto Débil, sino que -en su lugar- recupera al instante 1 PA, 1 PM, 1 PW y 20% de sus PdV máx.",
+      "pt": "O Sram não recebe Ponto Fraco a mais ao matar um inimigo, mas recupera imediatamente 1 PA, 1 PM, 1 PW e 20% de seus PV máx. em troca."
+    },
     "effectIds": [
       120835,
       159173,
@@ -1380,11 +1930,21 @@
   },
   {
     "spellId": 4609,
-    "name": "Piège de Répulsion II",
+    "name": {
+      "fr": "Piège de Répulsion II",
+      "en": "Repulsion Trap II",
+      "es": "Trampa de repulsión II",
+      "pt": "Armadilha de Repulsão II"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 7191,
-    "description": "The repulsion trap works differently. When triggered, the trap becomes single-target and pushes the target in the direction it is facing.",
+    "description": {
+      "fr": "Le piège de répulsion change de fonctionnement. Le piège devient monocible et pousse la cible dans la direction où elle regarde lors du déclenchement.",
+      "en": "The repulsion trap works differently. When triggered, the trap becomes single-target and pushes the target in the direction it is facing.",
+      "es": "La trampa de repulsión cambia de funcionamiento. La trampa se vuelve monobjetivo y empuja al objetivo en la dirección que este mire cuando se activa.",
+      "pt": "A Armadilha de Repulsão muda de função. A armadilha passa a ser de alvo único e empurra o alvo na direção que ele estiver olhando ao ser ativada."
+    },
     "effectIds": [
       159192
     ],
@@ -1399,11 +1959,21 @@
   },
   {
     "spellId": 4610,
-    "name": "Hémophilie",
+    "name": {
+      "fr": "Hémophilie",
+      "en": "Hemophilia",
+      "es": "Hemofilia",
+      "pt": "Hemofilia"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 5123,
-    "description": "At the end of their turn, the Sram transforms their enemies' Hemorrhage into start-of-turn poison. This poison still inflicts melee damage.",
+    "description": {
+      "fr": "À la fin de son tour, le Sram transforme l'Hémorragie de ses ennemis en poison de début de tour. Ce poison inflige toujours des dommages mêlée.",
+      "en": "At the end of their turn, the Sram transforms their enemies' Hemorrhage into start-of-turn poison. This poison still inflicts melee damage.",
+      "es": "Al final de su turno, el sram transforma la hemorragia de sus enemigos en veneno de inicio de turno. Este veneno inflige siempre daños en melé.",
+      "pt": "No fim do seu turno, o Sram transforma a Hemorragia dos seus inimigos em veneno de início de turno. Esse veneno sempre inflige danos a curta distância."
+    },
     "effectIds": [
       411228
     ],
@@ -1418,11 +1988,21 @@
   },
   {
     "spellId": 5122,
-    "name": "Embuscade",
+    "name": {
+      "fr": "Embuscade",
+      "en": "Ambush",
+      "es": "Emboscada",
+      "pt": "Emboscada"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 588,
-    "description": "The Sram's traps no longer give the Sram AP back when triggered but inflict damage on enemies. The Sram regains 1 WP when their traps are triggered.",
+    "description": {
+      "fr": "Les pièges du Sram ne lui rendent plus de PA au déclenchement mais infligent des dommages aux ennemis. Le Sram regagne 1 PW lorsque ses pièges sont déclenchés.",
+      "en": "The Sram's traps no longer give the Sram AP back when triggered but inflict damage on enemies. The Sram regains 1 WP when their traps are triggered.",
+      "es": "Las trampas del sram ya no le dan PA con la activación, sino que infligen daños a los enemigos. El sram recupera 1 PW cuando sus trampas se activan.",
+      "pt": "As armadilhas do Sram não geram mais PA ao serem ativadas, mas infligem danos aos inimigos. O Sram recupera 1 PW ao ativar as armadilhas."
+    },
     "effectIds": [
       410773
     ],
@@ -1437,11 +2017,21 @@
   },
   {
     "spellId": 5124,
-    "name": "Retenue",
+    "name": {
+      "fr": "Retenue",
+      "en": "Restraint",
+      "es": "Contención",
+      "pt": "Retenção"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 5124,
-    "description": "The Sram loses their invisibility when inflicting direct damage only when using a spell costing 4 AP or more. This means they can use smaller spells before revealing themself. In exchange, they can no longer turn an ally invisible.",
+    "description": {
+      "fr": "Le Sram perd son invisibilité en infligeant des dommages directs seulement s'il s'agit d'un sort à 4 PA ou plus. Il peut ainsi utiliser des petits sorts avant de se révéler. En contrepartie, il ne peut plus rendre un allié invisible.",
+      "en": "The Sram loses their invisibility when inflicting direct damage only when using a spell costing 4 AP or more. This means they can use smaller spells before revealing themself. In exchange, they can no longer turn an ally invisible.",
+      "es": "El sram pierde su invisibilidad al infligir daños directos solo si es un hechizo de 4 PA o más. Así puede usar pequeños hechizos antes de revelarse. A cambio, ya no puede volver invisible a un aliado.",
+      "pt": "O Sram perde sua Invisibilidade ao infligir danos diretos apenas se for um feitiço de 4 PA ou mais. Assim, pode usar feitiços mais leves antes de se revelar. Em contrapartida, não pode mais tornar um aliado invisível."
+    },
     "effectIds": [
       411075
     ],
@@ -1456,11 +2046,21 @@
   },
   {
     "spellId": 5126,
-    "name": "Duperie",
+    "name": {
+      "fr": "Duperie",
+      "en": "Dupery",
+      "es": "Treta",
+      "pt": "Treta"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 5126,
-    "description": "The Sram switches places with their Double after receiving direct damage.",
+    "description": {
+      "fr": "Le Sram échange de position avec son Double après avoir reçu des dommages directs.",
+      "en": "The Sram switches places with their Double after receiving direct damage.",
+      "es": "El sram intercambia posición con su doble después de recibir daños directos.",
+      "pt": "O Sram troca de lugar com seu Dublê após sofrer danos diretos."
+    },
     "effectIds": [
       410856,
       410868
@@ -1476,11 +2076,21 @@
   },
   {
     "spellId": 8503,
-    "name": null,
+    "name": {
+      "fr": "Piège d'Attraction II",
+      "en": "Attraction Trap II",
+      "es": "Trampa de atracción II",
+      "pt": "Armadilha de Atração II"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 6999,
-    "description": null,
+    "description": {
+      "fr": "Le piège d'attraction change de fonctionnement. Le piège devient en zone croix de taille 1 et attire les cibles vers le centre du piège.",
+      "en": "The attraction trap works differently. The trap becomes a 1-cell cross area of effect and attracts targets toward the center of the trap.",
+      "es": "La trampa de atracción cambia de funcionamiento. La trampa se convierte en zona cruz de tamaño 1 y atrae a los objetivos hacia el centro de la trampa.",
+      "pt": "A Armadilha de Atração muda de função. A armadilha passa a ser em zona de cruz de tamanho 1 e atrai os alvos em direção ao centro dela."
+    },
     "effectIds": [
       410799
     ],
@@ -1495,11 +2105,21 @@
   },
   {
     "spellId": 8504,
-    "name": null,
+    "name": {
+      "fr": "Piège de Téléportation II",
+      "en": "Teleportation Trap II",
+      "es": "Trampa de teletransportación II",
+      "pt": "Armadilha de Teletransporte II"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 4609,
-    "description": null,
+    "description": {
+      "fr": "Le piège de téléportation change de fonctionnement. Le piège reste 1 tour et n'est plus consommé à l'utilisation. La téléportation est limitée à 4 cases max. Seuls les alliés peuvent déclencher le piège.",
+      "en": "The teleportation trap works differently. The trap stays for 1 turn and is no longer consumed when used. Teleportation is limited to 4 cells max. Only allies can trigger the trap.",
+      "es": "La trampa de teletransportación cambia de funcionamiento. La trampa permanece 1 turno y ya no se consume al utilizarse. La teletransportación se limita a 4 casillas máx. Solo los aliados pueden activar la trampa.",
+      "pt": "A Armadilha de Teletransporte muda de função. A armadilha continua funcionando por 1 turno e não é consumida ao ser utilizada. O teletransporte é limitado a até 4 no máx. células. Apenas aliados podem acionar a armadilha."
+    },
     "effectIds": [
       410800
     ],
@@ -1514,11 +2134,21 @@
   },
   {
     "spellId": 8508,
-    "name": null,
+    "name": {
+      "fr": "Leurre",
+      "en": "Lure",
+      "es": "Señuelo",
+      "pt": "Engodo"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 5122,
-    "description": null,
+    "description": {
+      "fr": "Le Double explose lorsqu'il subit des dommages directs, ce qui applique de l'Hémorragie aux ennemis autour de lui.",
+      "en": "The Double explodes when it suffers direct damage, which applies Hemorrhage to enemies around it.",
+      "es": "El doble explota cuando sufre daños directos, lo que aplica Hemorragia a los enemigos a su alrededor.",
+      "pt": "O Dublê explode ao sofrer danos diretos, aplicando Hemorragia nos inimigos ao redor."
+    },
     "effectIds": [
       410864
     ],
@@ -1547,11 +2177,21 @@
   },
   {
     "spellId": 8510,
-    "name": null,
+    "name": {
+      "fr": "Peur alternative",
+      "en": "Alternate Fear",
+      "es": "Miedo Alternativo",
+      "pt": "Medo Alternativo"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2437,
-    "description": null,
+    "description": {
+      "fr": "Le sort Peur du Double change de fonction : les cibles sont attirées vers le Double au lieu d'être repoussées.",
+      "en": "The Double's Fear spell works differently. Targets are attracted toward the Double instead of being pushed back.",
+      "es": "El hechizo Miedo del doble cambia de funcionamiento: los objetivos son atraídos hacia el doble en vez de ser repelidos.",
+      "pt": "O feitiço Medo do Dublê muda de função: os alvos são atraídos para o Dublê em vez de serem afastados dele."
+    },
     "effectIds": [
       410939
     ],
@@ -1566,11 +2206,21 @@
   },
   {
     "spellId": 8511,
-    "name": null,
+    "name": {
+      "fr": "Assaut létal",
+      "en": "Lethal Assault",
+      "es": "Asalto Letal",
+      "pt": "Assalto Letal"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2441,
-    "description": null,
+    "description": {
+      "fr": "La marque létale du Double change de fonctionnement. Au lieu de déplacer le porteur de la marque lorsque le Sram tue un ennemi, il se téléporte directement dans son dos.",
+      "en": "The Double's lethal mark works differently. Instead of moving the mark bearer when the Sram kills an enemy, the Sram teleports right behind the mark bearer.",
+      "es": "La marca letal del doble cambia de funcionamiento. En vez de desplazar al portador de la marca cuando el sram mata a un enemigo, se teletransporta directamente a su espalda.",
+      "pt": "A marca letal do Dublê muda de função. Em vez de deslocar o portador da marca quando o Sram mata um inimigo, ele se teletransporta diretamente para trás de você."
+    },
     "effectIds": [
       410940
     ],
@@ -1585,11 +2235,21 @@
   },
   {
     "spellId": 8512,
-    "name": null,
+    "name": {
+      "fr": "Diversion alternative",
+      "en": "Alternate Diversion",
+      "es": "Distracción Alternativa",
+      "pt": "Distração Alternativa"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2118,
-    "description": null,
+    "description": {
+      "fr": "Le sort Diversion du Double change de fonction : les cibles sont retournées de dos au Double au lieu de face.",
+      "en": "The Double's Diversion spell works differently. Targets are turned around with their backs to the Double instead of facing the Double.",
+      "es": "El hechizo Distracción del doble cambia de funcionamiento: los objetivos se vuelven de espaldas al doble en vez de frente.",
+      "pt": "O feitiço Distração do Dublê muda de função: os alvos ficam virados de costas para o Dublê em vez de em frente a ele."
+    },
     "effectIds": [
       410941
     ],
@@ -1604,11 +2264,21 @@
   },
   {
     "spellId": 8513,
-    "name": null,
+    "name": {
+      "fr": "Localisation quantique",
+      "en": "Quantum Location",
+      "es": "Localización Cuántica",
+      "pt": "Localização Quântica"
+    },
     "breedId": 4,
     "class": "SRAM",
     "gfxId": 2438,
-    "description": null,
+    "description": {
+      "fr": "Le Sram convertit ses dommages de dos en dommages mêlée. En contrepartie, il ne prend plus en compte l'orientation de ses cibles : elles sont toujours considérées de face.",
+      "en": "The Sram converts their rear damage into melee damage. In exchange, they no longer take account of their targets' orientation; targets are always considered to be facing the Sram.",
+      "es": "El sram convierte sus daños de espalda en daños en melé. A cambio, ya no tiene en cuenta la orientación de sus objetivos: siempre se consideran de frente.",
+      "pt": "O Sram transforma seus danos pelas costas em danos a curta distância. Em contrapartida, ele deixa de considerar a orientação dos seus alvos: eles são sempre tratados como se estivessem de frente."
+    },
     "effectIds": [
       411108,
       411205
@@ -1624,11 +2294,21 @@
   },
   {
     "spellId": 756,
-    "name": "Mémoire",
+    "name": {
+      "fr": "Mémoire",
+      "en": "Memory",
+      "es": "Memoria",
+      "pt": "Memória"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 756,
-    "description": "Gains a large amount of WP while losing mobility through an MP restriction.",
+    "description": {
+      "fr": "Gagne une grande quantité de PW, mais perd en mobilité via une contrainte sur ses PM.",
+      "en": "Gains a large amount of WP while losing mobility through an MP restriction.",
+      "es": "Gana una gran cantidad de PW, pero pierde en movilidad mediante una restricción en sus PM.",
+      "pt": "Ganha uma grande quantidade de PW, mas perde mobilidade devido a uma restrição em seus PM."
+    },
     "effectIds": [
       164625,
       351765
@@ -1669,11 +2349,21 @@
   },
   {
     "spellId": 758,
-    "name": "Maître du cadran",
+    "name": {
+      "fr": "Maître du cadran",
+      "en": "Dial Master",
+      "es": "Maestro de la Esfera",
+      "pt": "Mestre do Quadrante"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 758,
-    "description": "Delayed effects (those with Sinistro, Sandglass, Against the Clock, etc.) are also triggered when the current hour goes around the dial.",
+    "description": {
+      "fr": "Les effets délayés (déclenchements de Sinistro, Sablier, Contre la montre, etc.) se déclenchent aussi lorsque l'heure courante fait un tour du cadran.",
+      "en": "Delayed effects (those with Sinistro, Sandglass, Against the Clock, etc.) are also triggered when the current hour goes around the dial.",
+      "es": "Los efectos retardados (activaciones de sinistro, Reloj de Arena, Contrarreloj, etc.) también se activan cuando la hora actual da una vuelta a la esfera.",
+      "pt": "Os efeitos difundidos (ativações de Sinistro, Ampulheta, Contra o Relógio, etc.) também são ativados quando a Hora Atual dá uma volta no Quadrante."
+    },
     "effectIds": [
       98353
     ],
@@ -1688,11 +2378,21 @@
   },
   {
     "spellId": 761,
-    "name": "Horlogerie",
+    "name": {
+      "fr": "Horlogerie",
+      "en": "Clockmaking",
+      "es": "Relojería",
+      "pt": "Relojoaria"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 761,
-    "description": "The Xelor is teleported to the current hour on their Dial at the start of each turn. If the current hour cell is occupied by an obstacle, the Xelor switches places with the obstacle.",
+    "description": {
+      "fr": "Le Xélor est téléporté sur l'heure courante de son Cadran à chaque début de tour. Si la case de l'heure courante est occupée par un obstacle, alors le Xélor échange de position avec l'obstacle.",
+      "en": "The Xelor is teleported to the current hour on their Dial at the start of each turn. If the current hour cell is occupied by an obstacle, the Xelor switches places with the obstacle.",
+      "es": "El xelor se teletransporta a la hora actual de su esfera al principio de cada turno. Si la casilla de la hora actual está ocupada por un obstáculo, el xelor cambia de posición con el obstáculo.",
+      "pt": "O Xelor é teletransportado para a hora atual de seu Quadrante no começo de cada turno. Se a célula da hora atual estiver ocupada por um obstáculo, o Xelor troca de lugar com ele."
+    },
     "effectIds": [
       20962
     ],
@@ -1721,11 +2421,21 @@
   },
   {
     "spellId": 764,
-    "name": "Taque, Tique",
+    "name": {
+      "fr": "Taque, Tique",
+      "en": "Tock, Tick",
+      "es": "Tac Tic",
+      "pt": "Taque, Tique"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 764,
-    "description": "Increases the damage inflicted during even turns, and reduces it during odd turns. In order to make full use of this passive's potential, the Xelor can keep resources from one turn to the next to use them at the right time.",
+    "description": {
+      "fr": "Augmente les dommages infligés les tours pairs, et les diminue les tours impairs. Afin d'exploiter tout le potentiel de ce passif, le Xélor peut conserver des ressources d'un tour à l'autre pour les utiliser au moment opportun.",
+      "en": "Increases the damage inflicted during even turns, and reduces it during odd turns. In order to make full use of this passive's potential, the Xelor can keep resources from one turn to the next to use them at the right time.",
+      "es": "Aumenta los daños infligidos en los turnos pares, y los disminuye en los turnos impares. Con el fin de explotar todo el potencial de este pasivo, el xelor puede conservar recursos de un turno a otro para utilizarlos en el momento oportuno.",
+      "pt": "Aumenta os danos infligidos nos turnos pares e diminui nos turnos ímpares. Para explorar todo o potencial deste passivo, o Xelor pode guardar recursos de um turno para outro a fim de usá-los no momento adequado."
+    },
     "effectIds": [
       312866
     ],
@@ -1742,11 +2452,21 @@
   },
   {
     "spellId": 785,
-    "name": "Cours du temps",
+    "name": {
+      "fr": "Cours du temps",
+      "en": "Course of Time",
+      "es": "Curso del Tiempo",
+      "pt": "Passar do Tempo"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 785,
-    "description": "Transpositions caused by the Xelor's spells or passives make the Xelor regain 1 AP or 1 WP.",
+    "description": {
+      "fr": "Les transpositions causées par le Xélor par le biais de ses sorts ou passifs lui font regagner 1 Point d'Action ou 1 Point de Wakfu.",
+      "en": "Transpositions caused by the Xelor's spells or passives make the Xelor regain 1 AP or 1 WP.",
+      "es": "Las trasposiciones causadas por el xelor mediante sus hechizos o pasivos le conceden 1 PA o 1 PW.",
+      "pt": "As transposições causadas pelo Xelor através dos seus feitiços ou passivos fazem com que ele recupere 1 Ponto de ação ou 1 Ponto de Wakfu."
+    },
     "effectIds": [
       314473,
       316380
@@ -1785,11 +2505,21 @@
   },
   {
     "spellId": 5351,
-    "name": "Présage",
+    "name": {
+      "fr": "Présage",
+      "en": "Portent",
+      "es": "Presagio",
+      "pt": "Presságio"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 5351,
-    "description": "The Xelor regains WP when they reduce an enemy's AP. However, the Xelor no longer regains WP based on their remaining AP at the end of the turn.",
+    "description": {
+      "fr": "Le Xélor regagne des PW lorsqu'il retire des PA à des ennemis. En revanche, il ne regagne plus de PW en fonction de son nombre de PA en fin de tour.",
+      "en": "The Xelor regains WP when they reduce an enemy's AP. However, the Xelor no longer regains WP based on their remaining AP at the end of the turn.",
+      "es": "El xelor recupera PW cuando retira PA a los enemigos. En cambio, no recupera PW según su número de PA al final del turno.",
+      "pt": "O Xelor recupera PW quando ele retira PA dos inimigos. Em contrapartida, ele deixa de recuperar PW em função de sua quantidade de PA no fim do turno."
+    },
     "effectIds": [
       349651
     ],
@@ -1816,11 +2546,21 @@
   },
   {
     "spellId": 5352,
-    "name": "Promptitude",
+    "name": {
+      "fr": "Promptitude",
+      "en": "Timeliness",
+      "es": "Prontitud",
+      "pt": "Prontidão"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 5352,
-    "description": "Depending on the current hour's position when the dial is summoned, the Xelor's elemental spells are cast without line of sight, meaning they can target through obstacles. However, these spells can only be cast in a straight line.",
+    "description": {
+      "fr": "Selon la position de l'heure courante lorsque le cadran est invoqué, les sorts élémentaires du Xélor passent sans ligne de vue et peuvent donc cibler à travers les obstacles. En revanche, ils sont contraints à un lancer en ligne.",
+      "en": "Depending on the current hour's position when the dial is summoned, the Xelor's elemental spells are cast without line of sight, meaning they can target through obstacles. However, these spells can only be cast in a straight line.",
+      "es": "Según la posición de la hora actual cuando se invoca la esfera, los hechizos elementales del xelor pasan sin línea de visión y pueden fijar objetivos a través de los obstáculos. En cambio, tienen la restricción de lanzamiento en línea.",
+      "pt": "De acordo com a posição da Hora Atual quando o Quadrante é invocado, os feitiços elementares do Xelor deixam de ter linha de visão e, assim, podem visar através dos obstáculos. Em contrapartida, eles são restritos a um lançamento em linha."
+    },
     "effectIds": [
       164680
     ],
@@ -1835,11 +2575,21 @@
   },
   {
     "spellId": 5353,
-    "name": "Tique, Taque",
+    "name": {
+      "fr": "Tique, Taque",
+      "en": "Tick, Tock",
+      "es": "Tic Tac",
+      "pt": "Tique, Taque"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 5353,
-    "description": "Reduces Force of Will on even turns and increases it on odd turns. In order to make full use of this passive's potential, the Xelor can keep resources from one turn to the next to use them at the right time.",
+    "description": {
+      "fr": "Diminue la Volonté les tours pairs, et l'augmente les tours impairs. Afin d'exploiter tout le potentiel de ce passif, le Xélor peut conserver des ressources d'un tour à l'autre pour les utiliser au moment opportun.",
+      "en": "Reduces Force of Will on even turns and increases it on odd turns. In order to make full use of this passive's potential, the Xelor can keep resources from one turn to the next to use them at the right time.",
+      "es": "Disminuye la voluntad en los turnos pares y la aumenta en los turnos impares. Con el fin de explotar todo el potencial de este pasivo, el xelor puede conservar recursos de un turno a otro para utilizarlos en el momento oportuno.",
+      "pt": "Diminui a vontade nos turnos pares e a aumenta nos turnos ímpares. Para explorar todo o potencial deste passivo, o Xelor pode guardar recursos de um turno para outro a fim de usá-los no momento adequado."
+    },
     "effectIds": [
       164766
     ],
@@ -1856,11 +2606,21 @@
   },
   {
     "spellId": 7184,
-    "name": "Contre-horaire",
+    "name": {
+      "fr": "Contre-horaire",
+      "en": "Counterclockwise",
+      "es": "Contrahorario",
+      "pt": "Anti-horário"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7184,
-    "description": "Every other turn, the current hour goes the other way.",
+    "description": {
+      "fr": "Un tour sur deux, l'heure courante avance dans l'autre sens.",
+      "en": "Every other turn, the current hour goes the other way.",
+      "es": "Cada dos turnos, la hora actual avanza en el otro sentido.",
+      "pt": "A cada dois turnos, a Hora Atual avança no outro sentido."
+    },
     "effectIds": [
       314248
     ],
@@ -1877,11 +2637,21 @@
   },
   {
     "spellId": 7185,
-    "name": "Déjà vu",
+    "name": {
+      "fr": "Déjà vu",
+      "en": "Déjà Vu",
+      "es": "Deja Vu",
+      "pt": "Déjà Vu"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7185,
-    "description": "Depending on the current hour's position when the dial is summoned, the Xelor's damage is reduced but regenerates the Xelor's health.",
+    "description": {
+      "fr": "Selon la position de l'heure courante lorsque le cadran est invoqué, les dommages du Xélor sont moins élevés, mais régénèrent la vie du Xélor.",
+      "en": "Depending on the current hour's position when the dial is summoned, the Xelor's damage is reduced but regenerates the Xelor's health.",
+      "es": "Según la posición de la hora actual cuando se invoca la esfera, los daños del xelor son menos elevados, pero regeneran la vida de este.",
+      "pt": "De acordo com a posição da Hora Atual quando o Quadrante é invocado, os danos do Xelor são mais baixos, mas regeneram a vida dele."
+    },
     "effectIds": [
       312878,
       349658,
@@ -1921,11 +2691,21 @@
   },
   {
     "spellId": 7186,
-    "name": "Connaissance du passé",
+    "name": {
+      "fr": "Connaissance du passé",
+      "en": "Knowledge of the Past",
+      "es": "Conocimiento del Pasado",
+      "pt": "Conhecimento do Passado"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7186,
-    "description": "The dial costs more to summon. However, when the current hour goes all the way around the dial, the Xelor regains AP and WP.",
+    "description": {
+      "fr": "Le cadran est plus résistant mais devient plus cher à invoquer.",
+      "en": "The dial is more resistant but costs more to summon.",
+      "es": "La esfera es más resistente, pero es más difícil invocarla.",
+      "pt": "O quadrante fica mais resistente, mas se torna mais caro de invocar."
+    },
     "effectIds": [
       349662
     ],
@@ -1940,11 +2720,21 @@
   },
   {
     "spellId": 7187,
-    "name": "Présages violents",
+    "name": {
+      "fr": "Présages violents",
+      "en": "Violent Omens",
+      "es": "Presagios Violentos",
+      "pt": "Presságios Violentos"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7187,
-    "description": "The current hour inflicts high damage on any fighter starting their turn on it.",
+    "description": {
+      "fr": "L'heure courante inflige des dommages élevés à tous les combattants qui commencent leur tour dessus.",
+      "en": "The current hour inflicts high damage on any fighter starting their turn on it.",
+      "es": "La hora actual inflige daños elevados a todos los combatientes que empiezan su turno encima.",
+      "pt": "A Hora Atual inflige danos elevados a todos os combatentes que começam o turno sobre ela."
+    },
     "effectIds": [
       349668,
       349669,
@@ -1975,11 +2765,21 @@
   },
   {
     "spellId": 7188,
-    "name": "Dimension sombre",
+    "name": {
+      "fr": "Dimension sombre",
+      "en": "Dark Dimension",
+      "es": "Dimensión Oscura",
+      "pt": "Dimensão Sombria"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7188,
-    "description": "The current hour gives a Force of Will bonus, improving the Xelor's ability to remove AP. However, the Xelor's AP removals can now only happen from the current hour or if they have Punctuality.",
+    "description": {
+      "fr": "L'heure courante donne un bonus de Volonté, ce qui améliore la faculté du Xélor à retirer des PA. Cependant, les retraits de PA du Xélor ne peuvent désormais s'effectuer que depuis l'heure courante ou s'il possède Ponctualité.",
+      "en": "The current hour gives a Force of Will bonus, improving the Xelor's ability to remove AP. However, the Xelor's AP removals can now only happen from the current hour or if they have Punctuality.",
+      "es": "La hora actual da un bonus de voluntad, lo que mejora la facultad de retirar PA del xelor. En cambio, las retiradas de PA del xelor ahora solo pueden hacerse desde la hora actual o si tiene Puntualidad.",
+      "pt": "A Hora Atual dá um bônus de Vontade, o que melhora a capacidade do Xelor de retirar PA. No entanto, as retiradas de PA do Xelor agora só podem acontecer a partir da Hora Atual ou se ele tiver Pontualidade."
+    },
     "effectIds": [
       312887
     ],
@@ -1994,11 +2794,21 @@
   },
   {
     "spellId": 7189,
-    "name": "Ralentissement du temps",
+    "name": {
+      "fr": "Ralentissement du temps",
+      "en": "Slowdown of Time",
+      "es": "Ralentización del Tiempo",
+      "pt": "Desaceleração do Tempo"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7189,
-    "description": "The Dial spreads its hour cells over a 6-cell ring rather than a 3-cell ring. Each hour cell is 4 cells from the next, unlike the Dial's standard layout (2 cells).",
+    "description": {
+      "fr": "Le Cadran répartit ses Cases heure sur un anneau de taille 6 plutôt que de taille 3. Chaque case heure est à quatre cases de la suivante, contrairement à la disposition classique du Cadran (deux cases).",
+      "en": "The Dial spreads its hour cells over a 6-cell ring rather than a 3-cell ring. Each hour cell is 4 cells from the next, unlike the Dial's standard layout (2 cells).",
+      "es": "La esfera reparte sus casillas de hora en un anillo de tamaño 6 en lugar de de tamaño 3. Cada casilla de hora está a cuatro casillas de la siguiente, al contrario que en la disposición clásica de la esfera (dos casillas).",
+      "pt": "O Quadrante distribui suas células Hora em um anel de tamanho 6 em vez de tamanho 3. Cada célula Hora fica a quatro células de distância da seguinte, diferentemente da disposição clássica do Quadrante (duas células)."
+    },
     "effectIds": [
       312890
     ],
@@ -2013,11 +2823,21 @@
   },
   {
     "spellId": 7190,
-    "name": "Rémanence",
+    "name": {
+      "fr": "Rémanence",
+      "en": "Remanence",
+      "es": "Remanencia",
+      "pt": "Remanência"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7190,
-    "description": "The Xelor's summons (Dial, Sinistro, Cog, Regulator) can no longer block line of sight; enemy and ally spells can go through them.",
+    "description": {
+      "fr": "Les invocations du Xélor (Cadran, Sinistro, Rouage, Régulateur) ne peuvent plus bloquer la ligne de vue : les sorts ennemis et alliés peuvent passer au travers.",
+      "en": "The Xelor's summons (Dial, Sinistro, Cog, Regulator) can no longer block line of sight; enemy and ally spells can go through them.",
+      "es": "Las invocaciones del xelor (esfera, sinistro, rueda dentada, regulador) ya no pueden bloquear la línea de visión: los hechizos enemigos y aliados pueden pasar a través de ellas.",
+      "pt": "As invocações do Xelor (Quadrante, Sinistro, Roda Dentada, Regulador) não bloqueiam mais a linha de visão: os feitiços dos inimigos e aliados podem passar através delas."
+    },
     "effectIds": [
       312893
     ],
@@ -2032,11 +2852,21 @@
   },
   {
     "spellId": 7191,
-    "name": "Mécanismes spécialisés",
+    "name": {
+      "fr": "Mécanismes spécialisés",
+      "en": "Specialized Mechanisms",
+      "es": "Mecanismos Especializados",
+      "pt": "Mecanismos Especializados"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7191,
-    "description": "The Xelor's summons (Dial, Sinistro, Cog and Regulator) gain an ability: When one is summoned, the Xelor immediately switches places with it (within a maximum Range of 6 cells).",
+    "description": {
+      "fr": "Les invocations du Xélor (Cadran, Sinistro, Rouage, Régulateur) gagnent une capacité : lorsqu'elles sont invoquées, le Xélor échange immédiatement de position avec (dans une limite de 6 de Portée).",
+      "en": "The Xelor's summons (Dial, Sinistro, Cog and Regulator) gain an ability: When one is summoned, the Xelor immediately switches places with it (within a maximum Range of 6 cells).",
+      "es": "Las invocaciones del xelor (esfera, sinistro, rueda dentada, regulador) ganan una capacidad: cuando son invocadas, el xelor intercambia su posición con ellas (hasta un límite de 6 de alcance).",
+      "pt": "As invocações do Xelor (Quadrante, Sinistro, Roda Dentada, Regulador) ganham uma habilidade: quando são invocadas, o Xelor troca imediatamente de lugar com elas (com um limite de 6 de alcance)."
+    },
     "effectIds": [
       349688
     ],
@@ -2051,11 +2881,21 @@
   },
   {
     "spellId": 7192,
-    "name": "Permutation momentanée",
+    "name": {
+      "fr": "Permutation momentanée",
+      "en": "Momentary Permutation",
+      "es": "Permutación Momentánea",
+      "pt": "Permutação Momentânea"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7192,
-    "description": "The Dial, which is Stabilized, can be repositioned anywhere on the field with this passive. The Xelor switches places with their Dial at the end of every turn.",
+    "description": {
+      "fr": "Le Cadran, qui est Stabilisé, peut être replacé n'importe où sur le terrain à l'aide de ce passif. Le Xélor échange de position avec son Cadran à chaque fin de tour.",
+      "en": "The Dial, which is Stabilized, can be repositioned anywhere on the field with this passive. The Xelor switches places with their Dial at the end of every turn.",
+      "es": "La esfera, que está Estabilizada, puede cambiarse a cualquier otro sitio del terreno con la ayuda de este pasivo. El xelor intercambia la posición con su esfera al final de cada turno.",
+      "pt": "O Quadrante, que está Estabilizado, pode ser colocado em qualquer lugar do terreno graças a este passivo. O Xelor troca de lugar com seu Quadrante no fim de cada turno."
+    },
     "effectIds": [
       312895
     ],
@@ -2084,11 +2924,21 @@
   },
   {
     "spellId": 7193,
-    "name": "Mage de combat",
+    "name": {
+      "fr": "Mage de combat",
+      "en": "Combat Mage",
+      "es": "Mago de Combate",
+      "pt": "Mago de Combate"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7193,
-    "description": "AP removals in melee combat (within 2 cells or less of the Xelor) are replaced with a damage penalty on the target.",
+    "description": {
+      "fr": "Les retraits de PA effectués en mêlée (2 cases et moins du Xélor) sont remplacés par un malus de dommages sur la cible.",
+      "en": "AP removals in melee combat (within 2 cells or less of the Xelor) are replaced with a damage penalty on the target.",
+      "es": "Las retiradas de PA efectuadas en melé (2 casillas o menos del xelor) se sustituyen por un malus de daños en el objetivo.",
+      "pt": "As retiradas de PA realizadas a curta distância (a 2 células ou menos do Xelor) são substituídas por uma penalidade de danos no alvo."
+    },
     "effectIds": [
       314331
     ],
@@ -2105,11 +2955,21 @@
   },
   {
     "spellId": 7195,
-    "name": "Flétrissement",
+    "name": {
+      "fr": "Flétrissement",
+      "en": "Shriveling",
+      "es": "Marchitación",
+      "pt": "Murchidão"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7195,
-    "description": "AP removals from a distance (3 or more cells from the Xelor) are replaced by application of indirect damage on the target.",
+    "description": {
+      "fr": "Les retraits de PA effectués à distance (3 cases et plus du Xélor) sont remplacés par une application de dommages indirects sur la cible.",
+      "en": "AP removals from a distance (3 or more cells from the Xelor) are replaced by application of indirect damage on the target.",
+      "es": "Las retiradas de PA efectuadas a distancia (3 casillas y más del xelor) se sustituyen por una aplicación de daños indirectos al objetivo.",
+      "pt": "As retiradas de PA realizadas à distância (a 3 células ou mais do Xelor) são substituídas por uma aplicação de danos indiretos ao alvo."
+    },
     "effectIds": [
       314321
     ],
@@ -2126,11 +2986,21 @@
   },
   {
     "spellId": 7196,
-    "name": "Assimilation",
+    "name": {
+      "fr": "Assimilation",
+      "en": "Assimilation",
+      "es": "Asimilación",
+      "pt": "Assimilação"
+    },
     "breedId": 5,
     "class": "XELOR",
     "gfxId": 7196,
-    "description": "Lowers the Xelor's WP gauge, but gives them greater WP regeneration capacity.",
+    "description": {
+      "fr": "Réduit la jauge de PW du Xélor, mais lui octroie une capacité supplémentaire de régénération de PW.",
+      "en": "Lowers the Xelor's WP gauge, but gives them greater WP regeneration capacity.",
+      "es": "Reduce el indicador de PW del xelor, pero le otorga una capacidad adicional de regeneración de PW.",
+      "pt": "Reduz o medidor de PW do Xelor, mas dá a ele uma habilidade extra de regeneração de PW."
+    },
     "effectIds": [
       314314,
       314319
@@ -2169,11 +3039,21 @@
   },
   {
     "spellId": 2059,
-    "name": "Tarot veinard",
+    "name": {
+      "fr": "Tarot veinard",
+      "en": "Lucky Tarot",
+      "es": "Tarot Suertudo",
+      "pt": "Tarô Sortudo"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5456,
-    "description": "Tarot cards increase the Ecaflip's Lucky Day and give them a boost to critical hit rate based on the cards' numerical value.",
+    "description": {
+      "fr": "Les cartes de tarot augmentent la Veine de l'Ecaflip et lui donnent un bonus de chances aux coups critiques en fonction de leur valeur numérique.",
+      "en": "Tarot cards increase the Ecaflip's Lucky Day and give them a boost to critical hit rate based on the cards' numerical value.",
+      "es": "Las cartas de tarot aumentan la racha del zurcarák y le dan un bonus de probabilidad a los golpes críticos en función de su valor numérico.",
+      "pt": "As cartas de tarô aumentam a Ventura do Ecaflip e dão a ele um bônus de chance de golpes críticos em função dos seus valores numéricos."
+    },
     "effectIds": [
       359821
     ],
@@ -2188,11 +3068,21 @@
   },
   {
     "spellId": 2062,
-    "name": "Pucif",
+    "name": {
+      "fr": "Pucif",
+      "en": "Fleassive",
+      "es": "Pulgación",
+      "pt": "Pulsivo"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 7931,
-    "description": "This passive reduces elemental healing done by the Ecaflip. In exchange, each elemental heal is replicated at the end of the target's turn before being transferred to the nearest ally.",
+    "description": {
+      "fr": "Ce passif réduit les soins élémentaires réalisés par l'Ecaflip. En revanche, chaque soin élémentaire se réplique à la fin du tour de la cible avant d'être transmis à l'allié le plus proche.",
+      "en": "This passive reduces elemental healing done by the Ecaflip. In exchange, each elemental heal is replicated at the end of the target's turn before being transferred to the nearest ally.",
+      "es": "Este pasivo reduce las curas elementales que realiza el zurcarák. En cambio, cada cura elemental se replica al final del turno del objetivo antes de transferirlo al aliado más cercano.",
+      "pt": "Este passivo reduz as curas elementares realizadas pelo Ecaflip. Por outro lado, cada cura elementar é aplicada novamente ao fim do turno do alvo antes de ser transmitida para o aliado mais próximo."
+    },
     "effectIds": [
       371372
     ],
@@ -2207,11 +3097,21 @@
   },
   {
     "spellId": 2068,
-    "name": "La Mésaventure",
+    "name": {
+      "fr": "La Mésaventure",
+      "en": "Misadventure",
+      "es": "Desventura",
+      "pt": "Desventura"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 2068,
-    "description": "Unlocks an extra tarot card (added to the draw pile). This card reduces the target's mobility and damage but increases their resistance for one turn.",
+    "description": {
+      "fr": "Débloque une carte de tarot supplémentaire (la pioche s'agrandit donc). Cette carte réduit la mobilité et les dommages de la cible, mais augmente ses résistances pendant un tour.",
+      "en": "Unlocks an extra tarot card (added to the draw pile). This card reduces the target's mobility and damage but increases their resistance for one turn.",
+      "es": "Desbloquea una carta de tarot adicional (así que aumenta el mazo). Esta carta reduce la movilidad y los daños del objetivo, pero aumenta sus resistencias durante un turno.",
+      "pt": "Desbloqueia uma carta de tarô adicional (o monte fica maior). Esta carta reduz a mobilidade e os danos do alvo, mas aumenta suas resistências durante um turno."
+    },
     "effectIds": [
       359755
     ],
@@ -2226,11 +3126,21 @@
   },
   {
     "spellId": 2076,
-    "name": "En veine",
+    "name": {
+      "fr": "En veine",
+      "en": "Winning Streak",
+      "es": "En Racha",
+      "pt": "Com Ventura"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5246,
-    "description": "Each Critical Hit point given by the Ecaflip (to themself or someone else) increases their Lucky Day by 1. However, when Critical Hit is given, it only lasts one turn.",
+    "description": {
+      "fr": "Chaque point de Coup critique donné par l'Ecaflip (sur lui-même ou un autre) augmente de 1 sa Veine. En revanche, les dons de Coup critique ne durent plus qu'un tour.",
+      "en": "Each Critical Hit point given by the Ecaflip (to themself or someone else) increases their Lucky Day by 1. However, when Critical Hit is given, it only lasts one turn.",
+      "es": "Cada punto de golpe crítico dado por el zurcarák (a sí mismo o a otro) aumenta su racha en 1. En cambio, los puntos de golpe crítico dados solo duran un turno.",
+      "pt": "Cada ponto de golpe crítico concedido pelo Ecaflip (nele mesmo ou em outro) aumenta em 1 sua Ventura. No entanto, as doações de golpe crítico só duram um turno."
+    },
     "effectIds": [
       359771
     ],
@@ -2245,11 +3155,21 @@
   },
   {
     "spellId": 2080,
-    "name": "L'Infortune",
+    "name": {
+      "fr": "L'Infortune",
+      "en": "Misfortune",
+      "es": "Desdicha",
+      "pt": "Infortúnio"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 2080,
-    "description": "Unlocks an extra tarot card (added to the draw pile). This tarot card converts the target's Critical Hit into Block, at a rate of one to one, for one turn.",
+    "description": {
+      "fr": "Débloque une carte de tarot supplémentaire (la pioche s'agrandit donc). Cette carte de tarot convertit les Coups critiques de la cible et les transforme en Parade, à taux d'un pour un, pendant un tour.",
+      "en": "Unlocks an extra tarot card (added to the draw pile). This tarot card converts the target's Critical Hit into Block, at a rate of one to one, for one turn.",
+      "es": "Desbloquea una carta de tarot adicional (así que aumenta el mazo). Esta carta de tarot convierte los golpes críticos del objetivo y los transforma en anticipación, con una tasa de dos por uno, durante un turno.",
+      "pt": "Desbloqueia uma carta de tarô adicional (o monte fica maior). Esta carta de tarô converte os golpes críticos do alvo e os transforma em parada, em uma proporção de um para um, durante um turno."
+    },
     "effectIds": [
       162572
     ],
@@ -2276,11 +3196,21 @@
   },
   {
     "spellId": 5246,
-    "name": "Tarot divinatoire",
+    "name": {
+      "fr": "Tarot divinatoire",
+      "en": "Prophetic Tarot",
+      "es": "Tarot Profético",
+      "pt": "Tarô Divinatório"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 4959,
-    "description": "The Ecaflip earns bonuses by playing cards in pairs of the same color. However, Roll Again costs more.",
+    "description": {
+      "fr": "Jouer des cartes par paires de couleur permet de donner des bonus à l'Ecaflip. En contrepartie, Relance coûte plus cher.",
+      "en": "The Ecaflip earns bonuses by playing cards in pairs of the same color. However, Roll Again costs more.",
+      "es": "Al jugar cartas por parejas de color, se pueden otorgar bonus al zurcarák. En cambio, Re-tirada cuesta más caro.",
+      "pt": "Jogar cartas por pares de cor permite conceder bônus ao Ecaflip. Porém, Jogar de Novo custará mais caro."
+    },
     "effectIds": [
       359823
     ],
@@ -2309,11 +3239,21 @@
   },
   {
     "spellId": 5249,
-    "name": "Impact félin",
+    "name": {
+      "fr": "Impact félin",
+      "en": "Feline Impact",
+      "es": "Impacto Felino",
+      "pt": "Impacto Felino"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5249,
-    "description": "This passive changes how the number of uses of Feline Leap is generated. Ending a turn adjacent to an enemy gives the spell two extra uses.",
+    "description": {
+      "fr": "Si l'Ecaflip finit son tour au contact d'un ennemi, il bénéficiera d'un Bond du félin gratuit au tour suivant. En contrepartie, le sort est utilisable deux fois par tour au lieu de trois.",
+      "en": "If the Ecaflip ends their turn adjacent to an enemy, the Ecaflip will gain a free Feline Leap the next turn. However, the spell can only be used two times per turn instead of three.",
+      "es": "Si el zurcarák termina su turno en contacto con un enemigo, recibirá un salto del felino gratis en el siguiente turno. A cambio, el hechizo puede utilizarse dos veces por turno en vez de tres.",
+      "pt": "Se o Ecaflip terminar o turno em contato com um inimigo, ele receberá um Salto Felino gratuito no turno seguinte. Em contrapartida, o feitiço pode ser usado duas vezes por turno em vez de três."
+    },
     "effectIds": [
       359836
     ],
@@ -2328,11 +3268,21 @@
   },
   {
     "spellId": 5250,
-    "name": "Le Destin d'Ecaflip",
+    "name": {
+      "fr": "Le Destin d'Ecaflip",
+      "en": "Ecaflip's Fate",
+      "es": "Destino de Zurcarák",
+      "pt": "Destino de Ecaflip"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5250,
-    "description": "Unlocks an extra tarot card (added to the draw pile). This tarot card inflicts serious damage on the target. However, if the target is still alive the next turn, the Ecaflip takes the same damage.",
+    "description": {
+      "fr": "Débloque une carte de tarot supplémentaire (la pioche s'agrandit donc). Cette carte de tarot inflige des dommages conséquents sur la cible. En revanche, si la cible est encore en vie au tour suivant, l'Ecaflip subit autant de dommages.",
+      "en": "Unlocks an extra tarot card (added to the draw pile). This tarot card inflicts serious damage on the target. However, if the target is still alive the next turn, the Ecaflip takes the same damage.",
+      "es": "Desbloquea una carta de tarot adicional (así que aumenta el mazo). Esta carta de tarot causa grandes daños en el objetivo. En cambio, si el objetivo sigue vivo en el siguiente turno, el zurcarák sufre la misma cantidad de daños.",
+      "pt": "Desbloqueia uma carta de tarô adicional (o monte fica maior). Esta carta de tarô inflige danos consideráveis ao alvo. Porém, se o alvo ainda estiver vivo no turno seguinte, o Ecaflip sofrerá a mesma quantidade de danos."
+    },
     "effectIds": [
       162479
     ],
@@ -2347,11 +3297,21 @@
   },
   {
     "spellId": 5251,
-    "name": "Triche",
+    "name": {
+      "fr": "Triche",
+      "en": "Cheat",
+      "es": "Trampas",
+      "pt": "Trapaça"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 852,
-    "description": "This passive allows the Ecaflip to play the first card of their turn for free. However, unless they use Roll Again, the Ecaflip can only draw a single card.",
+    "description": {
+      "fr": "Ce passif permet à l'Ecaflip de jouer la première carte de son tour gratuitement. En revanche, sans utiliser Relance, l'Ecaflip ne peut piocher qu'une seule carte.",
+      "en": "This passive allows the Ecaflip to play the first card of their turn for free. However, unless they use Roll Again, the Ecaflip can only draw a single card.",
+      "es": "Gracias a este pasivo, el zurcarák puede jugar la primera carta de su turno gratis. En cambio, sin utilizar Re-tirada, el zurcarák solo puede robar una sola carta.",
+      "pt": "Este passivo permite que o Ecaflip jogue a primeira carta de seu turno gratuitamente. Porém, sem utilizar Jogar de Novo, o Ecaflip só pode comprar apenas uma carta."
+    },
     "effectIds": [
       359923
     ],
@@ -2368,11 +3328,21 @@
   },
   {
     "spellId": 7954,
-    "name": "Veine soigneuse",
+    "name": {
+      "fr": "Veine soigneuse",
+      "en": "Healing Luck",
+      "es": "Racha Sanadora",
+      "pt": "Ventura Curadora"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5463,
-    "description": "With this passive, Lucky Day increases healing done by the Ecaflip. However, Lucky Day only lasts one turn, no matter how it's generated.",
+    "description": {
+      "fr": "Avec ce passif, la Veine augmente les soins réalisés par l'Ecaflip. En revanche, la Veine ne dure qu'un tour, quelle que soit la méthode de génération.",
+      "en": "With this passive, Lucky Day increases healing done by the Ecaflip. However, Lucky Day only lasts one turn, no matter how it's generated.",
+      "es": "Con este pasivo, la racha aumenta las curas que realice el zurcarák. En cambio, la racha solo dura un turno, sea cual sea el método de generación.",
+      "pt": "Com este passivo, Ventura aumenta as curas realizadas pelo Ecaflip. Porém, Ventura só dura um turno, não importa o método de geração."
+    },
     "effectIds": [
       359889,
       360622
@@ -2390,11 +3360,21 @@
   },
   {
     "spellId": 7955,
-    "name": "Tarot félin",
+    "name": {
+      "fr": "Tarot félin",
+      "en": "Feline Tarot",
+      "es": "Tarot Felino",
+      "pt": "Tarô Felino"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 7928,
-    "description": "When the Ecaflip uses a tarot card on a fighter, they switch places with them. However, the Ecaflip will be stabilized until their turn ends.",
+    "description": {
+      "fr": "Lorsque l'Ecaflip cible un combattant avec une carte de Tarot, il échange de position avec. En revanche, il devient stabilisé jusqu'à la fin de son tour.",
+      "en": "When the Ecaflip uses a tarot card on a fighter, they switch places with them. However, the Ecaflip will be stabilized until their turn ends.",
+      "es": "Cuando el zurcarák selecciona a un luchador con una carta de tarot, intercambiará de posición con él. En cambio, quedará Estabilizado hasta el final de turno.",
+      "pt": "Quando o Ecaflip visa um combatente com uma carta de tarô, ele troca de posição com ele. Porém, ele fica estabilizado até o fim do seu turno."
+    },
     "effectIds": [
       359891,
       374216
@@ -2410,11 +3390,21 @@
   },
   {
     "spellId": 7956,
-    "name": "La fortune sourit aux audacieux",
+    "name": {
+      "fr": "La fortune sourit aux audacieux",
+      "en": "Fortune Favors the Bold",
+      "es": "La Fortuna Sonríe a los Audaces",
+      "pt": "A sorte sorri para os audaciosos"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5466,
-    "description": "With this passive activated, the Ecaflip will regenerate Wakfu points when badly injured.",
+    "description": {
+      "fr": "Ce passif permet à l'Ecaflip de régénérer des Points de Wakfu lorsqu'il est gravement blessé.",
+      "en": "With this passive activated, the Ecaflip will regenerate Wakfu points when badly injured.",
+      "es": "Con este pasivo, el zurcarák puede regenerarse puntos de Wakfu cuando está gravemente herido.",
+      "pt": "Este passivo permite que o Ecaflip regenere Pontos de Wakfu quando estiver gravemente ferido."
+    },
     "effectIds": [
       367856
     ],
@@ -2444,11 +3434,21 @@
   },
   {
     "spellId": 7957,
-    "name": "Pile, je gagne",
+    "name": {
+      "fr": "Pile, je gagne",
+      "en": "Heads, I win",
+      "es": "Cruz, Gano",
+      "pt": "Coroa, Eu Ganho"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5251,
-    "description": "This passive boosts the Ecaflip's natural resistance and survival abilities. They regenerate and gain resistance bonuses when they play a card with 100 Lucky Day. In exchange, the Ecaflip loses all their dodge.",
+    "description": {
+      "fr": "Ce passif renforce le talent de l'Ecaflip à survivre et résister. Il se régénère et gagne des bonus de résistance lorsqu'il lance une carte avec 100 de Veine. En revanche, l'Ecaflip perd toute son esquive.",
+      "en": "This passive boosts the Ecaflip's natural resistance and survival abilities. They regenerate and gain resistance bonuses when they play a card with 100 Lucky Day. In exchange, the Ecaflip loses all their dodge.",
+      "es": "Este pasivo refuerza el talento del zurcarák para sobrevivir y resistir. Se regenera y gana bonus de resistencia cuando lanza una carta con 100 de racha. En cambio, el zurcarák pierde toda su esquiva.",
+      "pt": "Este passivo fortalece o talento do Ecaflip para sobreviver e resistir. Ele se regenera e ganha bônus de resistência quando lança uma carta com 100 de Ventura. Por outro lado, o Ecaflip perde toda a esquiva."
+    },
     "effectIds": [
       359896,
       371530
@@ -2498,11 +3498,21 @@
   },
   {
     "spellId": 7958,
-    "name": "Dés généreux",
+    "name": {
+      "fr": "Dés généreux",
+      "en": "Generous Dice",
+      "es": "Dados Generosos",
+      "pt": "Dados Generosos"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 7935,
-    "description": "This passive transforms Lucky Star, applied when the Ecaflip goes over 100 Critical Hit. Instead of boosting damage, Lucky Star now boosts healing.",
+    "description": {
+      "fr": "Ce passif transforme la Bonne étoile, appliquée lorsque l'Ecaflip dépasse 100 Coup critique. Bonne étoile, au lieu de donner des dommages, donne désormais des soins.",
+      "en": "This passive transforms Lucky Star, applied when the Ecaflip goes over 100 Critical Hit. Instead of boosting damage, Lucky Star now boosts healing.",
+      "es": "Este pasivo transforma la buena estrella, que se aplica cuando el zurcarák pasa los 100 de golpe crítico. En lugar de dar daños, buena Estrella ahora otorga curas.",
+      "pt": "Este passivo transforma a Estrela da Sorte, aplicada quando o Ecaflip passa de 100 de golpe crítico. Estrela da Sorte, em vez de infligir danos, passa a dar cura."
+    },
     "effectIds": [
       359897
     ],
@@ -2517,11 +3527,21 @@
   },
   {
     "spellId": 7959,
-    "name": "Félin suprême",
+    "name": {
+      "fr": "Félin suprême",
+      "en": "Graceful Feline",
+      "es": "Felino Supremo",
+      "pt": "Felino Supremo"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 2059,
-    "description": "This passive changes the Feline Leap spell. It can be cast without line of sight, but it costs more.",
+    "description": {
+      "fr": "Ce passif modifie le sort Bond du félin. Il devient lançable sans ligne de vue et à une plus grande portée, mais coûte plus cher.",
+      "en": "This passive changes the Feline Leap spell. It can be cast without line of sight and at longer range, but it costs more.",
+      "es": "Este pasivo modifica el hechizo Salto del Felino. Se puede lanzar sin línea de visión y a gran distancia, pero cuesta más caro.",
+      "pt": "Este passivo modifica o feitiço Salto do Felino. Ele pode ser lançado sem linha de visão e com maior alcance, mas custa mais caro."
+    },
     "effectIds": [
       359898
     ],
@@ -2536,11 +3556,21 @@
   },
   {
     "spellId": 7960,
-    "name": "Black Jack",
+    "name": {
+      "fr": "Black Jack",
+      "en": "Blackjack",
+      "es": "Black Jack",
+      "pt": "Pôquer"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5101,
-    "description": "Cards in the Ecaflip's hand are added up at the start of the turn. If their total value is equal to or less than 20, the Ecaflip gains Armor. If their value is over 20, the Ecaflip gets a penalty to final Armor received for 1 turn.",
+    "description": {
+      "fr": "Les cartes dans la main de l'Ecaflip sont additionnées au début du tour. Si leur valeur cumulée est inférieure ou égale à 20, alors l'Ecaflip gagne de l'Armure. Mais si leur valeur dépasse 20, l'Ecaflip reçoit un malus d'Armure finale reçue pendant 1 tour.",
+      "en": "Cards in the Ecaflip's hand are added up at the start of the turn. If their total value is equal to or less than 20, the Ecaflip gains Armor. If their value is over 20, the Ecaflip gets a penalty to final Armor received for 1 turn.",
+      "es": "Las cartas en mano del zurcarák se suman al inicio del turno. Si su valor acumulado es inferior o igual a 20, el zurcarák gana armadura. Pero, si su valor sobrepasa 20, el zurcarák recibe un malus de armadura final recibida durante 1 turno.",
+      "pt": "As cartas na mão do Ecaflip são adicionadas no início do turno. Se o valor acumulado for inferior ou igual a 20, o Ecaflip ganhará armadura. Mas se o valor passar de 20, o Ecaflip receberá uma penalidade de armadura final durante 1 turno."
+    },
     "effectIds": [
       359899
     ],
@@ -2557,11 +3587,21 @@
   },
   {
     "spellId": 7961,
-    "name": "Atouts périodiques",
+    "name": {
+      "fr": "Atouts périodiques",
+      "en": "Trump Cards",
+      "es": "Triunfos Periódicos",
+      "pt": "Trunfos Periódicos"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 5461,
-    "description": "This passive allows for some control over cards. On odd turns, the Ecaflip can only draw and play odd-numbered tarot cards, and on even turns, they can only draw and play even-numbered tarot cards.",
+    "description": {
+      "fr": "Ce passif permet d'exercer un certain contrôle sur les cartes. En tour impair, l'Ecaflip ne peut piocher et jouer que des cartes de tarot impaires, tandis qu'en tour pair, il ne peut piocher et jouer que des cartes de tarot paires.",
+      "en": "This passive allows for some control over cards. On odd turns, the Ecaflip can only draw and play odd-numbered tarot cards, and on even turns, they can only draw and play even-numbered tarot cards.",
+      "es": "Este pasivo permite tener cierto control sobre las cartas. En los turnos impares, el zurcarák solo puede robar y jugar cartas de tarot impares, mientras que en los turnos pares solo puede robar y jugar cartas de tarot pares.",
+      "pt": "Este passivo permite exercer um certo controle sobre as cartas. Em turnos ímpares, o Ecaflip só pode comprar e jogar cartas de tarô ímpares, enquanto que nos turnos pares, ele só pode comprar e jogar cartas de tarô pares."
+    },
     "effectIds": [
       360635
     ],
@@ -2576,11 +3616,21 @@
   },
   {
     "spellId": 7999,
-    "name": "Sept fétiche",
+    "name": {
+      "fr": "Sept fétiche",
+      "en": "Lucky Seven",
+      "es": "Siete Fetiche",
+      "pt": "Sete Sagrado"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 866,
-    "description": "Every six tarot cards played with their normal effect (not doubled by Lucky Day), the Ecaflip maximizes their Lucky Day and empties their draw pile.",
+    "description": {
+      "fr": "Toutes les six cartes de tarot jouées avec leur effet normal (pas doublé par la Veine), l'Ecaflip maximise sa Veine et vide sa pioche.",
+      "en": "Every six tarot cards played with their normal effect (not doubled by Lucky Day), the Ecaflip maximizes their Lucky Day and empties their draw pile.",
+      "es": "Cada seis cartas de tarot jugadas con su efecto normal (no duplicado por la racha), el zurcarák maximiza su racha y vacía su bolsillo.",
+      "pt": "A cada seis cartas de tarô jogadas com efeito normal (não aumentado por Ventura), o Ecaflip maximiza a sua Ventura e esvazia o monte de cartas."
+    },
     "effectIds": [
       371343
     ],
@@ -2597,11 +3647,21 @@
   },
   {
     "spellId": 8000,
-    "name": "L'Univers",
+    "name": {
+      "fr": "L'Univers",
+      "en": "Universe",
+      "es": "El Universo",
+      "pt": "O Universo"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 8000,
-    "description": "Cuts Lucky Day gains in half. Unlocks the Universe card when the Ecaflip reaches exactly 42 Lucky Day (the card is not in the draw pile).",
+    "description": {
+      "fr": "Divise les gains de Veine par deux. Débloque la carte L'Univers quand l'Ecaflip atteint exactement 42 de Veine (la carte n'est pas dans la pioche).",
+      "en": "Cuts Lucky Day gains in half. Unlocks the Universe card when the Ecaflip reaches exactly 42 Lucky Day (the card is not in the draw pile).",
+      "es": "Divide las ganancias de Racha a la mitad. Desbloquea la carta El Universo cuando el zurcarák alcanza exactamente 42 de Racha (la carta no está en el mazo).",
+      "pt": "Divide os ganhos de Ventura pela metade Desbloqueia a carta O Universo quando o Ecaflip atinge exatamente 42 de Ventura (a carta não está no monte)."
+    },
     "effectIds": [
       371344
     ],
@@ -2616,11 +3676,21 @@
   },
   {
     "spellId": 8001,
-    "name": "Veine des cartes",
+    "name": {
+      "fr": "Veine des cartes",
+      "en": "Lucky Cards",
+      "es": "Racha de Cartas",
+      "pt": "Ventura das Cartas"
+    },
     "breedId": 6,
     "class": "ECAFLIP",
     "gfxId": 2062,
-    "description": "This passive grants control over Lucky Day based on the cards still in the Ecaflip's hand at the end of their turn.",
+    "description": {
+      "fr": "Ce passif donne un contrôle sur la Veine en fonction des cartes encore dans la main de l'Ecaflip à la fin de son tour.",
+      "en": "This passive grants control over Lucky Day based on the cards still in the Ecaflip's hand at the end of their turn.",
+      "es": "El pasivo da un control en la Racha en función de las cartas aún en la mano del zurcarák al final de su turno.",
+      "pt": "Este passivo dá um controle sobre a Ventura em função das cartas que ainda estiverem na mão do Ecaflip no fim de seu turno."
+    },
     "effectIds": [
       371345
     ],
@@ -2638,11 +3708,21 @@
   },
   {
     "spellId": 628,
-    "name": "Médecin sans barrière",
+    "name": {
+      "fr": "Médecin sans barrière",
+      "en": "Doctor Without Barriers",
+      "es": "Médico sin Barreras",
+      "pt": "Médicos sem Barreira"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 628,
-    "description": "Changes how Propagator works: Performing heals no longer increases it, but inflicting damage does. Propagator is consumed on a single-target heal, and improves the healing performed.",
+    "description": {
+      "fr": "Propagateur change de fonctionnement : Réaliser des soins ne l'augmente plus, mais infliger des dommages oui. Propagateur est consommé sur un soin monocible et améliore ce soin.",
+      "en": "Changes how Propagator works: Performing heals no longer increases it, but inflicting damage does. Propagator is consumed on a single-target heal, and improves the healing performed.",
+      "es": "Propagador cambia de funcionamiento: realizar curas no lo aumenta, pero sí infligir daños. Propagador se consume con una cura de objetivo único, mejorando esa cura.",
+      "pt": "Propagador muda de funcionamento: Realizar curas não o aumenta mais, mas infligir danos, sim. Propagador é consumido em uma cura de alvo único e melhora esta cura."
+    },
     "effectIds": [
       369979
     ],
@@ -2657,11 +3737,21 @@
   },
   {
     "spellId": 644,
-    "name": "Marquage précis",
+    "name": {
+      "fr": "Marquage précis",
+      "en": "Precision Marking",
+      "es": "Marcaje Preciso",
+      "pt": "Marcação Precisa"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 567,
-    "description": "Only one mark of a given type can be active at a time. When this mark is consumed or triggered, the Eniripsa gains 10% of their level in Propagator points.",
+    "description": {
+      "fr": "Une seule marque d'un même type peut être active à la fois. Lorsque cette marque est consommée ou déclenchée, l'Eniripsa gagne 10 % de son niveau en Propagateur.",
+      "en": "Only one mark of a given type can be active at a time. When this mark is consumed or triggered, the Eniripsa gains 10% of their level in Propagator points.",
+      "es": "Solo puede activarse una marca del mismo tipo a la vez. Cuando esta marca se consume o se activa, el aniripsa gana un 10% de su nivel en Propagador.",
+      "pt": "Apenas uma marca de um mesmo tipo pode ser ativada por vez. Quando esta marca é consumida ou acionada, o Eniripsa ganha 10% de seu nível em Propagador."
+    },
     "effectIds": [
       368117,
       371713
@@ -2679,11 +3769,21 @@
   },
   {
     "spellId": 1415,
-    "name": "Soin unique",
+    "name": {
+      "fr": "Soin unique",
+      "en": "Single Heal",
+      "es": "Cura Única",
+      "pt": "Cura Única"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 1415,
-    "description": "Each turn, the first single-target healing spell cast by the Eniripsa is more powerful. In exchange, after the improved healing spell, any additional healing spells cast by the Eniripsa during their turn have reduced effects.",
+    "description": {
+      "fr": "Chaque tour, le premier sort de soin monocible lancé par l'Eniripsa est plus puissant. En revanche, après ce soin amélioré, les prochains soins de l'Eniripsa pendant son tour sont réduits.",
+      "en": "Each turn, the first single-target healing spell cast by the Eniripsa is more powerful. In exchange, after the improved healing spell, any additional healing spells cast by the Eniripsa during their turn have reduced effects.",
+      "es": "En cada turno, el primer hechizo de cura de objetivo único lanzado por el aniripsa es más fuerte. En cambio, después de esa cura mejorada, las siguientes curas del aniripsa se reducen durante su turno.",
+      "pt": "A cada turno, o primeiro feitiço de cura de alvo único lançado pelo Eniripsa é mais forte. Por outro lado, após esta cura melhorada, as próximas curas do Eniripsa durante seu turno são reduzidas."
+    },
     "effectIds": [
       143554
     ],
@@ -2710,11 +3810,21 @@
   },
   {
     "spellId": 1536,
-    "name": "Paroxysme vital",
+    "name": {
+      "fr": "Paroxysme vital",
+      "en": "Vital Climax",
+      "es": "Paroxismo Vital",
+      "pt": "Paroxismo Vital"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 646,
-    "description": "This passive increases the Eniripsa's heals received, but changes the ability activation threshold to require a certain amount of HP.",
+    "description": {
+      "fr": "Ce passif augmente les soins reçus de l'Eniripsa, mais modifie le seuil d'activation des capacités nécessitant d'avoir une certaine quantité de PV.",
+      "en": "This passive increases the Eniripsa's heals received, but changes the ability activation threshold to require a certain amount of HP.",
+      "es": "Este pasivo aumenta las curas recibidas del aniripsa, pero cambia el umbral de activación de las capacidades que requieren cierta cantidad de PdV.",
+      "pt": "Este passivo aumenta as curas recebidas pelo Eniripsa, mas modifica o limite de ativação das habilidades exigindo que se tenha uma certa quantidade de PV."
+    },
     "effectIds": [
       167898
     ],
@@ -2729,11 +3839,21 @@
   },
   {
     "spellId": 1537,
-    "name": "Serial marqueur",
+    "name": {
+      "fr": "Serial marqueur",
+      "en": "Serial Marker",
+      "es": "Marcador de Serie",
+      "pt": "Marcador em Série"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 1537,
-    "description": "Each mark placed on a target heals the fighters around that target. In exchange, Fire spells become harder to cast.",
+    "description": {
+      "fr": "Chaque marque posée sur une cible soigne les combattants autour de cette cible. En contrepartie, les sorts feu deviennent plus complexes à lancer.",
+      "en": "Each mark placed on a target heals the fighters around that target. In exchange, Fire spells become harder to cast.",
+      "es": "Cada marca puesta sobre un objetivo cura a los luchadores que hay alrededor de él. Como contrapartida, los hechizos de fuego son más difíciles de lanzar.",
+      "pt": "Cada marca colocada em um alvo cura os combatentes ao redor deste alvo. Por outro lado, os feitiços de fogo se tornam mais complexos para lançar."
+    },
     "effectIds": [
       368107
     ],
@@ -2760,11 +3880,21 @@
   },
   {
     "spellId": 5451,
-    "name": "Délai",
+    "name": {
+      "fr": "Délai",
+      "en": "Delay",
+      "es": "Retraso",
+      "pt": "Intervalo"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5451,
-    "description": "This passive delays half of the healing that the Eniripsa performs on their targets.",
+    "description": {
+      "fr": "Ce passif délaie la moitié des soins que l'Eniripsa réalise sur ses cibles.",
+      "en": "This passive delays half of the healing that the Eniripsa performs on their targets.",
+      "es": "Este pasivo retrasa la mitad de las curas que el aniripsa efectúa sobre sus objetivos.",
+      "pt": "Este passivo dissolve a metade das curas que o Eniripsa realiza em seus alvos."
+    },
     "effectIds": [
       369980
     ],
@@ -2781,11 +3911,21 @@
   },
   {
     "spellId": 5453,
-    "name": "Tous pour moi",
+    "name": {
+      "fr": "Tous pour moi",
+      "en": "All for Me",
+      "es": "Todos para Mí",
+      "pt": "Todos por Mim"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5453,
-    "description": "The Eniripsa's HP increase significantly. In exchange, the Coney spell can only be cast on adjacent targets.",
+    "description": {
+      "fr": "Les PV de l'Eniripsa augmentent substantiellement. En revanche, le sort Lapino ne peut être lancé qu'au contact.",
+      "en": "The Eniripsa's HP increase significantly. In exchange, the Coney spell can only be cast on adjacent targets.",
+      "es": "Los PdV del aniripsa aumentan sustancialmente. Como contrapartida, el hechizo Cunejo solo puede lanzarse en contacto.",
+      "pt": "Os PV do Eniripsa aumentam substancialmente. Por outro lado, o feitiço Toelho só pode ser lançado em contato."
+    },
     "effectIds": [
       368102
     ],
@@ -2802,11 +3942,21 @@
   },
   {
     "spellId": 5454,
-    "name": "Ponction",
+    "name": {
+      "fr": "Ponction",
+      "en": "Puncture",
+      "es": "Punción",
+      "pt": "Punção"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5454,
-    "description": "When the Eniripsa has 80% or more of their maximum HP, their heals performed are increased. However, they also take damage equivalent to 10% of the healing they perform.",
+    "description": {
+      "fr": "Lorsque l'Eniripsa possède une quantité de PV supérieure ou égale à 80 % de son maximum de PV, ses soins réalisés augmentent. Cependant, il subit 10 % des soins qu'il réalise.",
+      "en": "When the Eniripsa has 80% or more of their maximum HP, their heals performed are increased. However, they also take damage equivalent to 10% of the healing they perform.",
+      "es": "Cuando el aniripsa tiene una cantidad de PdV superior o igual al 80% de su máximo de PdV, sus curas realizadas aumentan. Sin embargo, sufre un 10% de las curas que realiza.",
+      "pt": "Quando o Eniripsa possui uma quantidade de PV superior ou igual a 80% de seu máximo de PV, as curas realizadas aumentam. Porém, ele sofre 10% das curas que realiza."
+    },
     "effectIds": [
       378748,
       368147,
@@ -2836,11 +3986,21 @@
   },
   {
     "spellId": 5455,
-    "name": "Nature morte",
+    "name": {
+      "fr": "Nature morte",
+      "en": "Still Life",
+      "es": "Naturaleza Muerta",
+      "pt": "Natureza Morta"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 1420,
-    "description": "When the Coney dies, a glyph appears on its position. In exchange, the Coney is more expensive.",
+    "description": {
+      "fr": "Lorsque le Lapino meurt, un glyphe apparaît sur sa position. En contrepartie, le Lapino coûte plus cher.",
+      "en": "When the Coney dies, a glyph appears on its position. In exchange, the Coney is more expensive.",
+      "es": "Cuando el cunejo muere, aparece un glifo en su posición. Como contrapartida, el cunejo es más caro.",
+      "pt": "Quando o Toelho morre, um glifo aparece em sua posição. Por outro lado, o Toelho custa mais caro."
+    },
     "effectIds": [
       168401
     ],
@@ -2855,11 +4015,21 @@
   },
   {
     "spellId": 5463,
-    "name": "Vampiripsa",
+    "name": {
+      "fr": "Vampiripsa",
+      "en": "Vampiripsa",
+      "es": "Vampiripsa",
+      "pt": "Vampiripsa"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5463,
-    "description": "This passive changes how Propagator works. Damage inflicted is lower, but the Eniripsa absorbs half of the damage inflicted via Propagator.",
+    "description": {
+      "fr": "Ce passif modifie la façon dont Propagateur fonctionne. Les dommages infligés sont moins élevés, cependant, l'Eniripsa absorbe la moitié des dommages infligés par le biais de Propagateur.",
+      "en": "This passive changes how Propagator works. Damage inflicted is lower, but the Eniripsa absorbs half of the damage inflicted via Propagator.",
+      "es": "Este pasivo cambia el funcionamiento de Propagador. Los daños infligidos son más bajos, pero el aniripsa absorbe la mitad de los daños infligidos mediante Propagador.",
+      "pt": "Este passivo modifica o modo como Propagador funciona. Os danos infligidos são menos elevados, no entanto, o Eniripsa absorve a metade dos danos infligidos por meio de Propagador."
+    },
     "effectIds": [
       368130
     ],
@@ -2874,11 +4044,21 @@
   },
   {
     "spellId": 7987,
-    "name": "Radiance",
+    "name": {
+      "fr": "Radiance",
+      "en": "Radiance",
+      "es": "Resplandor",
+      "pt": "Esplendor"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 7987,
-    "description": "When the Eniripsa ends their turn, they consume their Propagator to heal themself and their nearby allies.",
+    "description": {
+      "fr": "Lorsque l'Eniripsa termine son tour, il consomme son Propagateur pour se soigner lui ainsi que ses alliés à proximité.",
+      "en": "When the Eniripsa ends their turn, they consume their Propagator to heal themself and their nearby allies.",
+      "es": "Cuando el aniripsa termina su turno, consume su Propagador para curarse a sí mismo y a sus aliados cercanos.",
+      "pt": "Quando o Eniripsa termina seu turno, ele consome seu Propagador para curar a si mesmo e os aliados próximos."
+    },
     "effectIds": [
       368131
     ],
@@ -2893,11 +4073,21 @@
   },
   {
     "spellId": 7990,
-    "name": "Présence",
+    "name": {
+      "fr": "Présence",
+      "en": "Presence",
+      "es": "Presencia",
+      "pt": "Presença"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 7330,
-    "description": "At end of turn, if the Eniripsa is isolated, they gain mobility for the next turn, but lose their Propagator. Conversely, if there are one or more fighters near the Eniripsa, the Eniripsa gains Propagator, but loses Range on the next turn.",
+    "description": {
+      "fr": "En fin de tour, si l'Eniripsa est isolé, il gagne en mobilité pour le prochain tour, mais perd son Propagateur. Si, en revanche, il y a un ou plusieurs combattant(s) à proximité de l'Eniripsa, il gagne en Propagateur, mais perd de la Portée au prochain tour.",
+      "en": "At end of turn, if the Eniripsa is isolated, they gain mobility for the next turn, but lose their Propagator. Conversely, if there are one or more fighters near the Eniripsa, the Eniripsa gains Propagator, but loses Range on the next turn.",
+      "es": "Al final del turno, si el aniripsa está solo, gana movilidad para el siguiente turno, pero pierde Propagador. En cambio, si hay uno o varios luchadores cerca de él, gana Propagador y pierde alcance en el siguiente turno.",
+      "pt": "No fim do turno, se o Eniripsa estiver isolado, ele ganha em mobilidade no turno seguinte, mas perde seu Propagador. Porém, se tiver um ou vários combatentes perto do Eniripsa, ele ganha em Propagador, mas perde alcance no turno seguinte."
+    },
     "effectIds": [
       371754
     ],
@@ -2937,11 +4127,21 @@
   },
   {
     "spellId": 7991,
-    "name": "Super Lapino II",
+    "name": {
+      "fr": "Super Lapino II",
+      "en": "Super Coney II",
+      "es": "Súper Cunejo II",
+      "pt": "Supertoelho II"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 7344,
-    "description": "The Eniripsa now immediately summons the Super Coney, instead of waiting a turn. In exchange, the Coney spell now has a two-turn cooldown, and the Super Coney dies at the end of its turn.",
+    "description": {
+      "fr": "L'Eniripsa invoque désormais immédiatement le Super Lapino, au lieu de devoir attendre un tour. En revanche, le sort Lapino possède deux tours de relance et le Super Lapino meurt à la fin de son tour.",
+      "en": "The Eniripsa now immediately summons the Super Coney, instead of waiting a turn. In exchange, the Coney spell now has a two-turn cooldown, and the Super Coney dies at the end of its turn.",
+      "es": "El aniripsa invoca inmediatamente al súper cunejo en vez de tener que esperar un turno. Como contrapartida, el hechizo Cunejo tiene dos turnos de intervalo de lanzamiento y el súper cunejo muere al final de su turno.",
+      "pt": "O Eniripsa passa a invocar imediatamente o Supertoelho, em vez de ter que esperar um turno. Por outro lado, o feitiço Toelho possui dois turnos de relançamento e o Supertoelho morre no fim do seu turno."
+    },
     "effectIds": [
       371816
     ],
@@ -2956,11 +4156,21 @@
   },
   {
     "spellId": 7992,
-    "name": "Transgression",
+    "name": {
+      "fr": "Transgression",
+      "en": "Transgression",
+      "es": "Transgresión",
+      "pt": "Transgressão"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5245,
-    "description": "This passive increases the Eniripsa's resistance potential when under the effects of Unnatural Remedies. In exchange, their range decreases while in this mode.",
+    "description": {
+      "fr": "Ce passif augmente le potentiel de résistance de l'Eniripsa sous Contre-nature. En revanche, dans ce mode, sa portée diminue.",
+      "en": "This passive increases the Eniripsa's resistance potential when under the effects of Unnatural Remedies. In exchange, their range decreases while in this mode.",
+      "es": "Este pasivo aumenta el potencial de resistencia del aniripsa bajo Contra Natura. Como contrapartida, en este modo, su alcance disminuye.",
+      "pt": "Este passivo aumenta o potencial de resistência do Eniripsa em Antinatural. Por outro lado, neste modo, seu alcance diminui."
+    },
     "effectIds": [
       371817
     ],
@@ -2975,11 +4185,21 @@
   },
   {
     "spellId": 7993,
-    "name": "Elixir de vent",
+    "name": {
+      "fr": "Elixir de vent",
+      "en": "Wind Elixir",
+      "es": "Elixir de Viento",
+      "pt": "Elixir de vento"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 959,
-    "description": "This passive increases the Eniripsa's Dodge when they accumulate Propagator. In addition, consuming Propagator on a target removes Lock from it. However, the Eniripsa's Lock drops to 0.",
+    "description": {
+      "fr": "Ce passif augmente l'esquive de l'Eniripsa lorsqu'il accumule du Propagateur. En outre, consommer Propagateur sur une cible lui retire du Tacle. En revanche, le tacle de l'Eniripsa tombe à 0.",
+      "en": "This passive increases the Eniripsa's Dodge when they accumulate Propagator. In addition, consuming Propagator on a target removes Lock from it. However, the Eniripsa's Lock drops to 0.",
+      "es": "Este pasivo aumenta la esquiva del aniripsa cuando acumula Propagador. Además, consumir Propagador con un objetivo le retira placaje. En cambio, el placaje del aniripsa baja a 0.",
+      "pt": "Este passivo aumenta a esquiva do Eniripsa quando ele acumula Propagador. Além disso, consumir Propagador em um alvo retira bloqueio dele. Em compensação, o bloqueio do Eniripsa é reduzido a 0."
+    },
     "effectIds": [
       371831
     ],
@@ -3006,11 +4226,21 @@
   },
   {
     "spellId": 7994,
-    "name": "Apprenti alchimiste",
+    "name": {
+      "fr": "Apprenti alchimiste",
+      "en": "Apprentice Alchemist",
+      "es": "Aprendiz Alquimista",
+      "pt": "Aprendiz Alquimista"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 2040,
-    "description": "When Propagator is triggered, the Eniripsa steals 1 MP from the target. In exchange, the Eniripsa's generation of Propagator is cut in half.",
+    "description": {
+      "fr": "Lorsque Propagateur est déclenché, l'Eniripsa vole 1 PM à la cible. En revanche, sa génération de Propagateur est divisée par deux.",
+      "en": "When Propagator is triggered, the Eniripsa steals 1 MP from the target. In exchange, the Eniripsa's generation of Propagator is cut in half.",
+      "es": "Cuando Propagador se activa, el aniripsa roba 1 PM al objetivo. Como contrapartida, su generación de Propagador se reduce a la mitad.",
+      "pt": "Quando Propagador é acionado, o Eniripsa rouba 1 PM do alvo. Por outro lado, sua geração de Propagador é dividida por dois."
+    },
     "effectIds": [
       371838
     ],
@@ -3025,11 +4255,21 @@
   },
   {
     "spellId": 7995,
-    "name": "Secret de fabrication",
+    "name": {
+      "fr": "Secret de fabrication",
+      "en": "Production Secret",
+      "es": "Secreto de Producción",
+      "pt": "Segredo de Fabricação"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 877,
-    "description": "Propagator now applies its effects for a longer time: it lasts two turns.",
+    "description": {
+      "fr": "Propagateur applique désormais son effet sur la durée : il dure deux tours.",
+      "en": "Propagator now applies its effects for a longer time: it lasts two turns.",
+      "es": "Propagador aplica su efecto en el tiempo: dura dos turnos.",
+      "pt": "Propagador passa a aplicar seu efeito ao longo do tempo: ele dura dois turnos."
+    },
     "effectIds": [
       371890
     ],
@@ -3044,11 +4284,21 @@
   },
   {
     "spellId": 7996,
-    "name": "Marque anbareul",
+    "name": {
+      "fr": "Marque anbareul",
+      "en": "Anbarul Mark",
+      "es": "Marca Anbareul",
+      "pt": "Marca Anbareul"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5101,
-    "description": "Repulsion immediately triggers marks, but does not push the marked targets.",
+    "description": {
+      "fr": "Répulsion déclenche immédiatement les marques, mais ne pousse plus les cibles marquées.",
+      "en": "Repulsion immediately triggers marks, but does not push the marked targets.",
+      "es": "Repulsión activa inmediatamente las marcas, pero no empuja a los objetivos marcados.",
+      "pt": "Repulsão aciona imediatamente as marcas, mas não afasta mais os alvos marcados."
+    },
     "effectIds": [
       371972
     ],
@@ -3063,11 +4313,21 @@
   },
   {
     "spellId": 7997,
-    "name": "Paradoxe Contre-naturel",
+    "name": {
+      "fr": "Paradoxe Contre-naturel",
+      "en": "Unnatural Paradox",
+      "es": "Paradoja Contra Natura",
+      "pt": "Paradoxo Antinatural"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 5055,
-    "description": "Heals performed in normal mode increase the Propagator level twice as much, but in exchange, heals performed with Unnatural Remedies no longer increase the Propagator level.",
+    "description": {
+      "fr": "Les soins réalisés en mode normal augmentent 2 fois plus le niveau de Propagateur, en revanche, les soins réalisés sous Contre-nature n'augmentent plus le niveau de Propagateur.",
+      "en": "Heals performed in normal mode increase the Propagator level twice as much, but in exchange, heals performed with Unnatural Remedies no longer increase the Propagator level.",
+      "es": "Las curas realizadas en modo normal aumentan al doble el nivel de Propagador. Como contrapartida, las curas realizadas en Contra Natura no aumentan el nivel de Propagador.",
+      "pt": "As curas realizadas no modo normal aumentam duas vezes mais o nível de Propagador. Porém, as curas realizadas com Antinatural não aumentam mais o nível de Propagador."
+    },
     "effectIds": [
       371928
     ],
@@ -3082,11 +4342,21 @@
   },
   {
     "spellId": 7998,
-    "name": "Ambivalence",
+    "name": {
+      "fr": "Ambivalence",
+      "en": "Ambivalence",
+      "es": "Ambivalencia",
+      "pt": "Ambivalência"
+    },
     "breedId": 7,
     "class": "ENIRIPSA",
     "gfxId": 525,
-    "description": "Unnatural Remedies can now be cast on a target other than the Eniripsa, triggering different effects.",
+    "description": {
+      "fr": "Contre-nature peut désormais être lancé sur une autre cible que l'Eniripsa pour déclencher différents effets.",
+      "en": "Unnatural Remedies can now be cast on a target other than the Eniripsa, triggering different effects.",
+      "es": "Contra Natura ahora puede lanzarse sobre un objetivo diferente al aniripsa para activar efectos distintos.",
+      "pt": "Antinatural passa a poder ser lançado em outro alvo além do Eniripsa para acionar efeitos diferentes."
+    },
     "effectIds": [
       371983
     ],
@@ -3101,11 +4371,21 @@
   },
   {
     "spellId": 4795,
-    "name": "Virilité",
+    "name": {
+      "fr": "Virilité",
+      "en": "Virility",
+      "es": "Virilidad",
+      "pt": "Virilidade"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 525,
-    "description": "The Iop has more health points, but they can no longer use the Jump spell without line of sight (behind obstacles).",
+    "description": {
+      "fr": "Le Iop possède plus de points de vie, mais en contrepartie il ne peut plus utiliser le sort Bond sans ligne de vue (derrière les obstacles).",
+      "en": "The Iop has more health points, but they can no longer use the Jump spell without line of sight (behind obstacles).",
+      "es": "El yopuka cuenta con más puntos de vida, pero ya no puede utilizar el hechizo Salto sin línea de visión (detrás de los obstáculos).",
+      "pt": "O Iop tem mais pontos de vida, mas não pode usar o feitiço Salto sem linha de visão (atrás de obstáculos)."
+    },
     "effectIds": [
       149539,
       159084
@@ -3124,11 +4404,21 @@
   },
   {
     "spellId": 4796,
-    "name": "Compulsion",
+    "name": {
+      "fr": "Compulsion",
+      "en": "Compulsion",
+      "es": "Compulsión",
+      "pt": "Compulsão"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 521,
-    "description": "The Iop gains a level of Wrath at the start of each turn. However, they lose Wrath at the end of each turn.",
+    "description": {
+      "fr": "Le Iop gagne un niveau de Courroux à chaque début de tour. En revanche, il perd Courroux à chaque fin de tour.",
+      "en": "The Iop gains a level of Wrath at the start of each turn. However, they lose Wrath at the end of each turn.",
+      "es": "El yopuka gana un nivel de Furia al principio de cada turno. En contrapartida, pierde Furia al final de cada turno.",
+      "pt": "O Iop ganha um nível de Fúria a cada início de turno. Por outro lado, perde Fúria a cada fim de turno."
+    },
     "effectIds": [
       398154
     ],
@@ -3158,11 +4448,21 @@
   },
   {
     "spellId": 4797,
-    "name": "Autorité",
+    "name": {
+      "fr": "Autorité",
+      "en": "Authority",
+      "es": "Autoridad",
+      "pt": "Autoridade"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 523,
-    "description": "The Iop gains the ability to attract or repel targets by attacking them from the front or from behind.",
+    "description": {
+      "fr": "Le Iop devient capable d'attirer ou de repousser ses cibles, en les attaquant de face ou de dos.",
+      "en": "The Iop gains the ability to attract or repel targets by attacking them from the front or from behind.",
+      "es": "El yopuka se vuelve capaz de atraer o de repeler a sus objetivos atacándolos de frente o por la espalda.",
+      "pt": "O Iop passa a poder atrair ou empurrar os alvos ao atacá-los pela frente ou por trás."
+    },
     "effectIds": [
       398141
     ],
@@ -3177,11 +4477,21 @@
   },
   {
     "spellId": 4798,
-    "name": "Duelliste",
+    "name": {
+      "fr": "Duelliste",
+      "en": "Duelist",
+      "es": "Duelista",
+      "pt": "Duelista"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 522,
-    "description": "If the Iop ends their turn facing an enemy, both of them gain a large amount of resistance for 1 turn.",
+    "description": {
+      "fr": "Si le Iop finit son tour face à un ennemi, les deux gagnent un gros montant de résistance pour 1 tour.",
+      "en": "If the Iop ends their turn facing an enemy, both of them gain a large amount of resistance for 1 turn.",
+      "es": "Si el yopuka termina su turno frente a un enemigo, ambos ganan una gran cantidad de resistencia durante 1 turno.",
+      "pt": "Se o Iop terminar o turno dele diante de um inimigo, os dois ganham uma grande quantidade de resistência por 1 turno."
+    },
     "effectIds": [
       398184
     ],
@@ -3198,11 +4508,21 @@
   },
   {
     "spellId": 4799,
-    "name": "Roi de la Colline",
+    "name": {
+      "fr": "Roi de la Colline",
+      "en": "King of the Hill",
+      "es": "Rey de la Colina",
+      "pt": "Rei da Colina"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 1399,
-    "description": "The Iop gains a large amount of Lock and Flaming if they end their turn on their standard. However, they lose all their Lock if they don't end it on their standard.",
+    "description": {
+      "fr": "Le Iop gagne un gros montant de Tacle et d'Enflammé s'il finit son tour sur son Etendard. En revanche, il perd tout son Tacle s'il ne finit pas sur son Etendard.",
+      "en": "The Iop gains a large amount of Lock and Flaming if they end their turn on their standard. However, they lose all their Lock if they don't end it on their standard.",
+      "es": "El yopuka gana una gran cantidad de placaje y de Ardiente si termina su turno sobre su estandarte. Por el contrario, pierde todo su placaje si no termina sobre su estandarte.",
+      "pt": "O Iop ganha uma grande quantidade de bloqueio e de Flamejante ao terminar o turno no Estandarte. Em contrapartida, perde todo seu bloqueio se não terminar no Estandarte."
+    },
     "effectIds": [
       398265
     ],
@@ -3242,11 +4562,21 @@
   },
   {
     "spellId": 5100,
-    "name": "Bravoure",
+    "name": {
+      "fr": "Bravoure",
+      "en": "Bravery",
+      "es": "Valentía",
+      "pt": "Bravura"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5100,
-    "description": "The Iop gains Armor at end of turn based on their Power level. However, the Iop has to finish near their enemies at end of turn to gain Power.",
+    "description": {
+      "fr": "Le Iop gagne de l'Armure en fin de tour en fonction de son niveau de puissance. Par contre, le Iop doit forcément terminer à proximité de ses ennemis en fin de tour pour gagner de la Puissance.",
+      "en": "The Iop gains Armor at end of turn based on their Power level. However, the Iop has to finish near their enemies at end of turn to gain Power.",
+      "es": "El yopuka gana armadura al final del turno en función de su nivel de potencia. En cambio, el yopuka debe terminar su turno obligatoriamente cerca de sus enemigos para ganar potencia.",
+      "pt": "O Iop ganha armadura no fim do turno em função de seu nível de potência. Por outro lado, o Iop deve sempre terminar o turno perto dos inimigos para ganhar potência."
+    },
     "effectIds": [
       398146
     ],
@@ -3261,11 +4591,21 @@
   },
   {
     "spellId": 5101,
-    "name": "Précipitation",
+    "name": {
+      "fr": "Précipitation",
+      "en": "Precipitation",
+      "es": "Precipitación",
+      "pt": "Precipitação"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5101,
-    "description": "The Iop gains 1 MP every time they use one of their spells to move, but they also lose resistances for 1 turn.",
+    "description": {
+      "fr": "Le Iop gagne un Point de mouvement à chaque fois qu'il se déplace à l'aide de l'un de ses sorts, mais il perd également des résistances pour 1 tour.",
+      "en": "The Iop gains 1 MP every time they use one of their spells to move, but they also lose resistances for 1 turn.",
+      "es": "El yopuka gana un punto de movimiento cada vez que se desplaza con ayuda de uno de sus hechizos, pero también pierde resistencias durante 1 turno.",
+      "pt": "O Iop ganha um ponto de movimento toda vez que se desloca com um de seus feitiços, mas também perde resistências por 1 turno."
+    },
     "effectIds": [
       398183
     ],
@@ -3292,11 +4632,21 @@
   },
   {
     "spellId": 5102,
-    "name": "Ralliement",
+    "name": {
+      "fr": "Ralliement",
+      "en": "Rallying",
+      "es": "Agrupación",
+      "pt": "Aglomeração"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 7186,
-    "description": "When the Iop summons their standard, nearby targets are drawn to the Iop. The Bravery Standard spell loses 1 Range.",
+    "description": {
+      "fr": "Lorsque le Iop invoque son Etendard, les cibles à proximité sont attirées vers lui. Le sort Etendard de bravoure perd 1 de portée.",
+      "en": "When the Iop summons their standard, nearby targets are drawn to the Iop. The Bravery Standard spell loses 1 Range.",
+      "es": "Cuando el yopuka invoca su estandarte, los objetivos próximos son atraídos hacia él. El hechizo Estandarte de Valentía pierde 1 de alcance.",
+      "pt": "Quando o Iop invoca seu Estandarte, os alvos próximos são atraídos para ele. O feitiço Estandarte de Bravura perde 1 de alcance."
+    },
     "effectIds": [
       398149
     ],
@@ -3311,11 +4661,21 @@
   },
   {
     "spellId": 5103,
-    "name": "Mini-Bond",
+    "name": {
+      "fr": "Mini-Bond",
+      "en": "Mini-Jump",
+      "es": "Minisalto",
+      "pt": "Minissalto"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5103,
-    "description": "The Jump spell can be used multiple times in a turn and costs less AP. However, its range is reduced, and it costs 1 WP.",
+    "description": {
+      "fr": "Le sort Bond change : il devient utilisable plusieurs fois par tour et coûte moins cher en PA. Par contre, sa portée est réduite et il coûte 1 PW.",
+      "en": "The Jump spell can be used multiple times in a turn and costs less AP. However, its range is reduced, and it costs 1 WP.",
+      "es": "El hechizo Salto cambia: puede utilizarse varias veces por turno y cuesta menos PA. Sin embargo, su alcance se reduce y cuesta 1 PW.",
+      "pt": "O Salto muda: ele passa a poder ser usado várias vezes por turno e custa menos PA. Em contrapartida, seu alcance é reduzido e ele custa 1 PW."
+    },
     "effectIds": [
       398082
     ],
@@ -3330,11 +4690,21 @@
   },
   {
     "spellId": 5104,
-    "name": "Faille Sismique",
+    "name": {
+      "fr": "Faille Sismique",
+      "en": "Seismic Rift",
+      "es": "Falla Sísmica",
+      "pt": "Falha Sísmica"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5104,
-    "description": "Gutting Gust removes Dodge and gives Lock to the target and the Iop.",
+    "description": {
+      "fr": "Eventrail retire de l'Esquive et donne du Tacle à la cible ainsi qu'au Iop.",
+      "en": "Gutting Gust removes Dodge and gives Lock to the target and the Iop.",
+      "es": "Borrasca retira esquiva y da placaje al objetivo, así como al yopuka.",
+      "pt": "Ventania retira esquiva e concede bloqueio ao alvo e ao Iop."
+    },
     "effectIds": [
       398280
     ],
@@ -3349,11 +4719,21 @@
   },
   {
     "spellId": 8413,
-    "name": "Destin",
+    "name": {
+      "fr": "Destin",
+      "en": "Destiny",
+      "es": "Destino",
+      "pt": "Destino"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 6997,
-    "description": "The standard's aura no longer gives resistance; it becomes a redirection aura: Allies within the aura will redirect some of the damage they suffer to the Iop.",
+    "description": {
+      "fr": "L'aura de l'étendard ne donne plus de résistances mais devient une aura de redirection : les alliés à l'intérieur de l'aura redirigeront une partie des dommages qu'ils subiront vers le Iop.",
+      "en": "The standard's aura no longer gives resistance; it becomes a redirection aura: Allies within the aura will redirect some of the damage they suffer to the Iop.",
+      "es": "El aura del estandarte ya no da resistencias, sino que se convierte en un aura de redirección: los aliados que estén en el aura redirigirán una parte de los daños que sufran hacia el yopuka.",
+      "pt": "A aura do estandarte não concede mais resistências e vira uma aura de redirecionamento: os aliados nela redirecionam uma parte dos danos que sofrem para o Iop."
+    },
     "effectIds": [
       398305
     ],
@@ -3368,11 +4748,21 @@
   },
   {
     "spellId": 8414,
-    "name": "Impétueux",
+    "name": {
+      "fr": "Impétueux",
+      "en": "Impetuous",
+      "es": "Impetuoso",
+      "pt": "Impetuoso"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 7096,
-    "description": "When the Iop uses the Jump spell, its AP cost is refunded. However, the Iop will lose the same amount of AP at the start of their next turn.",
+    "description": {
+      "fr": "Lorsque le Iop utilise le sort Bond, son coût en PA est remboursé. Cependant, le Iop perdra autant de PA au début de son prochain tour.",
+      "en": "When the Iop uses the Jump spell, its AP cost is refunded. However, the Iop will lose the same amount of AP at the start of their next turn.",
+      "es": "Cuando el yopuka utiliza el hechizo Salto, se le devuelve el coste en PA. Sin embargo, el yopuka perderá la misma cantidad de PA al inicio de su próximo turno.",
+      "pt": "Quando o Iop usa o feitiço Salto, seu custo em PA é restituído. No entanto, ele perderá a mesma quantidade de PA no início de seu turno seguinte."
+    },
     "effectIds": [
       398314
     ],
@@ -3389,11 +4779,21 @@
   },
   {
     "spellId": 8415,
-    "name": "Démonstration",
+    "name": {
+      "fr": "Démonstration",
+      "en": "Show Off",
+      "es": "Demostración",
+      "pt": "Demonstração"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5132,
-    "description": "The Iop recovers WP and Preparation at end of turn based on the level of the Wrath state. However, they no longer recover WP instantly with Concentration.",
+    "description": {
+      "fr": "Le Iop regagne des PW et de la Préparation en fin de tour en fonction du niveau de l'état Courroux. En contrepartie, il ne regagne plus ses PW instantanément grâce à la Concentration.",
+      "en": "The Iop recovers WP and Preparation at end of turn based on the level of the Wrath state. However, they no longer recover WP instantly with Concentration.",
+      "es": "El yopuka recupera PW y Preparación al final del turno en función del nivel del estado Furia. En contrapartida, ya no recupera sus PW al momento mediante Concentración.",
+      "pt": "O Iop recupera PW e Preparação no fim do turno em função do nível do estado Fúria. Em contrapartida, não recupera mais os PW instantaneamente com a Concentração."
+    },
     "effectIds": [
       398326
     ],
@@ -3422,11 +4822,21 @@
   },
   {
     "spellId": 8416,
-    "name": "Frappe et court",
+    "name": {
+      "fr": "Frappe et court",
+      "en": "Hit and Run",
+      "es": "Golpea y Corre",
+      "pt": "Bate e Corre"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5352,
-    "description": "The Iop instantly recovers MP after using their Wrath. However, the Wrath is only triggered at a minimum of level 2.",
+    "description": {
+      "fr": "Le Iop regagne des PM instantanément après avoir utilisé son Courroux. Par contre, le Courroux est déclenché seulement s'il est niveau 2 minimum.",
+      "en": "The Iop instantly recovers MP after using their Wrath. However, the Wrath is only triggered at a minimum of level 2.",
+      "es": "El yopuka recupera PM inmediatamente después de utilizar Furia. Sin embargo, Furia se activa solo si es de nivel 2 como mínimo.",
+      "pt": "O Iop recupera PM instantaneamente após usar Fúria. Por outro lado, a Fúria só é ativada a partir do nível 2."
+    },
     "effectIds": [
       398329
     ],
@@ -3441,11 +4851,21 @@
   },
   {
     "spellId": 8417,
-    "name": "Dissipation",
+    "name": {
+      "fr": "Dissipation",
+      "en": "Dissipation",
+      "es": "Disipación",
+      "pt": "Dissipação"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 7105,
-    "description": "The Gutting Gust and Uppercut spells can be cast at longer range. However, the Iop no longer gains Concentration by performing combos.",
+    "description": {
+      "fr": "Les sorts Eventrail et Uppercut peuvent être lancés à une plus grande portée. Par contre, le Iop ne gagne plus de Concentration quand il réalise des combos.",
+      "en": "The Gutting Gust and Uppercut spells can be cast at longer range. However, the Iop no longer gains Concentration by performing combos.",
+      "es": "Los hechizos Borrasca y Uppercut se pueden lanzar a mayor alcance. En cambio, el yopuka ya no gana concentración cuando realiza combos.",
+      "pt": "O feitiços Ventania e Uppercut podem ser lançados de uma distância maior. Em contrapartida, o Iop não ganha mais concentração ao executar combos."
+    },
     "effectIds": [
       398370
     ],
@@ -3460,11 +4880,21 @@
   },
   {
     "spellId": 8418,
-    "name": "Avant-poste",
+    "name": {
+      "fr": "Avant-poste",
+      "en": "Outpost",
+      "es": "Puesto Avanzado",
+      "pt": "Posto Avançado"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 7107,
-    "description": "The Iop can use the Bravery Standard spell without line of sight (through obstacles). However, the Standard is destroyed if the Iop uses it to jump on top of it.",
+    "description": {
+      "fr": "Le Iop peut utiliser le sort Etendard de bravoure sans ligne de vue (à travers les obstacles). En contrepartie, l'Etendard est détruit si le Iop l'utilise pour bondir dessus.",
+      "en": "The Iop can use the Bravery Standard spell without line of sight (through obstacles). However, the Standard is destroyed if the Iop uses it to jump on top of it.",
+      "es": "El yopuka puede utilizar el hechizo Estandarte de Valentía sin línea de visión (a través de los obstáculos). En cambio, el estandarte se destruye si el yopuka lo utiliza para saltar encima.",
+      "pt": "O Iop pode utilizar o feitiço Estandarte de Bravura sem linha de visão (através de obstáculos). Em contrapartida, o Estandarte é destruído se o Iop utilizá-lo para saltar."
+    },
     "effectIds": [
       398378
     ],
@@ -3479,11 +4909,21 @@
   },
   {
     "spellId": 8419,
-    "name": "Fortification",
+    "name": {
+      "fr": "Fortification",
+      "en": "Fortification",
+      "es": "Fortificación",
+      "pt": "Fortificação"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5454,
-    "description": "If the Iop is on their Standard, each successful Block restores some of their HP. Also, if they end on their Standard, half of their Critical Hit is converted to Block until the end of the next turn.",
+    "description": {
+      "fr": "Si le Iop est sur son Etendard, chaque Parade effectuée lui régénère une partie de ses Points de vie manquants. En outre, s'il finit sur son Etendard, la moitié de ses Coup critique est convertie en Parade jusqu'à la fin du tour suivant.",
+      "en": "If the Iop is on their Standard, each successful Block restores some of their HP. Also, if they end on their Standard, half of their Critical Hit is converted to Block until the end of the next turn.",
+      "es": "Si el yopuka está sobre su estandarte, cada anticipación realizada le regenera una parte de los puntos de vida que le falten. Además, si termina sobre su estandarte, la mitad de sus golpes críticos se convierten en anticipación hasta el turno siguiente.",
+      "pt": "Se o Iop estiver em seu Estandarte, cada parada executada regenera uma parte dos pontos de vida que ele perdeu. Por outro lado, se ele terminar em seu Estandarte, metade de seus golpes críticos é convertida em parada até o fim do turno seguinte."
+    },
     "effectIds": [
       398385,
       398775
@@ -3522,11 +4962,21 @@
   },
   {
     "spellId": 8420,
-    "name": "Le Iop de Wazemmes",
+    "name": {
+      "fr": "Le Iop de Wazemmes",
+      "en": "The Iop of Wazemmes",
+      "es": "El Yopuka de Wazemmes",
+      "pt": "O Iop de Wazemmes"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 7111,
-    "description": "Damage inflicted by the Iop up to a range of 3 cells is considered melee damage. However, they receive less Armor.",
+    "description": {
+      "fr": "Les dommages que le Iop effectue jusqu'à 3 cases de distance sont considérés comme des dommages de mêlée. En revanche, il reçoit moins d'Armure.",
+      "en": "Damage inflicted by the Iop up to a range of 3 cells is considered melee damage. However, they receive less Armor.",
+      "es": "Los daños que el yopuka inflige hasta a 3 casillas de distancia se consideran daños de melé. En cambio, recibe menos armadura.",
+      "pt": "Os danos que o Iop inflige a até 3 células de distância são considerados danos em curta distância. Em contrapartida, ele recebe menos armadura."
+    },
     "effectIds": [
       398785,
       398192
@@ -3542,11 +4992,21 @@
   },
   {
     "spellId": 8421,
-    "name": "Conquête",
+    "name": {
+      "fr": "Conquête",
+      "en": "Conquest",
+      "es": "Conquista",
+      "pt": "Conquista"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5102,
-    "description": "When the Iop kills an enemy, they place a conquest glyph on this cell. If the cell is free at end of turn, they summon or move their Standard onto the conquest. If they kill an enemy while a conquest glyph is already present, the new glyph replaces the old one.",
+    "description": {
+      "fr": "Quand le Iop tue un ennemi, il place un glyphe conquête sur cette cellule. À la fin du tour, si la cellule est libre, il invoque ou déplace son Étendard sur la conquête. S'il tue un ennemi alors qu'un glyphe conquête est déjà présent, le nouveau glyphe remplace l'ancien.",
+      "en": "When the Iop kills an enemy, they place a conquest glyph on this cell. If the cell is free at end of turn, they summon or move their Standard onto the conquest. If they kill an enemy while a conquest glyph is already present, the new glyph replaces the old one.",
+      "es": "Cuando el yopuka mata a un enemigo, coloca un glifo de conquista en esta casilla. Al final del turno, si la casilla está libre, invoca o desplaza su estandarte a la conquista. Si mata a un enemigo cuando ya hay un glifo de conquista presente, el nuevo glifo reemplaza al antiguo.",
+      "pt": "Quando o Iop mata um inimigo, ele coloca um glifo de conquista nessa célula. No fim do turno, se a célula estiver vazia, ele invoca ou desloca seu Estandarte para a conquista. Se ele matar um inimigo e já houver um glifo de conquista presente, o novo glifo substituirá o antigo."
+    },
     "effectIds": [
       398748,
       398762
@@ -3564,11 +5024,21 @@
   },
   {
     "spellId": 8422,
-    "name": "Porte-étendard",
+    "name": {
+      "fr": "Porte-étendard",
+      "en": "Standard Bearer",
+      "es": "Portaestandarte",
+      "pt": "Porta-estandarte"
+    },
     "breedId": 8,
     "class": "IOP",
     "gfxId": 5131,
-    "description": "The Iop can use the Bravery Standard on themself to deploy the Bravery Aura around them at end of turn. In doing so, they become stabilized, and the aura's area of effect is larger. However, the Bravery Standard is more fragile.",
+    "description": {
+      "fr": "Le Iop peut utiliser le sort Etendard de bravoure sur lui-même pour déployer l'aura de bravoure autour de lui en fin de tour. Ce faisant, il devient stabilisé et la zone de l'aura est plus grande. En contrepartie, l'Etendard de bravoure est plus fragile.",
+      "en": "The Iop can use the Bravery Standard on themself to deploy the Bravery Aura around them at end of turn. In doing so, they become stabilized, and the aura's area of effect is larger. However, the Bravery Standard is more fragile.",
+      "es": "El yopuka puede utilizar el hechizo Estandarte de Valentía sobre sí mismo para desplegar el aura de valentía a su alrededor al final del turno. Al hacerlo, pasa a estar estabilizado y la zona del aura aumenta. En cambio, el estandarte de valentía es más frágil.",
+      "pt": "O Iop pode utilizar o feitiço Estandarte de Bravura em si mesmo para aplicar a aura de bravura a seu redor em fim de turno. Ao fazer isso, ele fica estabilizado e a zona da aura aumenta. Em contrapartida, o Estandarte de Bravura fica mais frágil."
+    },
     "effectIds": [
       398140
     ],
@@ -3583,11 +5053,21 @@
   },
   {
     "spellId": 6945,
-    "name": "Archer futé",
+    "name": {
+      "fr": "Archer futé",
+      "en": "Devious Archer",
+      "es": "Arquero Astuto",
+      "pt": "Arqueiro Astuto"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 4801,
-    "description": "Each Sharpened Arrowhead that the Cra gains gives them a Luminous Arrow. In exchange, the Luminous Arrow spell will now have non-modifiable range.",
+    "description": {
+      "fr": "Chaque Pointe affûtée que le Crâ gagne lui donne une Flèche lumineuse. En revanche, le sort Flèche lumineuse passe à portée non modifiable.",
+      "en": "Each Sharpened Arrowhead that the Cra gains gives them a Luminous Arrow. In exchange, the Luminous Arrow spell will now have non-modifiable range.",
+      "es": "Cada Flecha Afilada que el ocra gana le da una flecha luminosa. A cambio, el alcance del hechizo Flecha Luminosa es no modificable.",
+      "pt": "Cada Ponta Afiada obtida pelo Cra dá a ele uma Flecha Luminosa. Porém, o feitiço Flecha Luminosa passa a ter alcance inalterável."
+    },
     "effectIds": [
       350805
     ],
@@ -3602,11 +5082,21 @@
   },
   {
     "spellId": 6946,
-    "name": "Éclaireur spécialisé",
+    "name": {
+      "fr": "Éclaireur spécialisé",
+      "en": "Scout Specialty",
+      "es": "Explorador Especializado",
+      "pt": "Explorador Especializado"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 1420,
-    "description": "The Evasive state heals the Cra's missing HP. However, the area required to be Evasive becomes larger.",
+    "description": {
+      "fr": "Insaisissable soigne des PV manquants au Crâ. Cependant, la zone nécessaire pour être Insaisissable devient plus grande.",
+      "en": "The Evasive state heals the Cra's missing HP. However, the area required to be Evasive becomes larger.",
+      "es": "Esquivo cura PdV que le falten al ocra. En cambio, la zona necesaria para estar Esquivo es más grande.",
+      "pt": "Elusivo cura os PV que faltam ao Cra. No entanto, a zona necessária para ficar Elusivo se torna maior."
+    },
     "effectIds": [
       348457
     ],
@@ -3621,11 +5111,21 @@
   },
   {
     "spellId": 6947,
-    "name": "Balises discrètes",
+    "name": {
+      "fr": "Balises discrètes",
+      "en": "Discreet Beacons",
+      "es": "Balizas Discretas",
+      "pt": "Balizas Discretas"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 615,
-    "description": "Cra Beacons no longer block line of sight. When Beagon is cast, targets aligned with the beacon are pushed back.",
+    "description": {
+      "fr": "Les Balises du Crâ ne bloquent plus la ligne de vue. En lançant débalisage, les cibles alignées à la balise sont repoussées.",
+      "en": "Cra Beacons no longer block line of sight. When Beagon is cast, targets aligned with the beacon are pushed back.",
+      "es": "Las balizas del ocra ya no bloquean la línea de visión. Al lanzar Desbalizaje, los objetivos alineados con la baliza son empujados.",
+      "pt": "As balizas do Cra não bloqueiam mais a linha de visão. Ao lançar desbalizagem, os alvos alinhados com a baliza são afastados."
+    },
     "effectIds": [
       348456
     ],
@@ -3640,11 +5140,21 @@
   },
   {
     "spellId": 6948,
-    "name": "Parti pris",
+    "name": {
+      "fr": "Parti pris",
+      "en": "Firm Stance",
+      "es": "Tomar Partido",
+      "pt": "Parcialidade"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 5072,
-    "description": "When the Cra obtains their Sharpened Arrowhead, they convert MP into AP if they are in Precision Shot. If they have not cast Precision Shot, they convert AP to MP instead.",
+    "description": {
+      "fr": "Lorsqu'il obtient sa Pointe affûtée, le Crâ convertit des PM en PA s'il est en Tir précis. S'il n'a pas lancé Tir précis, il convertit des PA en PM à la place.",
+      "en": "When the Cra obtains their Sharpened Arrowhead, they convert MP into AP if they are in Precision Shot. If they have not cast Precision Shot, they convert AP to MP instead.",
+      "es": "Cuando consigue Flecha Afilada, el ocra convierte PM en PA si está en Tiro Preciso. Si no lo está, convierte PA en PM.",
+      "pt": "Quando ele obtém sua Ponta Afiada, o Cra converte PM em PA se estiver sob Tiro Preciso. Se ele não tiver lançado Tiro Preciso, ele converte PA em PM."
+    },
     "effectIds": [
       348234
     ],
@@ -3659,11 +5169,21 @@
   },
   {
     "spellId": 6949,
-    "name": "Distance focale",
+    "name": {
+      "fr": "Distance focale",
+      "en": "Focal Distance",
+      "es": "Distancia Focal",
+      "pt": "Distância Focal"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 7330,
-    "description": "The Cra can naturally cast their elemental spells 2 cells farther. In return, the minimum range of their elemental spells also increases by 2.",
+    "description": {
+      "fr": "Le Crâ peut lancer ses sorts élémentaires 2 cases plus loin naturellement. En échange, la portée minimale de ses sorts élémentaires augmente aussi de 2.",
+      "en": "The Cra can naturally cast their elemental spells 2 cells farther. In return, the minimum range of their elemental spells also increases by 2.",
+      "es": "El ocra puede lanzar hechizos elementales 2 casillas más lejos de forma natural. A cambio, el alcance mínimo de sus hechizos elementales también aumenta en 2.",
+      "pt": "O Cra pode lançar seus feitiços elementares 2 células mais longe, naturalmente. Em troca, o alcance mínimo dos seus feitiços elementares também aumenta em 2."
+    },
     "effectIds": [
       350806
     ],
@@ -3678,11 +5198,21 @@
   },
   {
     "spellId": 6950,
-    "name": "Précision vorace",
+    "name": {
+      "fr": "Précision vorace",
+      "en": "Voracious Precision",
+      "es": "Precisión Voraz",
+      "pt": "Precisão Voraz"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 5122,
-    "description": "When the Cra is affected by Precision Shot, their spells that consume Precision steal 25% of the damage inflicted. However, Precision Shot can only be cast once per turn.",
+    "description": {
+      "fr": "Lorsque le Crâ est sous Tir précis, ses sorts consommant de la Précision volent 25 % des dommages infligés. En échange, Tir précis ne peut se lancer qu'une fois par tour.",
+      "en": "When the Cra is affected by Precision Shot, their spells that consume Precision steal 25% of the damage inflicted. However, Precision Shot can only be cast once per turn.",
+      "es": "Cuando el ocra está bajo Tiro Preciso, sus hechizos que consumen Precisión roban un 25% de los daños infligidos. A cambio, Tiro Preciso solo se puede lanzar una vez por turno.",
+      "pt": "Quando o Cra está sob Tiro Preciso, seus feitiços que consomem precisão roubam 25% dos danos infligidos. Em contrapartida, Tiro Preciso só pode ser lançado uma vez por turno."
+    },
     "effectIds": [
       350828
     ],
@@ -3697,11 +5227,21 @@
   },
   {
     "spellId": 6951,
-    "name": "La voie de l'arc",
+    "name": {
+      "fr": "La voie de l'arc",
+      "en": "The Way of the Bow",
+      "es": "La Senda del Arquero",
+      "pt": "O Caminho do Arco"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 5077,
-    "description": "When the Cra removes MP from a target, they generate Precision and Sharpening. They no longer gain any at end of turn when Evasive.",
+    "description": {
+      "fr": "Lorsque le Crâ effectue des retraits de PM, il génère de la Précision et d'Affûtage. Il n'en gagne plus en fin de tour en étant Insaisissable.",
+      "en": "When the Cra removes MP from a target, they generate Precision and Sharpening. They no longer gain any at end of turn when Evasive.",
+      "es": "Cuando el ocra realiza retiradas de PM, genera precisión y afiladura. Ya no los gana al final del turno en esquivo.",
+      "pt": "Quando o Cra efetua retiradas de PM, ele gera Precisão e Afiação. Ele não ganha mais no fim do turno se estiver Elusivo."
+    },
     "effectIds": [
       351419
     ],
@@ -3719,11 +5259,21 @@
   },
   {
     "spellId": 6952,
-    "name": "Débalisage massif",
+    "name": {
+      "fr": "Débalisage massif",
+      "en": "Massive Beagon",
+      "es": "Desbalizaje Masivo",
+      "pt": "Desbalizagem Massiva"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 615,
-    "description": "The Beagon spell immediately destroys all the Cra's beacons to generate Sharpening and Precision.",
+    "description": {
+      "fr": "Le sort Débalisage détruit maintenant toutes les balises du Crâ pour générer de l'Affûtage et de la Précision.",
+      "en": "The Beagon spell immediately destroys all the Cra's beacons to generate Sharpening and Precision.",
+      "es": "El hechizo Desbalizaje destruye ahora todas las balizas del ocra para generar Afiladura y Precisión.",
+      "pt": "O feitiço Desbalizagem agora destrói todas as balizas do Cra para gerar Afiação e Precisão."
+    },
     "effectIds": [
       348242
     ],
@@ -3738,11 +5288,21 @@
   },
   {
     "spellId": 6953,
-    "name": "Étude balistique",
+    "name": {
+      "fr": "Étude balistique",
+      "en": "Ballistic Analysis",
+      "es": "Estudio Balístico",
+      "pt": "Estudo Balístico"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 620,
-    "description": "Beacons' redirected damage is no longer applied to allies; in addition, allies hit by a Beacon gain 1 Range. However, the Cra can now only summon one beacon in each element.",
+    "description": {
+      "fr": "Les dégâts de redirection des Balises ne sont plus appliqués sur les alliés : en outre, les alliés touchés par une Balise gagnent 1 Portée. En échange, le Crâ ne peut plus invoquer qu'une Balise de chaque élément.",
+      "en": "Beacons' redirected damage is no longer applied to allies; in addition, allies hit by a Beacon gain 1 Range. However, the Cra can now only summon one beacon in each element.",
+      "es": "Los daños de redirección de las balizas ya no se aplican a los aliados. Además, los aliados alcanzados por una baliza ganan 1 AL. En cambio, el ocra solo puede invocar una baliza de cada elemento.",
+      "pt": "Os danos de redirecionamento das balizas não são mais aplicados nos aliados; além disso, os aliados atingidos por uma baliza ganham 1 de alcance. Em troca, o Cra só pode invocar uma baliza de cada elemento."
+    },
     "effectIds": [
       349195
     ],
@@ -3757,11 +5317,21 @@
   },
   {
     "spellId": 6955,
-    "name": "Paradoxe du Crâ",
+    "name": {
+      "fr": "Paradoxe du Crâ",
+      "en": "Cra's Paradox",
+      "es": "Paradoja del Ocra",
+      "pt": "Paradoxo do Cra"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 2076,
-    "description": "To be able to acquire the Evasive bonus, the Cra must have at least one enemy within 3 cells or less.",
+    "description": {
+      "fr": "Pour pouvoir avoir le bonus d'Insaisissable, le Crâ doit avoir au moins un ennemi à 3 cases ou moins.",
+      "en": "To be able to acquire the Evasive bonus, the Cra must have at least one enemy within 3 cells or less.",
+      "es": "Para poder tener el bonus de esquivo, el ocra debe tener al menos un enemigo a 3 casillas o menos.",
+      "pt": "Para poder ter o bônus de Elusivo, o Cra deve ter pelo menos um inimigo a até 3 células de distância."
+    },
     "effectIds": [
       348494
     ],
@@ -3776,11 +5346,21 @@
   },
   {
     "spellId": 6956,
-    "name": "Éclaireur intouchable",
+    "name": {
+      "fr": "Éclaireur intouchable",
+      "en": "Untouchable Scout",
+      "es": "Explorador Intocable",
+      "pt": "Explorador Intocável"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 588,
-    "description": "The Cra gains Force of Will. In return, their Dodge is reduced to 0 at the start of the fight.",
+    "description": {
+      "fr": "Le Crâ gagne de la Volonté. En échange, son Esquive est réduite à 0 en début de combat.",
+      "en": "The Cra gains Force of Will. In return, their Dodge is reduced to 0 at the start of the fight.",
+      "es": "El ocra gana voluntad. A cambio, su esquiva se reduce a 0 al principio del combate.",
+      "pt": "O Cra ganha Vontade. Em troca, sua esquiva é reduzida a 0 no começo do combate."
+    },
     "effectIds": [
       348244,
       348245
@@ -3821,11 +5401,21 @@
   },
   {
     "spellId": 6957,
-    "name": "Instinct du chasseur",
+    "name": {
+      "fr": "Instinct du chasseur",
+      "en": "Hunter's Instinct",
+      "es": "Instinto de Cazador",
+      "pt": "Instinto do Caçador"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 6930,
-    "description": "The Cra's single-target spells have different effects on their Beacons. In exchange, their Beacons must be spaced farther apart when placed.",
+    "description": {
+      "fr": "Les sorts monocibles du Crâ ont des effets différents sur ses Balises. En revanche, ses Balises doivent être davantage espacées lorsqu'elles sont posées.",
+      "en": "The Cra's single-target spells have different effects on their Beacons. In exchange, their Beacons must be spaced farther apart when placed.",
+      "es": "Los hechizos monobjetivo del ocra tienen distintos efectos en sus balizas. A cambio, las balizas deben colocarse más espaciadas.",
+      "pt": "Os feitiços de alvo único do Cra têm efeitos diferentes nas balizas. Porém, suas balizas devem estar mais espaçadas quando são colocadas."
+    },
     "effectIds": [
       350835
     ],
@@ -3840,11 +5430,21 @@
   },
   {
     "spellId": 6958,
-    "name": "Balisage rapproché",
+    "name": {
+      "fr": "Balisage rapproché",
+      "en": "Short-Range Beaconing",
+      "es": "Balizaje Cercano",
+      "pt": "Balizagem Aproximada"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 610,
-    "description": "The Cra can remove their Beacons for free. However, the summoning range of the Beacons can no longer be modified.",
+    "description": {
+      "fr": "Le Crâ peut retirer ses Balises gratuitement. Cependant, la portée d'invocation des Balises ne peut plus être modifiée.",
+      "en": "The Cra can remove their Beacons for free. However, the summoning range of the Beacons can no longer be modified.",
+      "es": "El ocra puede retirar sus balizas gratuitamente. No obstante, no es posible modificar el alcance de invocación de las balizas.",
+      "pt": "O Cra pode retirar suas balizas gratuitamente. No entanto, o alcance de invocação das balizas não pode ser modificado."
+    },
     "effectIds": [
       350824
     ],
@@ -3859,11 +5459,21 @@
   },
   {
     "spellId": 6959,
-    "name": "Tireur solitaire",
+    "name": {
+      "fr": "Tireur solitaire",
+      "en": "Lone Shooter",
+      "es": "Tirador Solitario",
+      "pt": "Atirador Solitário"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 5073,
-    "description": "The Cra can gain bonuses when Evasive reaches level 40 or higher. However, the state also requires that there be no allies around the Cra.",
+    "description": {
+      "fr": "Le Crâ peut gagner des bonus lorsqu'Insaissable atteint le niveau 40 ou plus. Cependant, l'état nécessite aussi de ne pas avoir d'alliés autour de soi.",
+      "en": "The Cra can gain bonuses when Evasive reaches level 40 or higher. However, the state also requires that there be no allies around the Cra.",
+      "es": "El ocra puede ganar bonus cuando esquivo alcanza el nivel 40 o superior. Sin embargo, el estado también requiere que no haya aliados alrededor.",
+      "pt": "O Cra pode ganhar bônus quando Elusivo atinge o nível 40 ou mais. No entanto, o estado também exige que não haja aliados ao seu redor."
+    },
     "effectIds": [
       350823
     ],
@@ -3878,11 +5488,21 @@
   },
   {
     "spellId": 6960,
-    "name": "Esprit affûté",
+    "name": {
+      "fr": "Esprit affûté",
+      "en": "Sharp Mind",
+      "es": "Mente Aguzada",
+      "pt": "Mente Afiada"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 852,
-    "description": "The Cra gains Sharpening when they cast their Precision Shot. However, they can no longer increase their Precision level above 200.",
+    "description": {
+      "fr": "Le Crâ gagne de l'Affûtage en lançant son Tir précis. En échange, il ne peut plus monter son niveau de Précision au-delà de 200.",
+      "en": "The Cra gains Sharpening when they cast their Precision Shot. However, they can no longer increase their Precision level above 200.",
+      "es": "El ocra gana Afiladura al lanzar Tiro Preciso. A cambio, ya no puede subir su nivel de Precisión por encima de 200.",
+      "pt": "O Cra ganha Afiação ao lançar seu Tiro Preciso. Em troca, ele só pode subir seu nível de Precisão até 200."
+    },
     "effectIds": [
       350822
     ],
@@ -3897,11 +5517,21 @@
   },
   {
     "spellId": 6961,
-    "name": "L'art des Balises",
+    "name": {
+      "fr": "L'art des Balises",
+      "en": "The Art of Beacons",
+      "es": "El Arte de las Balizas",
+      "pt": "Arte das Balizas"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 3362,
-    "description": "Beacons can be cast without line of sight but cost 1 WP more.",
+    "description": {
+      "fr": "Les Balises peuvent se lancer sans ligne de vue, mais coûtent 1 PW de plus.",
+      "en": "Beacons can be cast without line of sight but cost 1 WP more.",
+      "es": "Las balizas pueden lanzarse sin línea de visión, pero cuestan 1 PW más.",
+      "pt": "As balizas podem ser lançadas sem linha de visão, mas custam 1 PW a mais."
+    },
     "effectIds": [
       348243
     ],
@@ -3916,11 +5546,21 @@
   },
   {
     "spellId": 6962,
-    "name": "Tir divergent",
+    "name": {
+      "fr": "Tir divergent",
+      "en": "Diverging Fire",
+      "es": "Tiro Divergente",
+      "pt": "Tiro Divergente"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 586,
-    "description": "When the Sharpened Arrowhead is consumed, the caster and the target of the spell suffer an MP removal.",
+    "description": {
+      "fr": "Lorsque la Pointe affûtée est consommée, le lanceur puis la cible du sort subissent un retrait de PM.",
+      "en": "When the Sharpened Arrowhead is consumed, the caster and the target of the spell suffer an MP removal.",
+      "es": "Cuando se consume flecha afilada, el lanzador y el objetivo del hechizo sufren una retirada de PM.",
+      "pt": "Quando a Ponta Afiada é consumida, o lançador e o alvo do feitiço sofrem uma retirada de PM."
+    },
     "effectIds": [
       348490,
       395229
@@ -3938,11 +5578,21 @@
   },
   {
     "spellId": 6963,
-    "name": "Perforation Crâ",
+    "name": {
+      "fr": "Perforation Crâ",
+      "en": "Cra Perforation",
+      "es": "Perforación Ocra",
+      "pt": "Perfuração Cra"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 619,
-    "description": "When the Cra has the Sharpened Arrowhead, their next single-target spell runs through the target and inflicts damage in a straight line. In return, their Sharpened Arrowhead no longer gives them damage inflicted.",
+    "description": {
+      "fr": "Lorsque le Crâ a sa Pointe affûtée, son prochain sort monocible transperce sa cible et fait des dommages en ligne. En échange, sa Pointe affûtée ne lui donne plus de dommages infligés.",
+      "en": "When the Cra has the Sharpened Arrowhead, their next single-target spell runs through the target and inflicts damage in a straight line. In return, their Sharpened Arrowhead no longer gives them damage inflicted.",
+      "es": "Cuando el ocra tiene Flecha Afilada, su próximo hechizo de objetivo único atraviesa al objetivo y causa daños en línea. A cambio, Flecha Afilada deja de darle daños infligidos.",
+      "pt": "Quando o Cra tem sua Ponta Afiada, seu próximo feitiço de alvo único trespassa o alvo e inflige danos em linha. Por outro lado, a Ponta Afiada não lhe concede mais danos infligidos."
+    },
     "effectIds": [
       348487
     ],
@@ -3957,11 +5607,21 @@
   },
   {
     "spellId": 7795,
-    "name": "Pointe protectrice",
+    "name": {
+      "fr": "Pointe protectrice",
+      "en": "Protective Point",
+      "es": "Flecha Protectora",
+      "pt": "Ponta Protetora"
+    },
     "breedId": 9,
     "class": "CRA",
     "gfxId": 6997,
-    "description": "If the Cra ends their turn with Sharpening, that state is consumed to give the Cra elemental resistance for the following turn.",
+    "description": {
+      "fr": "Si le Crâ termine son tour avec de l'Affûtage, celui-ci se consomme pour octroyer au Crâ des résistances élémentaires pour le tour à venir.",
+      "en": "If the Cra ends their turn with Sharpening, that state is consumed to give the Cra elemental resistance for the following turn.",
+      "es": "Si el ocra termina su turno con afiladura, se consume para conceder al ocra resistencias elementales para el siguiente turno.",
+      "pt": "Se o Cra terminar o turno com Afiação, ela é consumida para conceder a ele resistências elementares no próximo turno."
+    },
     "effectIds": [
       348484
     ],
@@ -3988,11 +5648,21 @@
   },
   {
     "spellId": 912,
-    "name": "Sadida Solitaire",
+    "name": {
+      "fr": "Sadida Solitaire",
+      "en": "Lone Sadida",
+      "es": "Sadida Solitario",
+      "pt": "Sadida Solitário"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 912,
-    "description": "The Nettling spell, which allows Dolls to transform into a seed, no longer costs AP. However, the Sadida no longer regains WP when a Doll uses this spell.",
+    "description": {
+      "fr": "Le sort Engrènement des Poupées, qui leur permet de se transformer en graine, ne coute plus de PA. Par contre, le Sadida ne regagne plus de PW lorsqu'une Poupée utilise ce sort.",
+      "en": "The Nettling spell, which allows Dolls to transform into a seed, no longer costs AP. However, the Sadida no longer regains WP when a Doll uses this spell.",
+      "es": "El hechizo Engranaje de las muñecas, con el que se transforman en semilla, ya no cuesta PA. En cambio, el sadida deja de recuperar PW cuando una muñeca utiliza dicho hechizo.",
+      "pt": "O feitiço Germinação das Bonecas, que lhes permitem se transformar em sementes, não custa mais PA. No entanto, o Sadida não recupera mais PW quando uma Boneca usa esse feitiço."
+    },
     "effectIds": [
       379523
     ],
@@ -4007,11 +5677,21 @@
   },
   {
     "spellId": 913,
-    "name": "Garde Feuille",
+    "name": {
+      "fr": "Garde Feuille",
+      "en": "Green Guard",
+      "es": "Guarda Plantas",
+      "pt": "Guarda Verde"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 913,
-    "description": "The Sadida's Trees give bonuses on Armor Received and Heals Received to nearby fighters to help keep them better protected.",
+    "description": {
+      "fr": "Les Arbres du Sadida donnent des bonus d'Armure reçue et de Soins reçus aux combattants à proximité, permettant de mieux les protéger.",
+      "en": "The Sadida's Trees give bonuses on Armor Received and Heals Received to nearby fighters to help keep them better protected.",
+      "es": "Los árboles del sadida dan bonus de armadura recibida y de curas recibidas a los luchadores cercanos, lo que permite protegerlos mejor.",
+      "pt": "As Árvores do Sadida dão bônus de armadura recebida e de curas recebidas aos combatentes próximos, o que permite melhor protegê-los."
+    },
     "effectIds": [
       379532
     ],
@@ -4026,11 +5706,21 @@
   },
   {
     "spellId": 916,
-    "name": "Lien Poupesque",
+    "name": {
+      "fr": "Lien Poupesque",
+      "en": "Doll Link",
+      "es": "Enlace Muñequero",
+      "pt": "Vínculo Bonecal"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 5463,
-    "description": "The Sadida's Dolls gain resistance. However, they pass on some of the damage they suffer to the Sadida.",
+    "description": {
+      "fr": "Les Poupées du Sadida gagnent en résistance. En contrepartie, elles transmettent une partie des dommages qu'elles subissent au Sadida.",
+      "en": "The Sadida's Dolls gain resistance. However, they pass on some of the damage they suffer to the Sadida.",
+      "es": "Las muñecas del sadida ganan resistencia. Como contrapartida, transmiten parte de los daños que sufren al sadida.",
+      "pt": "As Bonecas do Sadida ganham resistência. Em contrapartida, elas transmitem ao Sadida uma parte dos danos que sofrem."
+    },
     "effectIds": [
       379539
     ],
@@ -4045,11 +5735,21 @@
   },
   {
     "spellId": 917,
-    "name": "Don sylvestre",
+    "name": {
+      "fr": "Don sylvestre",
+      "en": "Sylvan Gift",
+      "es": "Don Silvestre",
+      "pt": "Dom Silvestre"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 5055,
-    "description": "When the Sadida removes one of their Trees, the Tree's remaining HP are sent to nearby fighters. However, the Trees have less max HP.",
+    "description": {
+      "fr": "Lorsque le Sadida retire un de ces Arbres, les PV restants de l'Arbre sont transmis aux combattants proches. En revanche, les Arbres possèdent moins de PV max.",
+      "en": "When the Sadida removes one of their Trees, the Tree's remaining HP are sent to nearby fighters. However, the Trees have less max HP.",
+      "es": "Cuando el sadida retira uno de sus árboles, los PdV restantes del árbol se transmiten a los luchadores cercanos. Como contrapartida, los árboles tienen menos PdV máx.",
+      "pt": "Quando o Sadida remove uma dessas Árvores, os PV restantes dela são transmitidos para os combatentes próximos. Por outro lado, as Árvores possuem menos PV máx."
+    },
     "effectIds": [
       379659
     ],
@@ -4064,11 +5764,21 @@
   },
   {
     "spellId": 933,
-    "name": "Exploupée",
+    "name": {
+      "fr": "Exploupée",
+      "en": "Explodoll",
+      "es": "Explomuñeca",
+      "pt": "Exploneca"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 933,
-    "description": "The Sadida's Dolls explode when they die, inflicting damage on enemies and healing allies in a 2-cell circle. However, the Dolls have less max HP.",
+    "description": {
+      "fr": "Les Poupées du Sadida explosent à leur mort, infligeant des dommages aux ennemis et soignant les alliés dans un cercle de taille 2. En contrepartie, elles possèdent moins de PV max.",
+      "en": "The Sadida's Dolls explode when they die, inflicting damage on enemies and healing allies in a 2-cell circle. However, the Dolls have less max HP.",
+      "es": "Las muñecas del sadida explotan al morir, infligiendo daños a los enemigos y curando a los aliados en un círculo de tamaño 2. Como contrapartida, tienen menos PdV máximos.",
+      "pt": "As Bonecas do Sadida explodem ao morrer, infligindo danos aos inimigos e curando os aliados em um círculo de tamanho 2. Em contrapartida, elas possuem menos PM máx."
+    },
     "effectIds": [
       379634
     ],
@@ -4083,11 +5793,21 @@
   },
   {
     "spellId": 4959,
-    "name": "Prière Sadida",
+    "name": {
+      "fr": "Prière Sadida",
+      "en": "Sadida Prayer",
+      "es": "Rezo Sadida",
+      "pt": "Oração Sadida"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 4959,
-    "description": "The Sadida's Trees heal fighters who finish their turn on an adjacent cell.",
+    "description": {
+      "fr": "Les Arbres du Sadida soignent les combattants qui finissent à leur contact.",
+      "en": "The Sadida's Trees heal fighters who finish their turn on an adjacent cell.",
+      "es": "Los árboles del sadida curan a los luchadores que terminan en contacto con ellos.",
+      "pt": "As Árvores do Sadida curam os combatentes que terminam em contato com elas."
+    },
     "effectIds": [
       379630
     ],
@@ -4114,11 +5834,21 @@
   },
   {
     "spellId": 5055,
-    "name": "Terrain infecté",
+    "name": {
+      "fr": "Terrain infecté",
+      "en": "Infected Soil",
+      "es": "Terreno Infectado",
+      "pt": "Terreno Infectado"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 7195,
-    "description": "The Sadida's Trees apply Toxines to enemies in their area of influence. The Sadida can only summon their Trees adjacent to a fighter.",
+    "description": {
+      "fr": "Les Arbres du Sadida appliquent des Toxines aux ennemis dans leur zone d'influence. Le Sadida ne peut invoquer ses Arbres qu'au contact d'un combattant.",
+      "en": "The Sadida's Trees apply Toxines to enemies in their area of influence. The Sadida can only summon their Trees adjacent to a fighter.",
+      "es": "Los árboles del sadida aplican toxinas a los enemigos en su zona de influencia. El sadida solo puede invocar sus árboles en contacto con un luchador.",
+      "pt": "As Árvores do Sadida aplicam Toxinas aos inimigos em sua zona de influência. O Sadida só pode invocar suas Árvores em contato com um combatente."
+    },
     "effectIds": [
       379660
     ],
@@ -4133,11 +5863,21 @@
   },
   {
     "spellId": 5058,
-    "name": "Murmures Sauvages",
+    "name": {
+      "fr": "Murmures Sauvages",
+      "en": "Wild Whispers",
+      "es": "Murmullos Salvajes",
+      "pt": "Murmúrios Selvagens"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 5058,
-    "description": "The Sadida can summon 2 Voodolls, but they are stabilized.",
+    "description": {
+      "fr": "Le Sadida peut invoquer 2 Voodoll, mais celles-ci sont stabilisées.",
+      "en": "The Sadida can summon 2 Voodolls, but they are stabilized.",
+      "es": "El sadida puede invocar 2 vuduls, pero están estabilizadas.",
+      "pt": "O Sadida pode invocar 2 Voodolls, mas elas ficam estabilizadas."
+    },
     "effectIds": [
       379562
     ],
@@ -4152,11 +5892,21 @@
   },
   {
     "spellId": 5234,
-    "name": "Venimeux",
+    "name": {
+      "fr": "Venimeux",
+      "en": "Venomous",
+      "es": "Venenoso",
+      "pt": "Venenoso"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 5234,
-    "description": "The Sadida cancels all MP reductions that they apply, but replaces them with Toxines. Toxines is a poison that inflicts damage at the start of the target's turn and can be maintained every turn.",
+    "description": {
+      "fr": "Le Sadida annule tous les retraits PM qu'il effectue mais les remplace par de la Toxines. Toxines est un poison qui inflige des dommages au début du tour de la cible et qui peut être maintenu tous les tours.",
+      "en": "The Sadida cancels all MP reductions that they apply, but replaces them with Toxines. Toxines is a poison that inflicts damage at the start of the target's turn and can be maintained every turn.",
+      "es": "El sadida cancela todas las retiradas de PM que realiza, pero las sustituye por Toxinas. Toxinas es un veneno que inflige daños al principio del turno del objetivo y que puede mantenerse todos los turnos.",
+      "pt": "O Sadida anula todas as retiradas de PM que ele efetua, mas as substitui por Toxinas. Toxinas é um veneno que inflige danos no início do turno do alvo e pode ser mantido a cada turno."
+    },
     "effectIds": [
       379592
     ],
@@ -4173,11 +5923,21 @@
   },
   {
     "spellId": 7053,
-    "name": "Terrain d'entente",
+    "name": {
+      "fr": "Terrain d'entente",
+      "en": "Common Ground",
+      "es": "Terreno de Entendimiento",
+      "pt": "Terreno de Entendimento"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 6997,
-    "description": "The Sadida's Trees protect adjacent fighters by giving them a resistance bonus. However, their area of influence is reduced.",
+    "description": {
+      "fr": "Les Arbres du Sadida protègent les combattants à leur contact en leur accordant un bonus de résistance. En contrepartie, leur zone d'influence est réduite.",
+      "en": "The Sadida's Trees protect adjacent fighters by giving them a resistance bonus. However, their area of influence is reduced.",
+      "es": "Los árboles del sadida protegen a los luchadores en contacto con ellos dándoles un bonus de resistencia. Como contrapartida, su zona de influencia se reduce.",
+      "pt": "As Árvores do Sadida concedem um bônus de resistência aos combatentes em contato com elas a fim de protegê-los. Em contrapartida, a zona de influência delas é reduzida."
+    },
     "effectIds": [
       379647
     ],
@@ -4192,11 +5952,21 @@
   },
   {
     "spellId": 8149,
-    "name": "Bénédiction Voodoll",
+    "name": {
+      "fr": "Bénédiction Voodoll",
+      "en": "Voodoll Blessing",
+      "es": "Bendición Vudul",
+      "pt": "Bênção Voodoll"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 2324,
-    "description": "The Voodoll can no longer be linked to an enemy, but it gains mobility and range to support the Sadida's other dolls.",
+    "description": {
+      "fr": "La Voodoll ne peut plus être liée à un ennemi, mais elle gagne en mobilité et en portée pour soutenir les autres poupées du Sadida.",
+      "en": "The Voodoll can no longer be linked to an enemy, but it gains mobility and range to support the Sadida's other dolls.",
+      "es": "La vudul ya no puede ligarse a un enemigo, pero gana movilidad y alcance para apoyar a las otras muñecas del sadida.",
+      "pt": "A Voodoll não pode mais ser vinculada a um inimigo, mas ela ganha mobilidade e alcance para dar suporte às outras bonecas do Sadida."
+    },
     "effectIds": [
       379605
     ],
@@ -4211,11 +5981,21 @@
   },
   {
     "spellId": 8150,
-    "name": "Poussée sylvestre",
+    "name": {
+      "fr": "Poussée sylvestre",
+      "en": "Sylvan Shoot",
+      "es": "Empuje Silvestre",
+      "pt": "Empurrão Silvestre"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 2118,
-    "description": "The Sadida instantly summons Trees with the Seed spell. At end of turn, the Sadida summons seeds adjacent to their Trees. However, the Trees no longer restore the Sadida's WP. The Sadida can remove the seeds from the battlefield by using the Seed spell.",
+    "description": {
+      "fr": "Le Sadida invoque instantanément des Arbres avec le sort Graine. En fin de tour, le Sadida invoque des graines au contact de ses Arbres, en revanche les Arbres ne lui font plus regagner de PW. Le Sadida peut retirer les graines du terrain en utilisant le sort Graine.",
+      "en": "The Sadida instantly summons Trees with the Seed spell. At end of turn, the Sadida summons seeds adjacent to their Trees. However, the Trees no longer restore the Sadida's WP. The Sadida can remove the seeds from the battlefield by using the Seed spell.",
+      "es": "El sadida invoca inmediatamente árboles con el hechizo Semilla. Al final del turno, el sadida invoca semillas en contacto con sus árboles. En cambio, los árboles dejan de proporcionarle PW. El sadida puede retirar las semillas del terreno con el hechizo Semilla.",
+      "pt": "O Sadida invoca Árvores instantaneamente com o feitiço Semente. No fim do turno, o Sadida invoca sementes em contato com suas Árvores. No entanto, as Árvores não permitem mais que ele recupere PW. O Sadida pode retirar as sementes do terreno usando o feitiço Semente."
+    },
     "effectIds": [
       379582
     ],
@@ -4232,11 +6012,21 @@
   },
   {
     "spellId": 8151,
-    "name": "Terrain fertile",
+    "name": {
+      "fr": "Terrain fertile",
+      "en": "Fertile Soil",
+      "es": "Terreno Fértil",
+      "pt": "Terreno Fértil"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 5104,
-    "description": "Dolls and Seeds gain 1 additional level of Nettled if they are near one of the Sadida's Trees; otherwise, they do not gain any Nettled.",
+    "description": {
+      "fr": "Les poupées et les graines gagnent 1 niveau d'engrainé supplémentaire si elles sont à proximité d'un arbre du Sadida, sinon elles n'en gagnent pas.",
+      "en": "Dolls and Seeds gain 1 additional level of Nettled if they are near one of the Sadida's Trees; otherwise, they do not gain any Nettled.",
+      "es": "Las muñecas y las semillas ganan 1 nivel de Reacción en Cadena adicional solo si están cerca de un árbol del sadida.",
+      "pt": "As bonecas e as sementes ganham 1 nível de Germinado adicional se elas estiverem perto de uma Árvore do Sadida. Caso contrário, não ganham nada."
+    },
     "effectIds": [
       379566
     ],
@@ -4251,11 +6041,21 @@
   },
   {
     "spellId": 8152,
-    "name": "Croissance accélérée",
+    "name": {
+      "fr": "Croissance accélérée",
+      "en": "Accelerated Growth",
+      "es": "Crecimiento Acelerado",
+      "pt": "Crescimento Acelerado"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 917,
-    "description": "Dolls gain Nettled more quickly. However, they lose all their levels of Nettled if they are transformed into seeds with the Nettling spell.",
+    "description": {
+      "fr": "Les Poupées gagnent de l'engrainé plus rapidement. Par contre, elles perdent tous leurs niveaux d'engrainé si elles se transforment en graine avec le sort Engrènement.",
+      "en": "Dolls gain Nettled more quickly. However, they lose all their levels of Nettled if they are transformed into seeds with the Nettling spell.",
+      "es": "Las muñecas ganan Reacción en Cadena más rápidamente. Pero pierden todos sus niveles de Reacción en Cadena si se transforman en semillas con el hechizo Engranaje.",
+      "pt": "As Bonecas ganham Germinado mais rapidamente. No entanto, elas perdem todos os níveis de Germinado caso se transformem em Semente com o feitiço Germinação."
+    },
     "effectIds": [
       379549
     ],
@@ -4276,11 +6076,21 @@
   },
   {
     "spellId": 8153,
-    "name": "Dévouement poupesque",
+    "name": {
+      "fr": "Dévouement poupesque",
+      "en": "Dollish Devotion",
+      "es": "Devoción Muñequil",
+      "pt": "Devoção Bonecal"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 916,
-    "description": "The Sadida regains WP by sacrificing their dolls with the Seed spell, but the dolls are no longer transformed into seeds.",
+    "description": {
+      "fr": "Le Sadida regagne des PW en sacrifiant ses poupées avec le sort Graine, mais ces dernières ne sont plus transformées en graines.",
+      "en": "The Sadida regains WP by sacrificing their dolls with the Seed spell, but the dolls are no longer transformed into seeds.",
+      "es": "El sadida recupera PW al sacrificar a sus muñecas con el hechizo Semilla, pero ya no se convierten en semillas.",
+      "pt": "O Sadida recupera PW ao sacrificar suas bonecas com o feitiço Semente, mas elas não são mais transformadas em sementes."
+    },
     "effectIds": [
       379609
     ],
@@ -4295,11 +6105,21 @@
   },
   {
     "spellId": 8154,
-    "name": "Mauvaise graine",
+    "name": {
+      "fr": "Mauvaise graine",
+      "en": "Bad Seed",
+      "es": "Mala Semilla",
+      "pt": "Semente do Mal"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 588,
-    "description": "Seeds disappear if a fighter walks on them. If the fighter is an enemy, the enemy loses MP based on the seed's level of Nettled.",
+    "description": {
+      "fr": "Les graines disparaissent si un combattant marche dessus. S'il s'agit d'un ennemi, il perd des PM en fonction du niveau d'Engrainé de la graine.",
+      "en": "Seeds disappear if a fighter walks on them. If the fighter is an enemy, the enemy loses MP based on the seed's level of Nettled.",
+      "es": "Las semillas desaparecen si un luchador las pisa. Si se trata de un enemigo, pierde PM en función del nivel de Reacción en Cadena de la semilla.",
+      "pt": "As sementes desaparecem se um combatente pisar nelas. Se for um inimigo, ele perde PM de acordo com o nível de Germinado da semente."
+    },
     "effectIds": [
       379518
     ],
@@ -4314,11 +6134,21 @@
   },
   {
     "spellId": 8155,
-    "name": "Cycle sylvestre",
+    "name": {
+      "fr": "Cycle sylvestre",
+      "en": "Sylvan Cycle",
+      "es": "Ciclo Silvestre",
+      "pt": "Ciclo Silvestre"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 4300,
-    "description": "Trees summoned by the Sadida gain additional Nettled, but die at the end of the Sadida's next turn.",
+    "description": {
+      "fr": "Les Arbres invoqués par le Sadida gagnent de l'Engrainé supplémentaire, mais meurent au début de son prochain tour.",
+      "en": "Trees summoned by the Sadida gain additional Nettled, but die at the end of the Sadida's next turn.",
+      "es": "Los árboles que invoca el sadida ganan Reacción en Cadena adicional, pero mueren al principio del próximo turno de él.",
+      "pt": "As Árvores invocadas pelo Sadida ganham Germinado adicional, mas morrem no começo de seu próximo turno."
+    },
     "effectIds": [
       379611
     ],
@@ -4333,11 +6163,21 @@
   },
   {
     "spellId": 8156,
-    "name": "Communication végétale",
+    "name": {
+      "fr": "Communication végétale",
+      "en": "Plant Communication",
+      "es": "Comunicación Vegetal",
+      "pt": "Comunicação Vegetal"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 7053,
-    "description": "The Sadida sends their remaining MP to their dolls at the end of the Sadida's turn. However, if the Sadida has no MP left at the end of their turn, their dolls lose all their MP.",
+    "description": {
+      "fr": "Le Sadida transmet ses PM restants à ses poupées à la fin de son tour. Par contre, s'il n'a plus de PM à la fin de son tour, ses poupées perdent tous leurs PM.",
+      "en": "The Sadida sends their remaining MP to their dolls at the end of the Sadida's turn. However, if the Sadida has no MP left at the end of their turn, their dolls lose all their MP.",
+      "es": "El sadida transmite sus PM restantes a sus muñecas al final de su turno. En cambio, si no tiene más PM al final de su turno, sus muñecas pierden todos sus PM.",
+      "pt": "O Sadida transmite seus PM restantes às suas bonecas no fim do turno. No entanto, se ele não tiver mais PM ao final de seu turno, suas bonecas perdem todos os PM."
+    },
     "effectIds": [
       379617
     ],
@@ -4366,11 +6206,21 @@
   },
   {
     "spellId": 8157,
-    "name": "Savoir Sadida",
+    "name": {
+      "fr": "Savoir Sadida",
+      "en": "Knowledge of Dolls",
+      "es": "Conocimiento Sadida",
+      "pt": "Conhecimento Sadida"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 1420,
-    "description": "The Sadida's Seed spell can only be cast on an adjacent cell, but all of their Dolls have more range on their spells.",
+    "description": {
+      "fr": "Le sort Graine du Sadida ne peut se lancer qu'à son contact, mais toutes ses poupées ont plus de portée sur leurs sorts.",
+      "en": "The Sadida's Seed spell can only be cast on an adjacent cell, but all of their Dolls have more range on their spells.",
+      "es": "El hechizo Semilla del sadida solo puede lanzarse en contacto con él, pero todas sus muñecas tienen más alcance con sus hechizos.",
+      "pt": "O feitiço Semente do Sadida só pode ser lançado em contato com ele, mas todas as suas bonecas têm mais alcance em seus feitiços."
+    },
     "effectIds": [
       379633
     ],
@@ -4385,11 +6235,21 @@
   },
   {
     "spellId": 8158,
-    "name": "Chaîne de la nature",
+    "name": {
+      "fr": "Chaîne de la nature",
+      "en": "Great Chain of Being",
+      "es": "Cadena de la Naturaleza",
+      "pt": "Corrente da Natureza"
+    },
     "breedId": 10,
     "class": "SADIDA",
     "gfxId": 7193,
-    "description": "The Sadida gains Force of Will but also loses an MP each time they apply an MP reduction.",
+    "description": {
+      "fr": "Le Sadida gagne en Volonté mais perd un PM également à chaque fois qu'il effectue un retrait PM.",
+      "en": "The Sadida gains Force of Will but also loses an MP each time they apply an MP reduction.",
+      "es": "El sadida gana voluntad, pero pierde 1 PM cada vez que realiza una retirada de PM.",
+      "pt": "O Sadida ganha Vontade, mas também perde 1 PM toda vez que efetua uma retirada de PM."
+    },
     "effectIds": [
       379546,
       379547
@@ -4419,11 +6279,21 @@
   },
   {
     "spellId": 5049,
-    "name": "Traînée de sang",
+    "name": {
+      "fr": "Traînée de sang",
+      "en": "Blood Trail",
+      "es": "Rastro de Sangre",
+      "pt": "Trono de Sangue"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5101,
-    "description": "The Sacrier boosts their Lock and Dodge each time they inflict a flame return on themself. However, the flame returns are greater.",
+    "description": {
+      "fr": "Le Sacrieur augmente son Tacle et son Esquive à chaque fois qu'il s'inflige un retour de flamme. En contrepartie, ces derniers sont plus élevés.",
+      "en": "The Sacrier boosts their Lock and Dodge each time they inflict a flame return on themself. However, the flame returns are greater.",
+      "es": "El sacrógrito aumenta su placaje y su esquiva cada vez que se aplica un Reavivar la Llama. A cambio, estos son cada vez mayores.",
+      "pt": "O Sacrier aumenta seu bloqueio e sua esquiva sempre que inflige a si mesmo um Retorno das Chamas. Em contrapartida, os Retornos das Chamas são mais elevados."
+    },
     "effectIds": [
       353416
     ],
@@ -4461,11 +6331,21 @@
   },
   {
     "spellId": 5050,
-    "name": "Placidité",
+    "name": {
+      "fr": "Placidité",
+      "en": "Placidity",
+      "es": "Placidez",
+      "pt": "Placidez"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5050,
-    "description": "As long as the Sacrier hasn't used MP to move, they heal themself using movement spells.",
+    "description": {
+      "fr": "Tant que le Sacrieur n'a pas utilisé de PM pour se déplacer, il se soigne en utilisant ses sorts de déplacement.",
+      "en": "As long as the Sacrier hasn't used MP to move, they heal themself using movement spells.",
+      "es": "Mientras el sacrógrito no haya utilizado PM para desplazarse, se curará al utilizar sus hechizos de desplazamiento.",
+      "pt": "Enquanto o Sacrier não tiver usado PM para se deslocar, ele pode se curar utilizando seus feitiços de deslocamento."
+    },
     "effectIds": [
       353795,
       353800
@@ -4493,11 +6373,21 @@
   },
   {
     "spellId": 5051,
-    "name": "Sang tatoué",
+    "name": {
+      "fr": "Sang tatoué",
+      "en": "Tattooed Blood",
+      "es": "Sangre Tatuada",
+      "pt": "Sangue Tatuado"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5051,
-    "description": "The Sacrier gains HP but loses Range, focusing on melee combat.",
+    "description": {
+      "fr": "Le Sacrieur gagne en PV mais perd en portée, se concentrant sur le jeu en mêlée.",
+      "en": "The Sacrier gains HP but loses Range, focusing on melee combat.",
+      "es": "El sacrógrito gana PdV, pero pierde AL, para un juego más en melé.",
+      "pt": "O Sacrier ganha PV e perde alcance, concentrando-se no combate a curta distância."
+    },
     "effectIds": [
       316633
     ],
@@ -4514,11 +6404,21 @@
   },
   {
     "spellId": 5052,
-    "name": "Refus de la mort",
+    "name": {
+      "fr": "Refus de la mort",
+      "en": "Clinging to Life",
+      "es": "Rechazo a la Muerte",
+      "pt": "Agarrado à Vida"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 845,
-    "description": "When the Sacrier is mortally wounded, they gain resistance and a large amount of Armor. However, they won't be able to go above 20% max HP for a full turn.",
+    "description": {
+      "fr": "Quand le Sacrieur est fatalement blessé, il gagne des résistances et un grand montant d'Armure. En échange, il ne pourra pas repasser au-dessus de 20 % des PV max pendant 1 tour complet.",
+      "en": "When the Sacrier is mortally wounded, they gain resistance and a large amount of Armor. However, they won't be able to go above 20% max HP for a full turn.",
+      "es": "Cuando el sacrógrito esté fatalmente herido, ganará resistencias y una gran cantidad de armadura. A cambio, no podrá subir del 20% de sus PdV máx. durante 1 turno completo.",
+      "pt": "Quando o Sacrier é ferido mortalmente, ele ganha resistências e uma grande quantidade de armadura. Em contrapartida, ele não pode ficar com mais de 20% dos PV máx. durante um turno inteiro."
+    },
     "effectIds": [
       353207
     ],
@@ -4535,11 +6435,21 @@
   },
   {
     "spellId": 5053,
-    "name": "Pacte de sang",
+    "name": {
+      "fr": "Pacte de sang",
+      "en": "Blood Pact",
+      "es": "Pacto de Sangre",
+      "pt": "Pacto de Sangue"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 877,
-    "description": "The Sacrier's max HP is reduced, but they gain Armor if they drop below 20% max HP and then if they go above 40% max HP afterward.",
+    "description": {
+      "fr": "Le Sacrieur possède moins de PV max mais gagne de l'Armure s'il passe en dessous de 20 % de ses PV max puis s'il repasse ensuite au-dessus de 40 % de ses PV max.",
+      "en": "The Sacrier's max HP is reduced, but they gain Armor if they drop below 20% max HP and then if they go above 40% max HP afterward.",
+      "es": "El sacrógrito posee menos PdV máx., pero gana armadura si baja del 20% de sus PdV máx. y luego sube del 40% de sus PdV máx.",
+      "pt": "O Sacrier possui menos PV máx., mas ganha armadura se ficar com menos de 20% dos PV máx. e, depois, se voltar a ficar com mais de 40% de seus PV máx."
+    },
     "effectIds": [
       353184,
       353190,
@@ -4579,11 +6489,21 @@
   },
   {
     "spellId": 5054,
-    "name": "Transcendance",
+    "name": {
+      "fr": "Transcendance",
+      "en": "Transcendence",
+      "es": "Trascendencia",
+      "pt": "Transcendência"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5194,
-    "description": "In exchange for one WP, the Sacrier can greatly increase their Dodge or Lock using their punishments.",
+    "description": {
+      "fr": "En échange d'un PW, le Sacrieur peut fortement augmenter son Esquive ou son Tacle grâce à ses châtiments.",
+      "en": "In exchange for one WP, the Sacrier can greatly increase their Dodge or Lock using their punishments.",
+      "es": "A cambio de un PW, el sacrógrito puede aumentar considerablemente su esquiva y su placaje mediante sus castigos.",
+      "pt": "Em troca de um PW, o Sacrier pode aumentar bastante sua esquiva ou seu bloqueio graças aos castigos."
+    },
     "effectIds": [
       353352
     ],
@@ -4598,11 +6518,21 @@
   },
   {
     "spellId": 5192,
-    "name": "Mobilité",
+    "name": {
+      "fr": "Mobilité",
+      "en": "Mobility",
+      "es": "Movilidad",
+      "pt": "Mobilidade"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5192,
-    "description": "The Sacrier can move their targets and themself more easily, but it costs their ability to keep opponents next to them.",
+    "description": {
+      "fr": "Le Sacrieur peut déplacer ses cibles et lui-même plus aisément, au détriment de sa capacité à maintenir ses adversaires au contact.",
+      "en": "The Sacrier can move their targets and themself more easily, but it costs their ability to keep opponents next to them.",
+      "es": "El sacrógrito puede desplazar a sus objetivos y a sí mismo más fácilmente, en detrimento de su capacidad de mantener a sus adversarios en contacto.",
+      "pt": "O Sacrier pode deslocar seus alvos e a si mesmo facilmente, em detrimento de sua capacidade de manter seus adversários em contato."
+    },
     "effectIds": [
       353178,
       353824
@@ -4654,11 +6584,21 @@
   },
   {
     "spellId": 5193,
-    "name": "Libation",
+    "name": {
+      "fr": "Libation",
+      "en": "Libation",
+      "es": "Libación",
+      "pt": "Libação"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5193,
-    "description": "The Sacrier loses their natural WP regeneration. However, they gain it by inflicting Flame Returns on themself.",
+    "description": {
+      "fr": "Le Sacrieur perd sa régénération naturelle de PW. En échange, il en gagne en s'infligeant des Retours de flamme.",
+      "en": "The Sacrier loses their natural WP regeneration. However, they gain it by inflicting Flame Returns on themself.",
+      "es": "El sacrógrito pierde su regeneración natural de PW. A cambio, la gana al causarse Reavivar la Llama.",
+      "pt": "O Sacrier perde sua regeneração natural de PW. Em contrapartida, ele ganha PW ao se infligir Retornos das Chamas."
+    },
     "effectIds": [
       353203
     ],
@@ -4675,11 +6615,21 @@
   },
   {
     "spellId": 5194,
-    "name": "Veines de Wakfu",
+    "name": {
+      "fr": "Veines de Wakfu",
+      "en": "Wakfu Veins",
+      "es": "Venas de Wakfu",
+      "pt": "Venturas de Wakfu"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7208,
-    "description": "The Sacrier replaces the WP cost of their movement spells with an AP cost. If the Sacrier uses a spell to move an enemy, the enemy will suffer direct damage. However, if the Sacrier uses a spell to move themself, they suffer a flame return.",
+    "description": {
+      "fr": "Le Sacrieur remplace le coût en PW de ses sorts de déplacement par un coût en PA. S'il déplace un ennemi avec un sort, ce dernier subira des dommages directs. En contrepartie, si le Sacrieur se déplace lui-même avec un sort, il subit un retour de flamme.",
+      "en": "The Sacrier replaces the WP cost of their movement spells with an AP cost. If the Sacrier uses a spell to move an enemy, the enemy will suffer direct damage. However, if the Sacrier uses a spell to move themself, they suffer a flame return.",
+      "es": "El sacrógrito remplaza el coste en PW de sus hechizos de desplazamiento por un coste en PA. Si desplaza a un enemigo con un hechizo, este sufrirá daños directos. A cambio, si el sacrógrito se desplaza a sí mismo con un hechizo, sufre un Reavivar la Llama.",
+      "pt": "O Sacrier substitui o custo em PW dos feitiços de deslocamento por um custo em PA. Se ele desloca um inimigo com um feitiço, o inimigo sofrerá danos diretos. Em contrapartida, se é o Sacrier que se desloca com um feitiço, ele sofre um Retorno das Chamas."
+    },
     "effectIds": [
       353322
     ],
@@ -4761,11 +6711,21 @@
   },
   {
     "spellId": 5195,
-    "name": "Fracasseur",
+    "name": {
+      "fr": "Fracasseur",
+      "en": "Smasher",
+      "es": "Quebrantador",
+      "pt": "Estilhaçador"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5195,
-    "description": "This passive gives the Sacrier more control over their HP. When the Sacrier inflicts damage on a target, they steal some if the target's % of HP is higher than the Sacrier's. If the Sacrier's % of HP is higher than their target's, the Sacrier inflicts a flame return on themself.",
+    "description": {
+      "fr": "Ce passif offre au Sacrieur un meilleur contrôle de ses PV : en infligeant des dommages à une cible, il en vole une partie si elle possède plus de % PV que le Sacrieur. Si ce dernier possède plus de % PV que sa cible, il s'inflige un retour de flamme.",
+      "en": "This passive gives the Sacrier more control over their HP. When the Sacrier inflicts damage on a target, they steal some if the target's % of HP is higher than the Sacrier's. If the Sacrier's % of HP is higher than their target's, the Sacrier inflicts a flame return on themself.",
+      "es": "Este pasivo ofrece al sacrógrito un mejor control de sus PdV: cuando causa daños a un objetivo, roba una parte de estos si el objetivo tiene más % de PdV que el sacrógrito. Si este último tiene más % de PdV que su objetivo, se inflige un Reavivar la Llama.",
+      "pt": "Este passivo dá ao Sacrier um melhor controle de seus PV: ao infligir danos a um alvo, ele rouba uma parte se o alvo tiver mais % de PV que o Sacrier. Se o Sacrier tiver mais % de PV que o alvo, ele inflige a si mesmo um Retorno das Chamas."
+    },
     "effectIds": [
       353572
     ],
@@ -4825,11 +6785,21 @@
   },
   {
     "spellId": 7213,
-    "name": "Circulation sanguine",
+    "name": {
+      "fr": "Circulation sanguine",
+      "en": "Blood Flow",
+      "es": "Circulación Sanguínea",
+      "pt": "Circulação Sanguínea"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7213,
-    "description": "The Sacrier's healing is significantly less reduced by resistance to healing, but the armor the Sacrier receives is reduced.",
+    "description": {
+      "fr": "Les soins du Sacrieur sont considérablement moins réduits par la résistance au soin, mais les armures qu'il reçoit sont réduites.",
+      "en": "The Sacrier's healing is significantly less reduced by resistance to healing, but the armor the Sacrier receives is reduced.",
+      "es": "Las curas del sacrórgito se reducen considerablemente menos por la resistencia a las curas, pero se reducen las armaduras que reciba.",
+      "pt": "A cura do Sacrier é consideravelmente menos reduzida pela resistência à cura, mas as armaduras que ele recebe são reduzidas."
+    },
     "effectIds": [
       353689,
       317019
@@ -4857,11 +6827,21 @@
   },
   {
     "spellId": 7214,
-    "name": "Jeu dangereux",
+    "name": {
+      "fr": "Jeu dangereux",
+      "en": "Dangerous Game",
+      "es": "Juego Peligroso",
+      "pt": "Jogo Perigoso"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7214,
-    "description": "This passive makes it much easier for the Sacrier to get out of a sticky situation when their HP is very low. However, they are harder to heal when their current HP are high.",
+    "description": {
+      "fr": "Ce passif rend beaucoup plus facile la capacité du Sacrieur à s'extirper d'une situation difficile où il possède très peu de PV. En revanche, il ne peut plus être facilement soigné lorsqu'il a des PV courants élevés.",
+      "en": "This passive makes it much easier for the Sacrier to get out of a sticky situation when their HP is very low. However, they are harder to heal when their current HP are high.",
+      "es": "Este pasivo aumenta la capacidad que tiene el sacrógrito para salir de situaciones difíciles en las que tiene muy pocos PdV. A cambio, ya no puede curarse tan fácilmente cuando tiene muchos PdV actuales.",
+      "pt": "Este passivo faz com que o Sacrier consiga sair mais facilmente de uma situação difícil em que ele tenha pouquíssimos PV. Entretanto, ele não poderá mais ser curado com facilidade quando tiver muitos PV."
+    },
     "effectIds": [
       316726
     ],
@@ -4876,11 +6856,21 @@
   },
   {
     "spellId": 7215,
-    "name": "Vision",
+    "name": {
+      "fr": "Vision",
+      "en": "Vision",
+      "es": "Visión",
+      "pt": "Visão"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7215,
-    "description": "This passive increases the range of the Sacrier's movement spells. In exchange, Armor gains are reduced by half if the Sacrier is not adjacent to another fighter.",
+    "description": {
+      "fr": "Ce passif augmente la portée des sorts de déplacement du Sacrieur. En contrepartie, les gains d'Armure sont réduits de moitié si le Sacrieur n'est pas au contact d'un autre combattant.",
+      "en": "This passive increases the range of the Sacrier's movement spells. In exchange, Armor gains are reduced by half if the Sacrier is not adjacent to another fighter.",
+      "es": "Este pasivo aumenta el alcance de los hechizos de desplazamiento del sacrógrito. A cambio, las ganancias de armadura se reducen a la mitad si el sacrógrito no está en contacto con otro luchador.",
+      "pt": "Este passivo aumenta o alcance dos feitiços de deslocamento do Sacrier. Em contrapartida, os ganhos de armadura serão reduzidos pela metade se o Sacrier não estiver em contato com outro combatente."
+    },
     "effectIds": [
       353425
     ],
@@ -4895,11 +6885,21 @@
   },
   {
     "spellId": 7216,
-    "name": "Armure brûlante",
+    "name": {
+      "fr": "Armure brûlante",
+      "en": "Burning Armor",
+      "es": "Armadura Ardiente",
+      "pt": "Armadura Ardente"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7216,
-    "description": "The Sacrier turns their flame returns into Armor. However, if they have Armor left when their turn starts, they suffer it as damage.",
+    "description": {
+      "fr": "Le Sacrieur transforme ses retours de flamme en Armure. En contrepartie, s'il lui reste de l'Armure au début de son tour, il la subit.",
+      "en": "The Sacrier turns their flame returns into Armor. However, if they have Armor left when their turn starts, they suffer it as damage.",
+      "es": "El sacrógrito transforma sus Reavivar la Llama en armadura. A cambio, si al principio de su turno le queda armadura, la sufre.",
+      "pt": "O Sacrier transforma seus Retornos das Chamas em armadura. Em contrapartida, se sobrar armadura no início de seu turno, ele sofre danos equivalentes à quantidade de armadura."
+    },
     "effectIds": [
       353367,
       353371
@@ -4938,11 +6938,21 @@
   },
   {
     "spellId": 7217,
-    "name": "Pacte de Wakfu",
+    "name": {
+      "fr": "Pacte de Wakfu",
+      "en": "Wakfu Pact",
+      "es": "Pacto de Wakfu",
+      "pt": "Pacto de Wakfu"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7207,
-    "description": "The Sacrier gains HP but suffers a flame return each time they use WP.",
+    "description": {
+      "fr": "Le Sacrieur gagne des PV, mais subit un retour de flamme à chaque fois qu'il utilise des PW.",
+      "en": "The Sacrier gains HP but suffers a flame return each time they use WP.",
+      "es": "El sacrógrito gana PdV, pero sufre un Reavivar la Llama cada vez que usa PW.",
+      "pt": "O Sacrier ganha PV, mas sofre um Retorno das Chamas toda vez que usa PW."
+    },
     "effectIds": [
       353411,
       353414
@@ -4972,11 +6982,21 @@
   },
   {
     "spellId": 7218,
-    "name": "Coeur de Sacrieur",
+    "name": {
+      "fr": "Coeur de Sacrieur",
+      "en": "Sacrier's Heart",
+      "es": "Corazón de Sacrógrito",
+      "pt": "Coração de Sacrier"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7218,
-    "description": "Under the influence of Bold Punishment, the Sacrier's melee mastery and distance mastery are added together to increase their damage and versatility, in exchange for their range.",
+    "description": {
+      "fr": "Sous l'influence du Châtiment osé, la maîtrise mêlée et la maîtrise distance du Sacrieur s'ajoutent pour augmenter ses dommages et sa polyvalence en contrepartie de sa portée.",
+      "en": "Under the influence of Bold Punishment, the Sacrier's melee mastery and distance mastery are added together to increase their damage and versatility, in exchange for their range.",
+      "es": "Bajo la influencia de Castigo Osado, el dominio de melé y el dominio de distancia del sacrógrito se unen para aumentar sus daños y su polivalencia, a cambio de su alcance.",
+      "pt": "Sob influência do Castigo Ousado, o domínio de curta distância e o domínio de distância do Sacrier são adicionados para aumentar seus danos e sua polivalência, em detrimento de seu alcance."
+    },
     "effectIds": [
       353437
     ],
@@ -4991,11 +7011,21 @@
   },
   {
     "spellId": 7219,
-    "name": "Mal des transports",
+    "name": {
+      "fr": "Mal des transports",
+      "en": "Motion Sick",
+      "es": "Agita Viajes",
+      "pt": "Enjoo de Movimento"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7219,
-    "description": "Targets moved by the Sacrier lose MP. If the Sacrier uses a spell to move themself, they also lose MP.",
+    "description": {
+      "fr": "Les cibles déplacées par le Sacrieur perdent des PM. Si le Sacrieur se déplace avec un sort, il perd des PM également.",
+      "en": "Targets moved by the Sacrier lose MP. If the Sacrier uses a spell to move themself, they also lose MP.",
+      "es": "Los objetivos desplazados por el sacrógrito pierden PM. Si el sacrógrito se desplaza mediante un hechizo, también pierde PM.",
+      "pt": "Os alvos deslocados pelo Sacrier perdem PM. Se o Sacrier se deslocar com um feitiço, ele também perderá PM."
+    },
     "effectIds": [
       353388
     ],
@@ -5010,11 +7040,21 @@
   },
   {
     "spellId": 7220,
-    "name": "Pilier",
+    "name": {
+      "fr": "Pilier",
+      "en": "Pillar",
+      "es": "Pilar",
+      "pt": "Pilar"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 880,
-    "description": "Makes the Sacrier less mobile but grants HP regeneration capabilities and a resistance bonus when the Sacrier is adjacent to their enemies.",
+    "description": {
+      "fr": "Rend le Sacrieur moins mobile, mais lui confère des capacités de régénérations de PV et un bonus de résistance lorsqu'il est au contact de ses ennemis.",
+      "en": "Makes the Sacrier less mobile but grants HP regeneration capabilities and a resistance bonus when the Sacrier is adjacent to their enemies.",
+      "es": "Vuelve al sacrógrito menos móvil, pero le da capacidades de regeneración de PdV y un bonus de resistencia cuando está cuerpo a cuerpo con sus enemigos.",
+      "pt": "O Sacrier perde em mobilidade, mas ganha regeneração de PV e um bônus de resistência quando está em contato com os inimigos."
+    },
     "effectIds": [
       316750
     ],
@@ -5118,11 +7158,21 @@
   },
   {
     "spellId": 7224,
-    "name": "Immolation",
+    "name": {
+      "fr": "Immolation",
+      "en": "Burning",
+      "es": "Inmolación",
+      "pt": "Imolação"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 7224,
-    "description": "The Sacrier catches fire if they end their turn adjacent to an enemy. If no enemies are adjacent to the Sacrier when they start a turn, the Sacrier suffers a flame return equivalent to Flaming.",
+    "description": {
+      "fr": "Le Sacrieur s'enflamme s'il finit au contact d'un ennemi. Si aucun ennemi n'est à son contact au début de son tour, il subit un retour de flamme équivalent à l'Enflammé.",
+      "en": "The Sacrier catches fire if they end their turn adjacent to an enemy. If no enemies are adjacent to the Sacrier when they start a turn, the Sacrier suffers a flame return equivalent to Flaming.",
+      "es": "El sacrógrito se vuelve Ardiente si termina en contacto con un enemigo. Si ningún enemigo está en contacto con él al principio de su turno, sufre un Reavivar la Llama equivalente al Ardiente.",
+      "pt": "O Sacrier fica flamejante se terminar em contato com um inimigo. Se ele não estiver em contato com nenhum inimigo no início de seu turno, ele sofre um Retorno das Chamas equivalente a Flamejante."
+    },
     "effectIds": [
       353439
     ],
@@ -5140,11 +7190,21 @@
   },
   {
     "spellId": 7830,
-    "name": "Exécuteur",
+    "name": {
+      "fr": "Exécuteur",
+      "en": "Executor",
+      "es": "Ejecutor",
+      "pt": "Carrasco"
+    },
     "breedId": 11,
     "class": "SACRIEUR",
     "gfxId": 5054,
-    "description": "This passive increases the range of the Sacrier's movement spells. In exchange, healing received is reduced by half if the Sacrier is adjacent to another fighter.",
+    "description": {
+      "fr": "Ce passif augmente la portée des sorts de déplacement du Sacrieur. En contrepartie, les soins reçus sont réduits de moitié si le Sacrieur est au contact d'un autre combattant.",
+      "en": "This passive increases the range of the Sacrier's movement spells. In exchange, healing received is reduced by half if the Sacrier is adjacent to another fighter.",
+      "es": "Este pasivo aumenta el alcance de los hechizos de desplazamiento del sacrógrito. A cambio, las curas recibidas se reducen a la mitad si el sacrógrito está en contacto con otro luchador.",
+      "pt": "Este passivo aumenta o alcance dos feitiços de deslocamento do Sacrier. Em contrapartida, as curas recebidas serão reduzidas pela metade se o Sacrier estiver em contato com outro combatente."
+    },
     "effectIds": [
       401711
     ],
@@ -5159,11 +7219,21 @@
   },
   {
     "spellId": 4722,
-    "name": "Cocktail",
+    "name": {
+      "fr": "Cocktail",
+      "en": "Cocktail",
+      "es": "Cóctel",
+      "pt": "Coquetel"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 7987,
-    "description": "The Pandawa's mastery of Cocktail mixology means they can improve healing in exchange for damage. The spells Flaming Burp and Bubble Trouble now heal allies.",
+    "description": {
+      "fr": "Sa maîtrise dans la confection de Cocktails permet au Pandawa d'améliorer ses soins en contre-partie de ses dégâts.\\nLes sorts Souffle Enflammé et Tekilait soignent désormais les alliés.",
+      "en": "The Pandawa's mastery of Cocktail mixology means they can improve healing in exchange for damage.\\nThe spells Flaming Burp and Bubble Trouble now heal allies.",
+      "es": "Su dominio en la elaboración de cócteles permite al pandawa mejorar sus curas en detrimento de sus daños.\\nLos hechizos Escupe Fuegos y Tequileche curarán a los aliados.",
+      "pt": "A maestria do Pandawa para fazer coquetéis torna-o capaz de melhorar a cura em troca de dano.\\nOs feitiços Sopro Flamejante e Tekileite agora curam aliados."
+    },
     "effectIds": [
       178113,
       178114,
@@ -5181,11 +7251,21 @@
   },
   {
     "spellId": 4723,
-    "name": "Maître de l'Ivresse",
+    "name": {
+      "fr": "Maître de l'Ivresse",
+      "en": "Master of Merriment",
+      "es": "Maestro de la Embriaguez",
+      "pt": "Mestre da Embriaguez"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 2212,
-    "description": "Master of his own Merriment, the Pandawa earns temporary bonuses for each change of state. The Pandawa regenerates Wakfu and Health Points by consuming Dizzy from targets using appropriate spells.",
+    "description": {
+      "fr": "Maître de son Ivresse, le Pandawa gagne des bonus temporaires à chaque changement d'état. Il régénère son Wakfu et ses points de vie en consommant Imbibé sur des cibles grâce aux sorts prévus à cet effet.",
+      "en": "Master of his own Merriment, the Pandawa earns temporary bonuses for each change of state. The Pandawa regenerates Wakfu and Health Points by consuming Dizzy from targets using appropriate spells.",
+      "es": "Gracias a su maestría de la embriaguez, el pandawa gana bonus temporales cada vez que cambia de estado. Regenera su wakfu y sus puntos de vida consumiendo el estado Achispado que tengan los objetivos mediante los hechizos correspondientes.",
+      "pt": "Mestre de sua Embriaguez, o Pandawa ganha bônus temporários a cada mudança de estado. O Pandawa regenera Wakfu e PV ao consumir o estado Tonto dos alvos que estiverem usando os feitiços apropriados."
+    },
     "effectIds": [
       147405,
       147406,
@@ -5225,11 +7305,21 @@
   },
   {
     "spellId": 4724,
-    "name": "Tonneau sans Fond",
+    "name": {
+      "fr": "Tonneau sans Fond",
+      "en": "Bottomless Barrel",
+      "es": "Tonel sin Fondo",
+      "pt": "Barril sem Fundo"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 2213,
-    "description": "Bottomless Barrel increases the Barrel's capacity. The Pandawa instinctively takes the Barrel at the end of the turn and heals by drinking several liters.",
+    "description": {
+      "fr": "Tonneau sans Fond augmente la contenance du Tonneau. Instinctivement, le Pandawa porte son Tonneau en fin de tour et se soigne en buvant quelques litres.",
+      "en": "Bottomless Barrel increases the Barrel's capacity. The Pandawa instinctively takes the Barrel at the end of the turn and heals by drinking several liters.",
+      "es": "Aumenta la capacidad del tonel. Instintivamente, el pandawa porta su tonel al final de turno y se cura bebiendo unos litros.",
+      "pt": "O Barril sem Fundo aumenta a capacidade do barril. O Pandawa pega o barril por instinto ao final do turno e se cura bebendo vários litros do líquido que está dentro dele."
+    },
     "effectIds": [
       146127,
       159881,
@@ -5248,11 +7338,21 @@
   },
   {
     "spellId": 4725,
-    "name": "Tonneau Agressif",
+    "name": {
+      "fr": "Tonneau Agressif",
+      "en": "Aggressive Barrel",
+      "es": "Tonel Agresivo",
+      "pt": "Barril Agressivo"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 2214,
-    "description": "This passive can reduce the AP cost of the Chamrak spell when the Barrel is carried.",
+    "description": {
+      "fr": "Ce passif peut réduire le coût en PA du sort Chamrak lorsque le Tonneau est porté.",
+      "en": "This passive can reduce the AP cost of the Chamrak spell when the Barrel is carried.",
+      "es": "Este pasivo puede reducir el coste en PA del hechizo Chamrak cuando se porta el tonel.",
+      "pt": "Esta habilidade passiva pode reduzir o custo em PA do feitiço Chamrak quando o Barril estiver sendo carregado."
+    },
     "effectIds": [
       168796,
       291115,
@@ -5269,11 +7369,21 @@
   },
   {
     "spellId": 4726,
-    "name": "Instinct Laiteux",
+    "name": {
+      "fr": "Instinct Laiteux",
+      "en": "Milky Instinct",
+      "es": "Instinto Lechoso",
+      "pt": "Instinto Leitoso"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 2211,
-    "description": "Each time Dizzy is consumed from a target, the Pandawa's next spell gains increased damage. In addition, this passive puts all targets round the Barrel in the Dizzy state at the start of each of the Pandawa's turns.",
+    "description": {
+      "fr": "Chaque fois qu'il consomme de l'Imbibé sur sa cible, le Pandawa gagne des dégâts pour son prochain sort. De plus, ce passif permet d'imbiber les cibles autour du Tonneau à chaque début de tour du Pandawa.",
+      "en": "Each time Dizzy is consumed from a target, the Pandawa's next spell gains increased damage. In addition, this passive puts all targets round the Barrel in the Dizzy state at the start of each of the Pandawa's turns.",
+      "es": "Cada vez que consume Achispado al lanzarlo sobre el objetivo, el pandawa aumenta sus daños en el próximo hechizo. Además, este pasivo permite achispar a los objetivos en torno al Tonel en cada inicio de turno del pandawa.",
+      "pt": "Toda vez que o estado Tonto for consumido de um alvo, o feitiço seguinte do Pandawa ganhará mais dano. Esta habilidade passiva coloca todos os alvos ao redor do barril no estado Tonto no início de cada um dos turnos do Pandawa."
+    },
     "effectIds": [
       146139,
       159754,
@@ -5293,11 +7403,21 @@
   },
   {
     "spellId": 5148,
-    "name": "Bambouteille",
+    "name": {
+      "fr": "Bambouteille",
+      "en": "Bambottle",
+      "es": "Bambutella",
+      "pt": "Bamburrafa"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 5148,
-    "description": "The Pandawa gains a bonus that increases Dodge or Lock depending on whether they are Merry or Worn-Out. This passive also reduces the cost of Ether.",
+    "description": {
+      "fr": "Le Pandawa profite de bonus qui augmentent son Esquive ou son Tacle selon qu'il est Ivre ou qu'il a la Gueule de Bois.\\nLe passif réduit également le coût du sort Ether.",
+      "en": "The Pandawa gains a bonus that increases Dodge or Lock depending on whether they are Merry or Worn-Out.\\nThis passive also reduces the cost of Ether.",
+      "es": "El pandawa disfruta de bonus que aumentan su esquiva y su placaje según esté en estado Ebrio o en estado Resaca.\\nEste pasivo también reduce el coste del hechizo Éter.",
+      "pt": "Dependendo de seu estado (Embriagado ou de Ressaca), o Pandawa ganha um bônus que aumenta esquiva ou bloqueio.\\nEsta habilidade passiva também reduz o custo do Éter."
+    },
     "effectIds": [
       159941,
       159942,
@@ -5314,11 +7434,21 @@
   },
   {
     "spellId": 5149,
-    "name": "Cyanose",
+    "name": {
+      "fr": "Cyanose",
+      "en": "Poisoned Chalice",
+      "es": "Cianosis",
+      "pt": "Cianose"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 5149,
-    "description": "With intimate knowledge of Bamboo Milk, the Pandawa can poison enemies using a recipe handed down from Pandawa to Pandawa over countless generations. But with taking such risks, the Pandawa loses the ability to effectively heal allies.",
+    "description": {
+      "fr": "Grâce à ses connaissances sur les laits de Bambou, le Pandawa peut empoisonner ses ennemis à l'aide d'une recette ancestrale dont seuls les vrais Pandawas ont le secret. En prenant de tels risques, le Pandawa perd la faculté à soigner efficacement ses alliés.",
+      "en": "With intimate knowledge of Bamboo Milk, the Pandawa can poison enemies using a recipe handed down from Pandawa to Pandawa over countless generations. But with taking such risks, the Pandawa loses the ability to effectively heal allies.",
+      "es": "Gracias a sus conocimientos en leche de bambú, el pandawa puede envenenar a sus enemigos mediante una receta ancestral que solo los verdaderos pandawas conocen. Aunque también asume el riesgo de perder su facultad de curar con eficacia a sus aliados.",
+      "pt": "Por conhecer profundamente o Leite de Bambu, o Pandawa consegue envenenar inimigos usando uma receita que é passada de geração a geração há muitos anos. Mas, ao correr esse risco, o Pandawa perde a habilidade de curar aliados."
+    },
     "effectIds": [
       178112,
       168719,
@@ -5347,11 +7477,21 @@
   },
   {
     "spellId": 5150,
-    "name": "Buvette",
+    "name": {
+      "fr": "Buvette",
+      "en": "Refreshment",
+      "es": "Tabernita",
+      "pt": "Refresco"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 5150,
-    "description": "Party tonight, everyone grab a refreshment! At the start of Pandawa’s turn, all the allies around the Barrel gain Final Damage.",
+    "description": {
+      "fr": "Ce soir, c'est la fête, tous à la buvette ! En début de tour du Pandawa, tous les alliés présents autour du Tonneau gagnent des Dégâts Finaux.",
+      "en": "Party tonight, everyone grab a refreshment! At the start of Pandawa's turn, all the allies around the Barrel gain Final Damage.",
+      "es": "¡Esta noche vamos todos a la tabernita a celebrar! Al inicio del turno del pandawa, todos los aliados presentes alrededor del tonel ganan daños finales.",
+      "pt": "Esta noite, com vento fresco, todos tomam refresco! No começo do turno do Pandawa, todos os aliados que estão perto do Barril ganham danos finais."
+    },
     "effectIds": [
       159926
     ],
@@ -5368,11 +7508,21 @@
   },
   {
     "spellId": 5151,
-    "name": "Pandémie",
+    "name": {
+      "fr": "Pandémie",
+      "en": "Pandemic",
+      "es": "Pandemia",
+      "pt": "Pandemia"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 5151,
-    "description": "A Pandawa that can handle his Barrel is a good Pandawa. That’s why, with this passive skill, Pandawa gains Robustness when carrying his Barrel.",
+    "description": {
+      "fr": "Un Pandawa sachant porter son Tonneau est un bon Pandawa. C'est pourquoi, avec ce passif, il gagne en robustesse quand il porte son Tonneau.",
+      "en": "A Pandawa that can handle his Barrel is a good Pandawa. That's why, with this passive skill, Pandawa gains Robustness when carrying his Barrel.",
+      "es": "Un pandawa que sabe llevar su tonel es un buen pandawa. Esto es porque, con este pasivo, gana en fortaleza cuando carga con su tonel.",
+      "pt": "Um Pandawa que sabe carregar seu barril é um bom Pandawa. Por isso, esta habilidade passiva lhe dá robustez quando ele carrega seu Barril."
+    },
     "effectIds": [
       178111,
       168795,
@@ -5389,11 +7539,21 @@
   },
   {
     "spellId": 6846,
-    "name": "Éméché",
+    "name": {
+      "fr": "Éméché",
+      "en": "Buzzed",
+      "es": "Piripi",
+      "pt": "Ébrio"
+    },
     "breedId": 12,
     "class": "PANDAWA",
     "gfxId": 2215,
-    "description": "This passive increases the Pandawa's ability to become dizzy to take advantage of better preparation effects. With a passive like this, the party's going to be wild!",
+    "description": {
+      "fr": "Ce passif augmente la capacité à imbiber du Pandawa, pour bénéficier de meilleurs effets de préparation. Avec un tel passif, la fête sera très humide !",
+      "en": "This passive increases the Pandawa's ability to become dizzy to take advantage of better preparation effects. With a passive like this, the party's going to be wild!",
+      "es": "Este pasivo aumenta la capacidad de achispar del pandawa, lo que le aporta mejores efectos de preparación. Con un pasivo así, ¡la fiesta será más refrescante!",
+      "pt": "Este passivo aumenta a capacidade que o Pandawa tem de deixar Tonto, para obter melhores efeitos de preparação. Com um passivo assim, a festa vai ser animada!"
+    },
     "effectIds": [
       290557,
       290620
@@ -5409,11 +7569,21 @@
   },
   {
     "spellId": 6479,
-    "name": "Roublaboom",
+    "name": {
+      "fr": "Roublaboom",
+      "en": "Boomarogue",
+      "es": "Tymobum",
+      "pt": "Ladinoboom"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 5357,
-    "description": "Lets the Rogue strengthen that valuable tool, the Boombot. In addition to gaining AP and MP, it can target fighters other than the Rogue's own bombs, but it dies at the end of its turn.",
+    "description": {
+      "fr": "Permet au Roublard de renforcer l'outil précieux qu'est le Roublabot. En plus de gagner des PA et des PM, il peut cibler d'autres combattants que les bombes du Roublard, mais il meurt à la fin de son tour.",
+      "en": "Lets the Rogue strengthen that valuable tool, the Boombot. In addition to gaining AP and MP, it can target fighters other than the Rogue's own bombs, but it dies at the end of its turn.",
+      "es": "Permite al tymador reforzar su preciada herramienta: el tymobot. Además de ganar PA y PM, puede seleccionar a otros luchadores aparte de las bombas del tymador, pero muere al final de su turno.",
+      "pt": "Permite que o Ladino tenha mais bombas e Ladinobot no campo e reforça o Ladinobot, que é uma ferramenta preciosa."
+    },
     "effectIds": [
       264352
     ],
@@ -5428,11 +7598,21 @@
   },
   {
     "spellId": 6480,
-    "name": "Grande évasion",
+    "name": {
+      "fr": "Grande évasion",
+      "en": "Great Escape",
+      "es": "Gran Evasión",
+      "pt": "Bugigangas Evoluídas"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 6480,
-    "description": "If the Rogue uses Ruse to change modes, they switch places with the farthest bomb, within a radius of 6 cells, and then detonate it.",
+    "description": {
+      "fr": "Si le Roublard utilise Ruse pour changer de mode, il échange de position avec la bombe la plus éloignée, dans un rayon maximum de 6 cases, puis la fait exploser.",
+      "en": "If the Rogue uses Ruse to change modes, they switch places with the farthest bomb, within a radius of 6 cells, and then detonate it.",
+      "es": "Si el tymador utiliza un ardid para cambiar de modo, intercambia de posición con le bomba más alejada, en un radio máximo de 6 casillas, luego la a hace explotar.",
+      "pt": "Faz todas as bugigangas do Ladino evoluírem, aumentando o alcance dos feitiços citados."
+    },
     "effectIds": [
       367913
     ],
@@ -5447,11 +7627,21 @@
   },
   {
     "spellId": 6481,
-    "name": "Bomber Fan",
+    "name": {
+      "fr": "Bomber Fan",
+      "en": "Bomber Fan",
+      "es": "Bomber Fan",
+      "pt": "Bomber Fan"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 4311,
-    "description": "The Rogue gains 1 AP when a bomb explodes, but their bombs only have a single health point.",
+    "description": {
+      "fr": "Le Roublard gagne 1 PA quand une bombe explose, mais ses bombes ne possèdent qu'un seul point de vie.",
+      "en": "The Rogue gains 1 AP when a bomb explodes, but their bombs only have a single health point.",
+      "es": "El tymador gana 1 PA cuando una bomba explota, pero sus bombas solo poseen un punto de vida.",
+      "pt": "Aumenta os combos que as bombas obtêm naturalmente por turno e o máximo de combo que elas podem possuir."
+    },
     "effectIds": [
       367942
     ],
@@ -5466,11 +7656,21 @@
   },
   {
     "spellId": 6482,
-    "name": "Artificier",
+    "name": {
+      "fr": "Artificier",
+      "en": "Pyrotechnist",
+      "es": "Artificiero",
+      "pt": "Especialista em Explosivos"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 6482,
-    "description": "Bombs evolve faster, but the Rogue can only place one of each element per turn.",
+    "description": {
+      "fr": "Les bombes évoluent plus vite, mais le Roublard ne peut en poser qu'une de chaque élément par tour.",
+      "en": "Bombs evolve faster, but the Rogue can only place one of each element per turn.",
+      "es": "Las bombas evolucionan más rápido, pero el tymador solo puede poner una de cada elemento por turno.",
+      "pt": "Como este passivo aumenta o tamanho e os danos do Muro de Pólvora, aconselha-se não deixar nenhum pavio por perto."
+    },
     "effectIds": [
       368106
     ],
@@ -5485,11 +7685,21 @@
   },
   {
     "spellId": 6483,
-    "name": "Tunique renforcée",
+    "name": {
+      "fr": "Tunique renforcée",
+      "en": "Reinforced Tunic",
+      "es": "Túnica Reforzada",
+      "pt": "Túnica Reforçada"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 1816,
-    "description": "At the end of their turn, the Rogue uses bombs adjacent to them as a shield by absorbing their resistance.",
+    "description": {
+      "fr": "À la fin de son tour, le Roublard utilise les bombes à son contact pour se protéger en absorbant leurs résistances.",
+      "en": "At the end of their turn, the Rogue uses bombs adjacent to them as a shield by absorbing their resistance.",
+      "es": "Al final de su turno, el tymador utiliza las bombas en contacto con él para protegerse absorbiendo sus resistencias.",
+      "pt": "Reforça a túnica e as armas do Ladino, aumentando seus pontos de vida e os de suas bombas."
+    },
     "effectIds": [
       367842,
       395592
@@ -5509,11 +7719,21 @@
   },
   {
     "spellId": 6484,
-    "name": "Démineur",
+    "name": {
+      "fr": "Démineur",
+      "en": "Minesweeper",
+      "es": "Desminador",
+      "pt": "Caça-minas"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 7064,
-    "description": "The Rogue can no longer change modes with Ruse, but changes modes automatically when they run out of Powder.",
+    "description": {
+      "fr": "Le Roublard ne peut plus changer de mode avec Ruse, mais il change automatiquement de mode lorsqu'il n'a plus de Poudre.",
+      "en": "The Rogue can no longer change modes with Ruse, but changes modes automatically when they run out of Powder.",
+      "es": "El tymador ya no puede cambiar de modo con Ardid, pero cambia automáticamente de modo cuando no le queda pólvora.",
+      "pt": "Desbloqueia uma versão mais potente de Detonação, para infligir cada vez mais danos. O feitiço também pode servir para aumentar os danos de um aliado."
+    },
     "effectIds": [
       368152
     ],
@@ -5532,11 +7752,21 @@
   },
   {
     "spellId": 6485,
-    "name": "Lame rouillée",
+    "name": {
+      "fr": "Lame rouillée",
+      "en": "Rusty Blade",
+      "es": "Hoja Oxidada",
+      "pt": "Mira Telescópica"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 5123,
-    "description": "The Rogue's elemental spells in Runaway mode have fixed range, but generate Rusty Blades. These Rusty Blades are consumed in Sneaky mode to apply a stackable poison on a target.",
+    "description": {
+      "fr": "Les sorts élémentaires du Roublard en Fuyard sont à portée fixe, mais génèrent des Lames rouillées. Ces Lames rouillées sont consommées en Fourbe pour appliquer un poison cumulable sur une cible.",
+      "en": "The Rogue's elemental spells in Runaway mode have fixed range, but generate Rusty Blades. These Rusty Blades are consumed in Sneaky mode to apply a stackable poison on a target.",
+      "es": "Los hechizos elementales del tymador en Huidizo son de alcance fijo, pero generan hojas oxidadas. Estas hojas oxidadas se consumen en Ruin para aplicar un veneno acumulable en un objetivo.",
+      "pt": "Certos Ladinos preferem manter a distância, pois já atravessaram relacionamentos complicados. Este passivo lhes permite ganhar alcance e transformar o terreno em um campo minado de longe."
+    },
     "effectIds": [
       371745
     ],
@@ -5551,11 +7781,21 @@
   },
   {
     "spellId": 6486,
-    "name": "Maître des lames",
+    "name": {
+      "fr": "Maître des lames",
+      "en": "Blade Master",
+      "es": "Maestro de las Hojas",
+      "pt": "Mestre Ladino"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 5050,
-    "description": "In Sneaky mode, the Rogue consumes their Powder to gain Armor.",
+    "description": {
+      "fr": "En étant Fourbe, le Roublard consomme sa Poudre pour gagner de l'Armure.",
+      "en": "In Sneaky mode, the Rogue consumes their Powder to gain Armor.",
+      "es": "En Ruin, el tymador consume su pólvora para ganar armadura.",
+      "pt": "Outros Ladinos preferem estabelecer relacionamentos estreitos com suas vítimas. Por isso, este passivo oferece Esquiva para se aproximar melhor delas, armadura para se proteger e Lâmina Longa para finalidades mais... fatais."
+    },
     "effectIds": [
       367961
     ],
@@ -5570,11 +7810,21 @@
   },
   {
     "spellId": 6487,
-    "name": "Mur de poudre",
+    "name": {
+      "fr": "Mur de poudre",
+      "en": "Powder Wall",
+      "es": "Pared de Pólvora",
+      "pt": "K-Boom"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 6933,
-    "description": "The Rogue can create Powder Walls by placing bombs in a line spaced less than 5 cells apart. The Powder Wall inflicts damage on all fighters who start their turn inside it.",
+    "description": {
+      "fr": "Le Roublard peut créer des Murs de poudre en alignant des bombes à moins de 5 cases les unes des autres. Le Mur de poudre inflige des dommages à tous les combattants qui commencent leur tour dedans.",
+      "en": "The Rogue can create Powder Walls by placing bombs in a line spaced less than 5 cells apart. The Powder Wall inflicts damage on all fighters who start their turn inside it.",
+      "es": "El tymador puede crear paredes de pólvora alineando bombas a menos de 5 casillas unas de otras. La pared de pólvora inflige daños a todos los luchadores que empiecen su turno en ella.",
+      "pt": "\"K-Boom\" é o som de uma bomba explodindo, mas também do coração batendo por um aliado carente de danos. Um bom incentivo para aplicar uma boa surra!"
+    },
     "effectIds": [
       372016,
       372150
@@ -5592,11 +7842,21 @@
   },
   {
     "spellId": 6488,
-    "name": "Fugitif",
+    "name": {
+      "fr": "Fugitif",
+      "en": "Fugitive",
+      "es": "Fugitivo",
+      "pt": "Fugitivo"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 2334,
-    "description": "At the start of their turn, the Rogue switches places with their closest bomb, up to 4 cells away, then stabilizes it.",
+    "description": {
+      "fr": "Au début de son tour, le Roublard échange de position avec sa bombe la plus proche, située à 4 cases maximum, puis la stabilise.",
+      "en": "At the start of their turn, the Rogue switches places with their closest bomb, up to 4 cells away, then stabilizes it.",
+      "es": "Al principio de su turno, el tymador intercambia de posición con su bomba más cercana situada a 4 casillas como máximo, luego la estabiliza.",
+      "pt": "Oferece uma mobilidade excepcional ao Ladino em detrimento de seus danos diretos. Porém, os danos das bombas e do Muro de Pólvora continuam muito elevados graças ao ganho de combo."
+    },
     "effectIds": [
       367829
     ],
@@ -5611,11 +7871,21 @@
   },
   {
     "spellId": 7062,
-    "name": "Tir surprise",
+    "name": {
+      "fr": "Tir surprise",
+      "en": "Surprise Shot",
+      "es": "Tiro Sorpresa",
+      "pt": "Tiro Surpresa"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 2332,
-    "description": "The Rogue will inflict additional damage on their next elemental spell after changing modes. The connection is lost if the Rogue uses their MP to move. In exchange, Ruse can no longer be used to switch places with another fighter.",
+    "description": {
+      "fr": "Le Roublard infligera des dommages supplémentaires sur son prochain sort élémentaire après avoir changé de mode. La connexion est perdue si le Roublard utilise ses PM pour se déplacer. En contrepartie, Ruse ne peut plus être utilisé pour échanger de position avec un autre combattant.",
+      "en": "The Rogue will inflict additional damage on their next elemental spell after changing modes. The connection is lost if the Rogue uses their MP to move. In exchange, Ruse can no longer be used to switch places with another fighter.",
+      "es": "El tymador infligirá daños adicionales en su próximo hechizo elemental tras haber cambiado de modo. Se pierde la conexión si el tymador utiliza sus PM para desplazarse. En cambio, Ardid ya no se puede utilizar para intercambiar de posición con otro luchador.",
+      "pt": "O Ladino infligirá danos adicionais em seu próximo feitiço elementar após ter trocado de modo. A conexão se perde se o Ladino utiliza seus PM para se deslocar. Por outro lado, Astúcia não pode mais ser utilizada para trocar de posição com outro combatente."
+    },
     "effectIds": [
       371569
     ],
@@ -5630,11 +7900,21 @@
   },
   {
     "spellId": 7063,
-    "name": "Baril",
+    "name": {
+      "fr": "Baril",
+      "en": "Powder Keg",
+      "es": "Barril",
+      "pt": "Barril"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 4300,
-    "description": "The Rogue's Powder reserves are larger, but their bombs no longer evolve naturally.",
+    "description": {
+      "fr": "La réserve de Poudre du Roublard est plus grande, mais ses bombes n'évoluent plus naturellement.",
+      "en": "The Rogue's Powder reserves are larger, but their bombs no longer evolve naturally.",
+      "es": "La reserva de pólvora del tymador es mayor, pero sus bombas ya no evolucionan naturalmente.",
+      "pt": "A reserva de Pólvora do Ladino é maior, mas suas bombas não evoluem mais naturalmente."
+    },
     "effectIds": [
       371656
     ],
@@ -5649,11 +7929,21 @@
   },
   {
     "spellId": 7064,
-    "name": "Dynamite",
+    "name": {
+      "fr": "Dynamite",
+      "en": "Dynamite",
+      "es": "Dinamita",
+      "pt": "Dinamite"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 6485,
-    "description": "The Rogue can cast Dynamite on other fighters. If they cast it on an ally, they share the damage increase with that ally. Casting it on an enemy makes the enemy vulnerable to explosions.",
+    "description": {
+      "fr": "Le Roublard peut lancer Dynamite sur d'autres combattants. S'il le lance sur un allié, il partage le gain de dommages avec lui. S'il le lance sur un ennemi, il le rend vulnérable aux explosions.",
+      "en": "The Rogue can cast Dynamite on other fighters. If they cast it on an ally, they share the damage increase with that ally. Casting it on an enemy makes the enemy vulnerable to explosions.",
+      "es": "El tymador puede lanzar Dinamita sobre otros luchadores. Si lo lanza sobre un aliado, comparte la ganancia de daños con él. Si lo lanza sobre un enemigo, lo vuelve vulnerable a las explosiones.",
+      "pt": "O Ladino pode lançar Dinamite em outros combatentes. Se lançar em um aliado, ele compartilha os ganhos de danos com ele. Se lançar em um inimigo, ele o torna vulnerável às explosões."
+    },
     "effectIds": [
       371667
     ],
@@ -5668,11 +7958,21 @@
   },
   {
     "spellId": 7065,
-    "name": "Explobombe",
+    "name": {
+      "fr": "Explobombe",
+      "en": "Explobomb",
+      "es": "Explobomba",
+      "pt": "Explobomba"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 7065,
-    "description": "Bombs explode when they die. Talk about going out with a bang!",
+    "description": {
+      "fr": "Les bombes explosent à leur mort. Un final explosif de toute beauté !",
+      "en": "Bombs explode when they die. Talk about going out with a bang!",
+      "es": "Las bombas explotan cuando mueren. ¡Un final de lo más explosivo!",
+      "pt": "As bombas explodem ao morrerem. Um final belo e explosivo!"
+    },
     "effectIds": [
       358847
     ],
@@ -5687,11 +7987,21 @@
   },
   {
     "spellId": 7090,
-    "name": "Bombes élémentaires",
+    "name": {
+      "fr": "Bombes élémentaires",
+      "en": "Elemental Bombs",
+      "es": "Bombas Elementales",
+      "pt": "Bombas Elementares"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 7090,
-    "description": "The Rogue's bombs have additional effects. However, the bombs' maximum level is reduced.",
+    "description": {
+      "fr": "Les bombes du Roublard possèdent des effets supplémentaires. En contrepartie, le niveau maximum des bombes est réduit.",
+      "en": "The Rogue's bombs have additional effects. However, the bombs' maximum level is reduced.",
+      "es": "Las bombas del tymador tienen efectos adicionales. En cambio, el nivel máximo de las bombas se reduce.",
+      "pt": "As bombas de Ladino possuem efeitos adicionais. Por outro lado, o nível máximo das bombas é reduzido."
+    },
     "effectIds": [
       307985
     ],
@@ -5708,11 +8018,21 @@
   },
   {
     "spellId": 7091,
-    "name": "Maître Roublard",
+    "name": {
+      "fr": "Maître Roublard",
+      "en": "Rogue Master",
+      "es": "Maestro Tymador",
+      "pt": "Mestre Ladino"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 2339,
-    "description": "At start of turn, the Rogue accumulates the \"Rogue Master\" state up to a maximum level of 5. Upon switching from Sneaky to Runaway, or from Runaway to Sneaky, the Rogue will gain additional bonuses depending on the mode. In exchange, the Ruse spell has a 2 turn cooldown.",
+    "description": {
+      "fr": "En début de tour, le Roublard cumule l'état \"Maître Roublard\" jusqu'au niveau 5 maximum. En passant de Fourbe à Fuyard, ou de Fuyard à Fourbe, le Roublard gagnera des bonus supplémentaires selon le mode. En contrepartie, le sort Ruse possède 2 tours de relance.",
+      "en": "At start of turn, the Rogue accumulates the \"Rogue Master\" state up to a maximum level of 5. Upon switching from Sneaky to Runaway, or from Runaway to Sneaky, the Rogue will gain additional bonuses depending on the mode. In exchange, the Ruse spell has a 2 turn cooldown.",
+      "es": "Al principio del turno, el tymador acumula el estado Maestro Tymador hasta el nivel 5 como máximo. Al pasar de Ruin a Huidizo, o al revés, el tymador ganará bonus adicionales según el modo. Como contrapartida, el hechizo Ardid tiene 2 turnos de intervalo de lanzamiento.",
+      "pt": "No início do turno, o Ladino acumula o estado \"Mestre Ladino\" até o nível 5 no máximo. Ao passar de Perfídia a Escapista, ou de Escapista a Perfídia, o Ladino ganhará bônus adicionais de acordo com o modo. Por outro lado, o feitiço Astúcia possui 2 turnos de relançamento."
+    },
     "effectIds": [
       371693
     ],
@@ -5729,11 +8049,21 @@
   },
   {
     "spellId": 7092,
-    "name": "Jackpot",
+    "name": {
+      "fr": "Jackpot",
+      "en": "Jackpot",
+      "es": "Jackpot",
+      "pt": "Sorte Grande"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 7092,
-    "description": "The Rogue switches places with the first bomb placed on their turn while in Sneaky mode, then switches places with it again at the end of the turn if the bomb is still on the field.",
+    "description": {
+      "fr": "Le Roublard échange de position avec la première bombe posée pendant son tour en étant Fourbe, puis échange à nouveau de position avec en fin de tour, si elle est encore sur le terrain.",
+      "en": "The Rogue switches places with the first bomb placed on their turn while in Sneaky mode, then switches places with it again at the end of the turn if the bomb is still on the field.",
+      "es": "El tymador intercambia la posición con la primera bomba puesta durante su turno estando en Ruin, luego vuelve a intercambiar de posición con ella al final del turno, si esta sigue en el terreno.",
+      "pt": "O Ladino troca de lugar com a primeira bomba colocada durante seu turno se estiver no mofo Perfídia e, em seguida, troca de lugar com ela novamente no final do turno se ela ainda estiver no terreno."
+    },
     "effectIds": [
       367900
     ],
@@ -5748,11 +8078,21 @@
   },
   {
     "spellId": 7982,
-    "name": "Tacticien",
+    "name": {
+      "fr": "Tacticien",
+      "en": "Tactician",
+      "es": "Táctico",
+      "pt": "Tático"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 2335,
-    "description": "The Rogue regains AP by moving their bombs, but the bombs lose 1 level after being moved. The Rogue can regain up to 6 AP per turn.",
+    "description": {
+      "fr": "Le Roublard regagne des PA en déplaçant ses bombes, mais les bombes déplacées perdent 1 niveau. Le Roublard peut regagner 6 PA maximum par tour.",
+      "en": "The Rogue regains AP by moving their bombs, but the bombs lose 1 level after being moved. The Rogue can regain up to 6 AP per turn.",
+      "es": "El tymador recupera PA desplazando sus bombas, pero las bombas desplazadas pierden 1 nivel. El tymador puede recuperar 6 PA como máximo por turno.",
+      "pt": "O Ladino recupera PA deslocando suas bombas, mas as bombas deslocadas perdem 1 nível. O Ladino pode recuperar 6 PA máx. por turno."
+    },
     "effectIds": [
       367874
     ],
@@ -5767,11 +8107,21 @@
   },
   {
     "spellId": 7983,
-    "name": "Trainée de poudre",
+    "name": {
+      "fr": "Trainée de poudre",
+      "en": "Powder Trail",
+      "es": "Rastro de Pólvora",
+      "pt": "Rastilho de Pólvora"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 5192,
-    "description": "The Rogue gains MP by summoning bombs. In exchange, Ruse now has a line of sight.",
+    "description": {
+      "fr": "Le Roublard gagne des PM en invoquant des bombes. En contrepartie, Ruse possède maintenant une ligne de vue.",
+      "en": "The Rogue gains MP by summoning bombs. In exchange, Ruse now has a line of sight.",
+      "es": "El tymador gana PM invocando bombas. En cambio, Ardid ahora tiene una línea de visión.",
+      "pt": "O Ladino ganha PM invocando bombas. Por outro lado, Astúcia agora possui linha de visão."
+    },
     "effectIds": [
       367887
     ],
@@ -5786,11 +8136,21 @@
   },
   {
     "spellId": 7984,
-    "name": "Bombes à retardement",
+    "name": {
+      "fr": "Bombes à retardement",
+      "en": "Time Bombs",
+      "es": "Bombas de Efecto Retardado",
+      "pt": "Bombas-Relógio"
+    },
     "breedId": 13,
     "class": "ROUBLARD",
     "gfxId": 7063,
-    "description": "Instead of directly placing bombs, the Rogue places glyphs. At the start of the next turn, these glyphs turn into bombs if the cell is still free. The bombs summoned in this way level up directly.",
+    "description": {
+      "fr": "Au lieu de poser directement des bombes, le Roublard pose des glyphes. Au début du prochain tour, ces glyphes se transforment en bombe si la cellule est toujours libre. Les bombes invoquées ainsi gagnent directement des niveaux.",
+      "en": "Instead of directly placing bombs, the Rogue places glyphs. At the start of the next turn, these glyphs turn into bombs if the cell is still free. The bombs summoned in this way level up directly.",
+      "es": "En lugar de poner directamente bombas, los tymadores ponen glifos. Al principio del próximo turno, estos glifos se transforman en bomba si la casilla sigue estando libre. Las bombas invocadas así ganan niveles directamente.",
+      "pt": "Em vez de colocar bombas diretamente, o Ladino coloca glifos. No início do próximo turno, esses glifos se transformam em bombas se a célula ainda estiver livre. As bombas invocadas dessa maneira ganham níveis diretamente."
+    },
     "effectIds": [
       367658
     ],
@@ -5807,11 +8167,21 @@
   },
   {
     "spellId": 7093,
-    "name": "Jeu de jambes",
+    "name": {
+      "fr": "Jeu de jambes",
+      "en": "Fancy Footwork",
+      "es": "Juego de Piernas",
+      "pt": "Jogo de Cintura"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7093,
-    "description": "The Masqueraider gains mobility but loses resistance.",
+    "description": {
+      "fr": "Le Zobal gagne en mobilité mais perd en résistance.",
+      "en": "The Masqueraider gains mobility but loses resistance.",
+      "es": "El zobal gana movilidad, pero pierde resistencia.",
+      "pt": "O Zobal ganha mobilidade, mas perde resistência."
+    },
     "effectIds": [
       308163,
       308257,
@@ -5854,11 +8224,21 @@
   },
   {
     "spellId": 7094,
-    "name": "Bas les masques",
+    "name": {
+      "fr": "Bas les masques",
+      "en": "Masks Off",
+      "es": "Fuera Máscaras",
+      "pt": "Abaixo as máscaras"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 3364,
-    "description": "The Masqueraider regains 2 AP when they start wearing a mask different from the one they already have.",
+    "description": {
+      "fr": "Le Zobal regagne 2 PA lorsqu'il se met à porter un masque autre que celui qu'il possède déjà.",
+      "en": "The Masqueraider regains 2 AP when they start wearing a mask different from the one they already have.",
+      "es": "El zobal recupera 2 PA cuando se pone una máscara diferente de la que ya tiene.",
+      "pt": "O Zobal recupera 2 PA quando passa a usar uma máscara diferente da que já tem."
+    },
     "effectIds": [
       308038
     ],
@@ -5873,11 +8253,21 @@
   },
   {
     "spellId": 7095,
-    "name": "Poussées violentes",
+    "name": {
+      "fr": "Poussées violentes",
+      "en": "Violent Pushes",
+      "es": "Empujes Violentos",
+      "pt": "Empurrões Violentos"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7095,
-    "description": "\"Dopu\" was a famous Masqueraider specializing in collisions. He pushed his opponents around so much that they took pushback damage. An ancestral art that was thought to have been lost since the Dofus Era...",
+    "description": {
+      "fr": "\"Dopou\" était un célèbre Zobal spécialiste des collisions. Il parvenait à pousser ses adversaires tant et si bien qu'ils subissaient des dommages de poussée. Un art ancestral qu'on croyait disparu depuis l'âge des Dofus...",
+      "en": "\"Dopu\" was a famous Masqueraider specializing in collisions. He pushed his opponents around so much that they took pushback damage. An ancestral art that was thought to have been lost since the Dofus Era...",
+      "es": "Dopu era un famoso zobal especialista en las colisiones. Conseguía empujar a sus adversarios tan bien que estos sufrían daños de empuje. Un arte ancestral que se creía perdido desde la Edad de los Dofus.",
+      "pt": "\"Daem\" era um famoso Zobal especialista em colisões. Ele conseguia empurrar os adversários tão bem que eles sofriam danos de empurrão. Uma arte ancestral considerada extinta desde a era dos Dofus..."
+    },
     "effectIds": [
       308039,
       308062,
@@ -5896,11 +8286,21 @@
   },
   {
     "spellId": 7096,
-    "name": "Art de la vengeance",
+    "name": {
+      "fr": "Art de la vengeance",
+      "en": "Artful Locker",
+      "es": "Arte de la Venganza",
+      "pt": "Arte da Vingança"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7096,
-    "description": "The Masqueraider gains melee damage based on their Lock.",
+    "description": {
+      "fr": "Le Zobal gagne en Dommages de mêlée en fonction de son tacle.",
+      "en": "The Masqueraider gains melee damage based on their Lock.",
+      "es": "El zobal gana daños en melé en función de su placaje.",
+      "pt": "O Zobal ganha danos a curta distância em função de seu bloqueio."
+    },
     "effectIds": [
       308161
     ],
@@ -5915,11 +8315,21 @@
   },
   {
     "spellId": 7097,
-    "name": "Masque de vie",
+    "name": {
+      "fr": "Masque de vie",
+      "en": "Health Mask",
+      "es": "Máscara de Vida",
+      "pt": "Máscara de Vida"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7097,
-    "description": "This passive gives the Masqueraider a health-stealing ability on targets they attack from the front.",
+    "description": {
+      "fr": "Ce passif donne au Zobal une capacité de vol de vie sur les cibles qu'il attaque de face.",
+      "en": "This passive gives the Masqueraider a health-stealing ability on targets they attack from the front.",
+      "es": "Este pasivo da al zobal una capacidad de robo de vida sobre los objetivos que ataca de frente.",
+      "pt": "Este passivo dá ao Zobal a capacidade de roubar vida dos inimigos que ataca de frente."
+    },
     "effectIds": [
       308066,
       308068
@@ -5958,11 +8368,21 @@
   },
   {
     "spellId": 7098,
-    "name": "Carnaval",
+    "name": {
+      "fr": "Carnaval",
+      "en": "Carnival",
+      "es": "Carnaval",
+      "pt": "Carnaval"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 3357,
-    "description": "Masks do not consume WP but they have a shared recast time of 4 turns.",
+    "description": {
+      "fr": "Les masques ne consomment pas de PW, mais ils ont 4 tours de relance partagés.",
+      "en": "Masks do not consume WP but they have a shared recast time of 4 turns.",
+      "es": "Las máscaras no consumen PW, pero tienen 4 turnos de intervalo de lanzamiento compartidos.",
+      "pt": "As máscaras não gastam PW, mas têm 4 turnos de relançamento compartilhados."
+    },
     "effectIds": [
       308073,
       308515
@@ -5980,11 +8400,21 @@
   },
   {
     "spellId": 7099,
-    "name": "Armure unique",
+    "name": {
+      "fr": "Armure unique",
+      "en": "Unique Armor",
+      "es": "Armadura Única",
+      "pt": "Armadura Única"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7099,
-    "description": "This passive significantly strengthens the Armor given to a target that has none at all. Giving Armor in the right situation is an art.",
+    "description": {
+      "fr": "Ce passif rend bien plus forte l'armure donnée sur une cible qui n'en possède pas du tout. C'est tout un art de donner de l'Armure lorsque la situation s'y prête.",
+      "en": "This passive significantly strengthens the Armor given to a target that has none at all. Giving Armor in the right situation is an art.",
+      "es": "Este pasivo vuelve mucho más fuerte la armadura dada a un objetivo que no tiene ninguna. Es todo un arte dar armadura cuando es necesario.",
+      "pt": "Este passivo fortalece muito a armadura concedida a um alvo sem nenhuma. Saber dar armadura na situação adequada é uma arte."
+    },
     "effectIds": [
       308173
     ],
@@ -6024,11 +8454,21 @@
   },
   {
     "spellId": 7100,
-    "name": "Ancre",
+    "name": {
+      "fr": "Ancre",
+      "en": "Anchor",
+      "es": "Ancla",
+      "pt": "Âncora"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 3363,
-    "description": "The Masqueraider increases their Lock to keep opponents in close combat but loses mobility in exchange.",
+    "description": {
+      "fr": "Le Zobal gagne en tacle pour retenir ses adversaires au corps-à-corps, mais il perd en mobilité en échange.",
+      "en": "The Masqueraider increases their Lock to keep opponents in close combat but loses mobility in exchange.",
+      "es": "El zobal gana placaje para retener a sus adversarios en el cuerpo a cuerpo, pero pierde movilidad.",
+      "pt": "O Zobal ganha bloqueio para segurar os adversários no corpo a corpo, mas perde mobilidade."
+    },
     "effectIds": [
       308081,
       308083
@@ -6067,11 +8507,21 @@
   },
   {
     "spellId": 7101,
-    "name": "Brute",
+    "name": {
+      "fr": "Brute",
+      "en": "Brute",
+      "es": "Bruto",
+      "pt": "Bruto"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 3356,
-    "description": "The Masqueraider specializes in dealing damage, and inflicts more damage on their opponents. In exchange, their ability to give and receive Armor is reduced.",
+    "description": {
+      "fr": "Le Zobal se spécialise dans les dégâts, et inflige davantage de dommages à ses adversaires. Ce faisant, ses capacités d'Armure donnée et reçue sont réduites.",
+      "en": "The Masqueraider specializes in dealing damage, and inflicts more damage on their opponents. In exchange, their ability to give and receive Armor is reduced.",
+      "es": "El zobal se especializa en los daños e inflige más a sus adversarios. Sin embargo, sus capacidades de armadura dada y recibida se reducen.",
+      "pt": "O Zobal se especializa nos danos e inflige mais danos aos adversários. Ao fazer isso, a armadura que concede e recebe é reduzida."
+    },
     "effectIds": [
       308084,
       308085,
@@ -6111,11 +8561,21 @@
   },
   {
     "spellId": 7102,
-    "name": "Protecteur reculé",
+    "name": {
+      "fr": "Protecteur reculé",
+      "en": "Cautious Protector",
+      "es": "Protector Apartado",
+      "pt": "Protetor Recuado"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 5348,
-    "description": "With this passive, the amount of healing provided varies depending on the Masqueraider's recent actions. Heals increase if the Masqueraider didn't heal anyone on the previous turn, and decrease if they did heal someone on the previous turn.",
+    "description": {
+      "fr": "Ce passif rend variable l'efficacité des soins réalisés, selon la circonstance des interventions du Zobal. Il gagne du soin s'il n'a pas soigné au tour précédent, et perd du soin s'il a soigné au tour précédent.",
+      "en": "With this passive, the amount of healing provided varies depending on the Masqueraider's recent actions. Heals increase if the Masqueraider didn't heal anyone on the previous turn, and decrease if they did heal someone on the previous turn.",
+      "es": "Este pasivo vuelve variable la eficacia de las curas realizadas según la circunstancia de las intervenciones del zobal. Gana cura si no ha curado en el turno anterior y la pierde si sí lo ha hecho.",
+      "pt": "Este passivo faz a eficácia das curas realizadas variar de acordo com as circunstâncias das intervenções do Zobal. Ele ganha cura se não tiver sido curado no turno anterior e perde se tiver sido."
+    },
     "effectIds": [
       308264
     ],
@@ -6133,11 +8593,21 @@
   },
   {
     "spellId": 7103,
-    "name": "Collisions de support",
+    "name": {
+      "fr": "Collisions de support",
+      "en": "Support Collisions",
+      "es": "Colisiones de Apoyo",
+      "pt": "Colisões de Suporte"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7103,
-    "description": "The Masqueraider increases their support potential through collisions. Add a dash of crash and smash!",
+    "description": {
+      "fr": "Le Zobal augmente son potentiel de support via les collisions. Certains jeunes adeptes le chantent : \"colli, colli, colli, colli...\".",
+      "en": "The Masqueraider increases their support potential through collisions. Add a dash of crash and smash!",
+      "es": "El zobal aumenta su potencial de apoyo mediante las colisiones. Algunos jóvenes adeptos lo cantan: \"coli, coli, coli...\".",
+      "pt": "O Zobal aumenta seu potencial de suporte por meio das colisões. A torcida canta: \"Coli... coli coli colá...\""
+    },
     "effectIds": [
       308128,
       308136,
@@ -6156,11 +8626,21 @@
   },
   {
     "spellId": 7104,
-    "name": "Érosion",
+    "name": {
+      "fr": "Érosion",
+      "en": "Erosion",
+      "es": "Erosión",
+      "pt": "Erosão"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7104,
-    "description": "Changes the Psychopath Mask so that the Masqueraider's spells remove resistance from opponents, specifically from the direct target of the spell. The resistance is removed before the spell's effects (damage, etc.) are applied. In exchange, the Masqueraider's offensive ability is reduced.",
+    "description": {
+      "fr": "Change le Masque de Psychopathe afin que les sorts du Zobal retirent des résistances aux adversaires : plus précisément sur la cible directe du sort lancé. Le retrait de résistance s'effectue avant les effets (dommages etc.) de ses sorts. En revanche, le Zobal perd en capacités offensives.",
+      "en": "Changes the Psychopath Mask so that the Masqueraider's spells remove resistance from opponents, specifically from the direct target of the spell. The resistance is removed before the spell's effects (damage, etc.) are applied. In exchange, the Masqueraider's offensive ability is reduced.",
+      "es": "Cambia la Máscara Sáikopat para que los hechizos del zobal retiren resistencias a los adversarios, más concretamente al objetivo directo del hechizo lanzado. La retirada de resistencia se realiza antes de los efectos (daños, etc.) de sus hechizos. En cambio, el zobal pierde capacidades ofensivas.",
+      "pt": "Modifica a Máscara de Psicopata para que os feitiços do Zobal retirem resistência dos adversários – mais especificamente, do alvo direto do feitiço lançado. A retirada de resistência ocorre antes dos efeitos (danos, etc) de seus feitiços. Por outro lado, o Zobal perde habilidades ofensivas."
+    },
     "effectIds": [
       311665,
       308246
@@ -6178,11 +8658,21 @@
   },
   {
     "spellId": 7105,
-    "name": "Virevolte",
+    "name": {
+      "fr": "Virevolte",
+      "en": "Pirouette",
+      "es": "Giro",
+      "pt": "Cambalhota"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7105,
-    "description": "Increases damage from the side but reduces damage from the front.",
+    "description": {
+      "fr": "Augmente les dommages de côté mais réduit les dommages de face.",
+      "en": "Increases damage from the side but reduces damage from the front.",
+      "es": "Aumenta los daños de lado, pero reduce los daños de frente.",
+      "pt": "Aumenta os danos laterais, mas reduz os frontais."
+    },
     "effectIds": [
       308093
     ],
@@ -6197,11 +8687,21 @@
   },
   {
     "spellId": 7106,
-    "name": "Collisions régénérantes",
+    "name": {
+      "fr": "Collisions régénérantes",
+      "en": "Regenerating Collisions",
+      "es": "Colisiones Regenerativas",
+      "pt": "Colisões Regenerativas"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7106,
-    "description": "Collisions gain a healing effect. When you push one obstacle into another, the second one will receive the healing.",
+    "description": {
+      "fr": "Les collisions gagnent un effet de soin. Il faut pousser un obstacle contre un autre, et si des alliés sont concernés, ils bénéficieront de soin.",
+      "en": "Collisions gain a healing effect. You have to push an obstacle into another one, and if allies are involved, they will receive healing.",
+      "es": "Las colisiones ganan un efecto de cura. Hay que empujar un obstáculo contra otro y, si hay aliados implicados, recibirán cura.",
+      "pt": "As colisões ganham um efeito de cura. É preciso empurrar um obstáculo contra outro e, se aliados forem afetados, eles receberão cura."
+    },
     "effectIds": [
       308144,
       308157,
@@ -6231,11 +8731,21 @@
   },
   {
     "spellId": 7107,
-    "name": "Miroirs",
+    "name": {
+      "fr": "Miroirs",
+      "en": "Mirrors",
+      "es": "Espejos",
+      "pt": "Espelhos"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7107,
-    "description": "The Masqueraider switches places with the direct target of a spell cast in melee. The Masqueraider cannot switch places if they are being carried or stabilized.",
+    "description": {
+      "fr": "Le Zobal échange de position avec la cible directe d'un sort lancé en mêlée. Le Zobal ne peut pas échanger de position s'il est porté ou stabilisé.",
+      "en": "The Masqueraider switches places with the direct target of a spell cast in melee. The Masqueraider cannot switch places if they are being carried or stabilized.",
+      "es": "El zobal intercambia la posición con el objetivo directo de un hechizo lanzado en melé. El zobal no puede cambiar de posición si portado o estabilizado.",
+      "pt": "O Zobal troca de lugar com o alvo direto de um feitiço lançado a curta distância. O Zobal não pode trocar de lugar se for carregado ou estabilizado."
+    },
     "effectIds": [
       308238
     ],
@@ -6250,11 +8760,21 @@
   },
   {
     "spellId": 7108,
-    "name": "Au contact",
+    "name": {
+      "fr": "Au contact",
+      "en": "Keep in Contact",
+      "es": "En Contacto",
+      "pt": "Em Contato"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 5347,
-    "description": "The Masqueraider increases their damage and resistance abilities if they stay adjacent to a fighter (allied or enemy). If they move away and finish their turn in an isolated position, they have a penalty instead.",
+    "description": {
+      "fr": "Le Zobal gagne en capacités de dommages et résistances s'il reste au corps-à-corps d'un combattant (allié ou ennemi). S'il s'éloigne et termine son tour isolé, il possède un malus à la place.",
+      "en": "The Masqueraider increases their damage and resistance abilities if they stay adjacent to a fighter (allied or enemy). If they move away and finish their turn in an isolated position, they have a penalty instead.",
+      "es": "El zobal gana capacidades de daños y de resistencias si se queda en el cuerpo a cuerpo de un combatiente (aliado o enemigo). Si se aleja y termina su turno apartado, posee un malus en su lugar.",
+      "pt": "O Zobal ganha nos quesitos danos e resistências quando fica à distância corpo a corpo de um combatente (aliado ou inimigo). Se ele se afastar e terminar seu turno isolado, ele ganhará uma penalidade em vez disso."
+    },
     "effectIds": [
       308096
     ],
@@ -6272,11 +8792,21 @@
   },
   {
     "spellId": 7111,
-    "name": "Art de la fuite",
+    "name": {
+      "fr": "Art de la fuite",
+      "en": "Artful Dodger",
+      "es": "Arte de la Huida",
+      "pt": "Arte da Fuga"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7111,
-    "description": "The Masqueraider gains ranged damage based on their Dodge.",
+    "description": {
+      "fr": "Le Zobal gagne en Dommages à distance en fonction de son esquive.",
+      "en": "The Masqueraider gains ranged damage based on their Dodge.",
+      "es": "El zobal gana daños a distancia en función de su esquiva.",
+      "pt": "O Zobal ganha em danos a distância em função de sua esquiva."
+    },
     "effectIds": [
       308171
     ],
@@ -6291,11 +8821,21 @@
   },
   {
     "spellId": 7112,
-    "name": "Regard masqué",
+    "name": {
+      "fr": "Regard masqué",
+      "en": "Masked Gaze",
+      "es": "Mirada Enmascarada",
+      "pt": "Olhar Mascarado"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 5359,
-    "description": "The Masqueraider gains mobility, but can no longer cast any spells on adjacent cells.",
+    "description": {
+      "fr": "Le Zobal gagne en mobilité, mais ne peut plus lancer le moindre sort à son contact.",
+      "en": "The Masqueraider gains mobility, but can no longer cast any spells on adjacent cells.",
+      "es": "El zobal gana movilidad, pero no puede lanzar el más mínimo hechizo en su zona de contacto.",
+      "pt": "O Zobal ganha mobilidade, mas não pode mais lançar nenhum feitiço no corpo a corpo."
+    },
     "effectIds": [
       308115
     ],
@@ -6324,11 +8864,21 @@
   },
   {
     "spellId": 7113,
-    "name": "Poussées d'entrave",
+    "name": {
+      "fr": "Poussées d'entrave",
+      "en": "Debuff Pushes",
+      "es": "Empujes de Traba",
+      "pt": "Empurrões de Entrave"
+    },
     "breedId": 14,
     "class": "ZOBAL",
     "gfxId": 7113,
-    "description": "Pushes that cause a collision remove MP instead of AP. Useful for Masqueraiders who want to reduce their opponents' mobility.",
+    "description": {
+      "fr": "Les poussées entraînant une collision retirent des PM. Utile pour les Zobals voulant réduire la mobilité de leurs adversaires.",
+      "en": "Any pushback causing a collision will reduce MP. Useful for Masqueraiders who want to reduce their opponents' mobility.",
+      "es": "Los empujes que conllevan una colisión retiran PM. Útil para los zobals que quieran reducir la movilidad de sus adversarios.",
+      "pt": "Empurrões que causam colisão retiram PM. Útil para os Zobais que quiserem reduzir a mobilidade dos adversários."
+    },
     "effectIds": [
       308117,
       308125,
@@ -6369,11 +8919,21 @@
   },
   {
     "spellId": 6271,
-    "name": "Terrier",
+    "name": {
+      "fr": "Terrier",
+      "en": "Burrow",
+      "es": "Cubil",
+      "pt": "Toca"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6271,
-    "description": "At end of turn, the Ouginak switches places with their Bow Wow. The Bow Wow then switches places with the Ouginak at the end of its turn.",
+    "description": {
+      "fr": "En fin de tour, l'Ouginak échange de position avec son chienchien. À son tour, le chienchien échange de position avec l'Ouginak à la fin de son tour.",
+      "en": "At end of turn, the Ouginak switches places with their Bow Wow. The Bow Wow then switches places with the Ouginak at the end of its turn.",
+      "es": "Al final del turno, el uginak intercambia posición con su wauwau. En su turno, el wauwau intercambia posición con el uginak al final de su turno.",
+      "pt": "No fim do turno do Kilorf, ele troca de lugar com seu Awaw. O Awaw também troca de lugar com o Kilorf no fim de seu turno."
+    },
     "effectIds": [
       340145
     ],
@@ -6388,11 +8948,21 @@
   },
   {
     "spellId": 6272,
-    "name": "Art Canin",
+    "name": {
+      "fr": "Art Canin",
+      "en": "Canine Art",
+      "es": "Arte Canino",
+      "pt": "Arte Canina"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6275,
-    "description": "The Ouginak steals part of the indirect damage they inflict and converts it to armor. This is damage done outside of their turn, such as poisons. In exchange, their damage is reduced. The armor obtained with Canine Art is limited to 50% of the Ouginak's max HP per turn.",
+    "description": {
+      "fr": "L'Ouginak vole une partie des dommages indirects qu'il inflige et les convertit en armure. Il s'agit des dommages effectués en dehors de son tour, comme les poisons. En contrepartie, ses dommages sont réduits. L'Armure obtenue par Art canin est limitée à 50 % des PV max de l'Ouginak par tour.",
+      "en": "The Ouginak steals part of the indirect damage they inflict and converts it to armor. This is damage done outside of their turn, such as poisons. In exchange, their damage is reduced. The armor obtained with Canine Art is limited to 50% of the Ouginak's max HP per turn.",
+      "es": "El uginak roba una parte de los daños indirectos que inflige y los convierte en armadura. Estos son los daños que se infligen fuera del turno, como los venenos. En contrapartida, sus daños se reducen. La armadura obtenida con Arte Canino está limitada al 50% de los PdV máx. del uginak por turno.",
+      "pt": "O Kilorf rouba parte dos danos indiretos que inflige e os converte em armadura. Trata-se de danos efetuados fora de seu turno, como os venenos. Em contrapartida, seus danos são reduzidos. A armadura obtida por Arte Canina é limitada a 50% dos PV máx. do Kilorf por turno."
+    },
     "effectIds": [
       340136,
       340142,
@@ -6425,11 +8995,21 @@
   },
   {
     "spellId": 6273,
-    "name": "Maître Chien",
+    "name": {
+      "fr": "Maître Chien",
+      "en": "Dog Handler",
+      "es": "Maestro Perrero",
+      "pt": "Mestre Cão"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6273,
-    "description": "The Bow Wow copies the Ouginak's actions. However, it can no longer cast spells.",
+    "description": {
+      "fr": "Le Chienchien reproduit les actions de l'Ouginak. En contrepartie, il ne peut plus lancer de sort.",
+      "en": "The Bow Wow copies the Ouginak's actions. However, it can no longer cast spells.",
+      "es": "El wauwau reproduce las acciones del uginak. A cambio, ya no puede lanzar hechizos.",
+      "pt": "O Awaw reproduz as ações do Kilorf. Em contrapartida, ele não pode mais lançar este feitiço."
+    },
     "effectIds": [
       341489
     ],
@@ -6444,11 +9024,21 @@
   },
   {
     "spellId": 6274,
-    "name": "Compagnon",
+    "name": {
+      "fr": "Compagnon",
+      "en": "Sidekick",
+      "es": "Compañero",
+      "pt": "Companheiro"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6274,
-    "description": "The Bow Wow is more resistant and has more AP. In exchange, it can no longer dodge. When it dies, the Ouginak regains 2 WP.",
+    "description": {
+      "fr": "Le Chienchien est plus résistant et possède plus de PA. En échange, il ne peut plus esquiver. À sa mort, l'Ouginak regagne 2 PW.",
+      "en": "The Bow Wow is more resistant and has more AP. In exchange, it can no longer dodge. When it dies, the Ouginak regains 2 WP.",
+      "es": "El wauwau es más resistente y posee más PA. Como contrapartida, no puede esquivar. Al morir, el uginak recobra 2 PW.",
+      "pt": "O Awaw fica mais resistente e tem mais PA. Em contrapartida, ele não pode mais esquivar. Quando ele morre, o Kilorf recupera 2 PW."
+    },
     "effectIds": [
       242504
     ],
@@ -6475,11 +9065,21 @@
   },
   {
     "spellId": 6275,
-    "name": "Ardeur",
+    "name": {
+      "fr": "Ardeur",
+      "en": "Ardor",
+      "es": "Ardor",
+      "pt": "Ímpeto"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7328,
-    "description": "The Ouginak's mobility is reduced, but they gain lots of damage-dealing power if they can finish their turn adjacent to their Prey.",
+    "description": {
+      "fr": "La mobilité de l'Ouginak est réduite, mais il gagne beaucoup de dommages s'il réussit à finir au contact de ses Proies.",
+      "en": "The Ouginak's mobility is reduced, but they gain lots of damage-dealing power if they can finish their turn adjacent to their Prey.",
+      "es": "El uginak reduce su movilidad, pero gana muchos daños si consigue acabar en contacto con sus presas.",
+      "pt": "A mobilidade do Kilorf é reduzida, mas ele ganha muitos danos se conseguir terminar em contato com suas Presas."
+    },
     "effectIds": [
       340104,
       340113,
@@ -6510,11 +9110,21 @@
   },
   {
     "spellId": 6276,
-    "name": "Epuisement",
+    "name": {
+      "fr": "Epuisement",
+      "en": "Exhaustion",
+      "es": "Agotamiento",
+      "pt": "Exaustão"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6276,
-    "description": "The Ouginak loses range, but their indirect damage increases. This is damage done outside of their turn, such as poisons.",
+    "description": {
+      "fr": "L'Ouginak perd de la portée, mais augmente ses dommages indirects. Il s'agit des dommages effectués en dehors de son tour, comme les poisons.",
+      "en": "The Ouginak loses range, but their indirect damage increases. This is damage done outside of their turn, such as poisons.",
+      "es": "El uginak pierde alcance, pero aumenta sus daños indirectos. Estos son los daños que se infligen fuera del turno, como los venenos.",
+      "pt": "O Kilorf perde Alcance, mas aumenta seus danos indiretos. Trata-se de danos efetuados fora de seu turno, como os venenos."
+    },
     "effectIds": [
       242686,
       340122
@@ -6553,11 +9163,21 @@
   },
   {
     "spellId": 6277,
-    "name": "Pillage",
+    "name": {
+      "fr": "Pillage",
+      "en": "Raiding",
+      "es": "Pillaje",
+      "pt": "Saque"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6277,
-    "description": "The Ouginak sacrifices damage in order to improve their ability to take a hit. They gain HP and armor received. They also gain armor at the start of their turn if adjacent to prey.",
+    "description": {
+      "fr": "L'Ouginak sacrifie des dommages dans le but de mieux encaisser les coups. Il gagne des PV et de l'armure reçue. En plus, il gagne de l'armure au début de son tour s'il est au contact d'une proie.",
+      "en": "The Ouginak sacrifices damage in order to improve their ability to take a hit. They gain HP and armor received. They also gain armor at the start of their turn if adjacent to prey.",
+      "es": "El uginak sacrifica daños para encajar mejor los golpes. Gana PdV y armadura recibida. Además, gana armadura al principio de su turno si está en contacto con una presa.",
+      "pt": "O Kilorf sacrifica danos com o intuito de suportar melhor os golpes. Ele ganha PV e armadura recebida. Além disso, ele ganha armadura no início do turno se estiver em contato com uma Presa."
+    },
     "effectIds": [
       293061,
       242627,
@@ -6591,11 +9211,21 @@
   },
   {
     "spellId": 6278,
-    "name": "Crocs Futés",
+    "name": {
+      "fr": "Crocs Futés",
+      "en": "Cunning Fang",
+      "es": "Colmillos Agudos",
+      "pt": "Presa Esperta"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6278,
-    "description": "The Ouginak gains Block to become more resistant. When it transforms into a Were-Ouginak, it converts its Block into Critical Hits to go on the attack.",
+    "description": {
+      "fr": "L'Ouginak gagne de la parade afin d'être plus résistant. Lorsqu'il passe en Ougigarou, il convertit sa parade en coup critique pour passer à l'attaque.",
+      "en": "The Ouginak gains Block to become more resistant. When it transforms into a Were-Ouginak, it converts its Block into Critical Hits to go on the attack.",
+      "es": "El uginak gana anticipación para volverse más resistente. Cuando se transforma en uginikántropo, convierte su anticipación en golpe crítico y pasa al ataque.",
+      "pt": "O Kilorf ganha Parada para ficar mais resistente. Quando vira Kilorfisomem, ele converte sua Parada em Golpe Crítico a fim de partir para o ataque."
+    },
     "effectIds": [
       340154,
       340155
@@ -6625,11 +9255,21 @@
   },
   {
     "spellId": 6279,
-    "name": "Flair",
+    "name": {
+      "fr": "Flair",
+      "en": "Sniff",
+      "es": "Olfacción",
+      "pt": "Faro"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6279,
-    "description": "The Ouginak's Prey are poisoned and take damage every turn.",
+    "description": {
+      "fr": "Les Proies de l'Ouginak sont empoisonnées et subissent des dommages tous les tours.",
+      "en": "The Ouginak's Prey are poisoned and take damage every turn.",
+      "es": "Las presas del uginak reciben un veneno y sufren daños en cada turno.",
+      "pt": "As Presas do Kilorf são envenenadas e sofrem danos em todos os turnos."
+    },
     "effectIds": [
       341038
     ],
@@ -6644,11 +9284,21 @@
   },
   {
     "spellId": 6280,
-    "name": "Marchandage",
+    "name": {
+      "fr": "Marchandage",
+      "en": "Haggling",
+      "es": "Regateo",
+      "pt": "Negociação"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6280,
-    "description": "The Ouginak gains resistance based on its Fury when it transforms into a Were-Ouginak. In exchange, it loses Fury at start of turn.",
+    "description": {
+      "fr": "L'Ouginak gagne des résistances en fonction de sa Rage lorsqu'il passe en Ougigarou. En contrepartie, il perd de la Rage en début de tour.",
+      "en": "The Ouginak gains resistance based on its Fury when it transforms into a Were-Ouginak. In exchange, it loses Fury at start of turn.",
+      "es": "El uginak gana resistencias en función de su rabia cuando se transforma en uginikántropo. En compensación, pierde rabia al principio del turno.",
+      "pt": "O Kilorf ganha resistências em função de sua Raiva quando vira Kilorfisomem. Em contrapartida, ele perde Raiva no começo do turno."
+    },
     "effectIds": [
       341023
     ],
@@ -6663,11 +9313,21 @@
   },
   {
     "spellId": 6281,
-    "name": "Pistage",
+    "name": {
+      "fr": "Pistage",
+      "en": "Tailing",
+      "es": "Busca",
+      "pt": "Busca"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 5103,
-    "description": "The Ouginak is more effective when attacking its targets from behind. To get there more easily, it gains mobility.",
+    "description": {
+      "fr": "L'Ouginak est plus efficace dans le dos de ses cibles. Pour y parvenir plus facilement, il gagne en mobilité.",
+      "en": "The Ouginak is more effective when attacking its targets from behind. To get there more easily, it gains mobility.",
+      "es": "El uginak es más eficaz atacando por la espalda a sus objetivos. Para que le sea más fácil lograrlo, gana movilidad.",
+      "pt": "O Kilorf é mais eficaz quando ataca os alvos pelas costas. Para fazê-lo mais facilmente, ele ganha mobilidade."
+    },
     "effectIds": [
       340123,
       341037
@@ -6697,11 +9357,21 @@
   },
   {
     "spellId": 6282,
-    "name": "Force sage",
+    "name": {
+      "fr": "Force sage",
+      "en": "Wise Strength",
+      "es": "Fuerza Sabia",
+      "pt": "Força Sábia"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7185,
-    "description": "MP removals are replaced by application of indirect damage on the target.",
+    "description": {
+      "fr": "Les retraits de PM sont remplacés par une application de dommages indirects sur la cible.",
+      "en": "MP removals are replaced by application of indirect damage on the target.",
+      "es": "Las retiradas de PM se cambian por daños indirectos al objetivo.",
+      "pt": "As retiradas de PM são substituídas por uma aplicação de danos indiretos ao alvo."
+    },
     "effectIds": [
       341041
     ],
@@ -6718,11 +9388,21 @@
   },
   {
     "spellId": 7553,
-    "name": "Acharné",
+    "name": {
+      "fr": "Acharné",
+      "en": "Relentless",
+      "es": "Acérrimo",
+      "pt": "Obstinado"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7193,
-    "description": "The Ouginak gains force of will to bind targets more easily. The Ouginak gains Fury each time they remove MP. In exchange, they lose damage inflicted.",
+    "description": {
+      "fr": "L'Ouginak gagne de la volonté afin d'entraver ses cibles plus facilement. Il gagne de la Rage à chaque fois qu'il retire des PM. En échange, il perd en dommages infligés.",
+      "en": "The Ouginak gains force of will to bind targets more easily. The Ouginak gains Fury each time they remove MP. In exchange, they lose damage inflicted.",
+      "es": "El uginak gana voluntad para trabar a sus objetivos con más facilidad. Gana rabia cada vez que retira PM. A cambio, pierde en daños infligidos.",
+      "pt": "O Kilorf ganha Vontade para entravar seus alvos mais facilmente. Ele ganha Raiva toda vez que retira PM. Em troca, ele perde danos infligidos."
+    },
     "effectIds": [
       340085,
       340091,
@@ -6764,11 +9444,21 @@
   },
   {
     "spellId": 7554,
-    "name": "Chasse ouverte",
+    "name": {
+      "fr": "Chasse ouverte",
+      "en": "Open Season",
+      "es": "Veda Abierta",
+      "pt": "Caçada Aberta"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7554,
-    "description": "The Ouginak gains Fury and damage upon attacking its Prey, but its maximum Fury decreases.",
+    "description": {
+      "fr": "L'Ouginak obtient de la Rage et des dommages dès qu'il attaque sa Proie, mais sa Rage maximum diminue.",
+      "en": "The Ouginak gains Fury and damage upon attacking its Prey, but its maximum Fury decreases.",
+      "es": "El uginak obtiene rabia y daños en cuanto ataca a su presa, pero su rabia máxima disminuye.",
+      "pt": "O Kilorf obtém Raiva e danos assim que ataca sua Presa, mas sua Raiva máxima diminui."
+    },
     "effectIds": [
       341032,
       345698
@@ -6784,11 +9474,21 @@
   },
   {
     "spellId": 7555,
-    "name": "Digestion",
+    "name": {
+      "fr": "Digestion",
+      "en": "Digestion",
+      "es": "Digestión",
+      "pt": "Digestão"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 6272,
-    "description": "The Ouginak gains Fury and heals themself when they do indirect damage; this is damage done outside of their turn, such as poisons. In exchange, they sacrifice some of their damage.",
+    "description": {
+      "fr": "L'Ouginak gagne de la Rage et se soigne lorsqu'il inflige des dommages indirects : il s'agit des dommages effectués en dehors de son tour, comme les poisons. En contrepartie, il sacrifie une partie de ses dommages.",
+      "en": "The Ouginak gains Fury and heals themself when they do indirect damage; this is damage done outside of their turn, such as poisons. In exchange, they sacrifice some of their damage.",
+      "es": "El uginak gana rabia y se cura cuando inflige daños indirectos; estos son los daños que se infligen fuera del turno, como los venenos. En contrapartida, sacrifica una parte de sus daños.",
+      "pt": "O Kilorf ganha Raiva e se cura quando inflige danos indiretos: trata-se de danos efetuados fora de seu turno, como os venenos. Em contrapartida, ele sacrifica uma parte de seus danos."
+    },
     "effectIds": [
       340098,
       340099
@@ -6829,11 +9529,21 @@
   },
   {
     "spellId": 7556,
-    "name": "Énergie Canine",
+    "name": {
+      "fr": "Énergie Canine",
+      "en": "Canine Energy",
+      "es": "Energía Canina",
+      "pt": "Energia Canina"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7343,
-    "description": "The Ouginak has more max WP, but their damage bonus in Were-Ouginak form is reduced.",
+    "description": {
+      "fr": "L'Ouginak possède plus de PW max, mais son bonus de dommages en Ougigarou est réduit.",
+      "en": "The Ouginak has more max WP, but their damage bonus in Were-Ouginak form is reduced.",
+      "es": "El uginak cuenta con más PW máximos, pero se reduce su bonus de daños como uginikántropo.",
+      "pt": "O Kilorf tem mais PW máx., mas seu bônus de danos enquanto Kilorfisomem é reduzido."
+    },
     "effectIds": [
       340101,
       340112
@@ -6863,11 +9573,21 @@
   },
   {
     "spellId": 7557,
-    "name": "Fureur",
+    "name": {
+      "fr": "Fureur",
+      "en": "Fury",
+      "es": "Furor",
+      "pt": "Furor"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7557,
-    "description": "The Ouginak has greater maximum Fury. In exchange, their max WP decreases.",
+    "description": {
+      "fr": "L'Ouginak possède plus de Rage maximum. En contrepartie, il perd des PW max.",
+      "en": "The Ouginak has greater maximum Fury. In exchange, their max WP decreases.",
+      "es": "El uginak cuenta con más rabia máxima. A cambio, pierde PW máx.",
+      "pt": "O Kilorf possui mais Raiva máxima. Em contrapartida, ele perde PW máx."
+    },
     "effectIds": [
       340117,
       345699,
@@ -6896,11 +9616,21 @@
   },
   {
     "spellId": 7558,
-    "name": "Traqueur Canin",
+    "name": {
+      "fr": "Traqueur Canin",
+      "en": "Canine Tracker",
+      "es": "Rastreador Canino",
+      "pt": "Rastreador Canino"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7558,
-    "description": "The Ouginak converts damage into resistance when it ends its turn in contact with Prey.",
+    "description": {
+      "fr": "L'Ouginak convertit des dommages en résistance lorsqu'il finit au contact d'une Proie.",
+      "en": "The Ouginak converts damage into resistance when it ends its turn in contact with Prey.",
+      "es": "El uginak convierte daños en resistencia cuando termina en contacto con una presa.",
+      "pt": "O Kilorf converte danos em resistência quando termina em contato com uma Presa."
+    },
     "effectIds": [
       340176,
       340158
@@ -6918,11 +9648,21 @@
   },
   {
     "spellId": 7596,
-    "name": "Canin'Os",
+    "name": {
+      "fr": "Canin'Os",
+      "en": "Growlight",
+      "es": "Sa Hueso",
+      "pt": "Caninosso"
+    },
     "breedId": 15,
     "class": "OUGINAK",
     "gfxId": 7596,
-    "description": "The Ouginak gains lock. When it transforms into a Were-Ouginak, its lock is converted to dodge.",
+    "description": {
+      "fr": "L'Ouginak gagne du tacle. Lorsqu'il passe en Ougigarou, son tacle est converti en esquive.",
+      "en": "The Ouginak gains lock. When it transforms into a Were-Ouginak, its lock is converted to dodge.",
+      "es": "El uginak gana placaje. Cuando se transforma en uginikántropo, su placaje se convierte en esquiva.",
+      "pt": "O Kilorf ganha Esquiva. Quando ele vira Kilorfisomem, seu Bloqueio é convertido em Esquiva."
+    },
     "effectIds": [
       341024
     ],
@@ -6949,11 +9689,21 @@
   },
   {
     "spellId": 6925,
-    "name": "Modérateur d'énergie",
+    "name": {
+      "fr": "Modérateur d'énergie",
+      "en": "Energy Moderator",
+      "es": "Moderador de Energía",
+      "pt": "Moderador de Energia"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6931,
-    "description": "The Foggernaut gains an MP and Range bonus at start of their turn if they are at full WP.",
+    "description": {
+      "fr": "Le Steamer gagne un bonus de PM et de Portée au début de son tour s'il possède tous ses PW.",
+      "en": "The Foggernaut gains an MP and Range bonus at start of their turn if they are at full WP.",
+      "es": "El steamer gana un bonus de PM y de AL al principio de su turno si tiene todos sus PW.",
+      "pt": "O Steamer ganha um bônus de PM e AL no começo do turno se tiver todos os seus PW."
+    },
     "effectIds": [
       344474
     ],
@@ -6993,11 +9743,21 @@
   },
   {
     "spellId": 6926,
-    "name": "Routes sinueuses",
+    "name": {
+      "fr": "Routes sinueuses",
+      "en": "Winding Roads",
+      "es": "Caminos Tortuosos",
+      "pt": "Estradas Sinuosas"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 2817,
-    "description": "The Foggernaut can place more microbots each turn. In exchange, the maximum length of rails (between two microbots) decreases.",
+    "description": {
+      "fr": "Le Steamer peut poser plus de microbots chaque tour. En échange, la taille maximale des rails (entre deux microbots) diminue.",
+      "en": "The Foggernaut can place more microbots each turn. In exchange, the maximum length of rails (between two microbots) decreases.",
+      "es": "El steamer puede colocar más microbots cada turno. A cambio, el tamaño máximo de los rieles (entre dos microbots) se reduce.",
+      "pt": "O Steamer pode colocar mais Microbots a cada turno. Em troca, o tamanho máximo dos trilhos (entre dois Microbots) diminui."
+    },
     "effectIds": [
       297815
     ],
@@ -7012,11 +9772,21 @@
   },
   {
     "spellId": 6927,
-    "name": "Versatilité",
+    "name": {
+      "fr": "Versatilité",
+      "en": "Versatility",
+      "es": "Versatilidad",
+      "pt": "Versatilidade"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 4689,
-    "description": "The Foggernaut gains end-of-turn bonuses based on their positioning.",
+    "description": {
+      "fr": "Le Steamer gagne des bonus en fin de tour selon son positionnement.",
+      "en": "The Foggernaut gains end-of-turn bonuses based on their positioning.",
+      "es": "El steamer gana bonus al final del turno según su posicionamiento.",
+      "pt": "O Steamer ganha bônus no fim do turno de acordo com seu posicionamento."
+    },
     "effectIds": [
       343946
     ],
@@ -7034,11 +9804,21 @@
   },
   {
     "spellId": 6928,
-    "name": "Blindage renforcé",
+    "name": {
+      "fr": "Blindage renforcé",
+      "en": "Reinforced Armor Plating",
+      "es": "Blindaje Reforzado",
+      "pt": "Blindagem Reforçada"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6691,
-    "description": "The turret is more resistant to damage. In exchange, the Foggernaut can only place it at a range of up to 3 cells max, rather than 6.",
+    "description": {
+      "fr": "La tourelle est plus résistante. En contrepartie, le Steamer ne peut la poser qu'à 3 cases max au lieu de 6.",
+      "en": "The turret is more resistant to damage. In exchange, the Foggernaut can only place it at a range of up to 3 cells max, rather than 6.",
+      "es": "La torreta es más resistente. Pero el steamer solo puede ponerla a 3 casillas como máximo, y no a 6.",
+      "pt": "A torre fica mais resistente. Em compensação, o Steamer só pode colocá-la a até 3 células em vez de 6."
+    },
     "effectIds": [
       343974
     ],
@@ -7053,11 +9833,21 @@
   },
   {
     "spellId": 6929,
-    "name": "Stratégie robotique",
+    "name": {
+      "fr": "Stratégie robotique",
+      "en": "Robotic Strategy",
+      "es": "Estrategia Robótica",
+      "pt": "Estratégia Robótica"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 5462,
-    "description": "The Foggernaut steals HP when their Turret inflicts damage, in exchange for part of their indirect damage.",
+    "description": {
+      "fr": "Le Steamer vole de la vie lorsque sa Tourelle inflige des dommages en échange d'une partie de ses dommages indirects.",
+      "en": "The Foggernaut steals HP when their Turret inflicts damage, in exchange for part of their indirect damage.",
+      "es": "El steamer roba vida cuando su torreta inflige daños, a cambio de una parte de sus daños indirectos.",
+      "pt": "O Steamer rouba vida quando sua Torre inflige danos em troca de uma parte de seus danos indiretos."
+    },
     "effectIds": [
       346193,
       351785
@@ -7096,11 +9886,21 @@
   },
   {
     "spellId": 6930,
-    "name": "Technologie de transports",
+    "name": {
+      "fr": "Technologie de transports",
+      "en": "Transportation Technology",
+      "es": "Tecnología de Transportes",
+      "pt": "Tecnologia de Transportes"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6930,
-    "description": "Microbot cost decreases. In exchange, the maximum range is reduced to 3.",
+    "description": {
+      "fr": "Le coût des Microbots diminue. En contrepartie, la portée est réduite à 3 maximum.",
+      "en": "Microbot cost decreases. In exchange, the maximum range is reduced to 3.",
+      "es": "El coste de los microbots se reduce. Como contrapartida, el alcance se reduce a 3 como máximo.",
+      "pt": "O custo dos Microbots diminui. Em contrapartida, o alcance é reduzido a no máximo 3."
+    },
     "effectIds": [
       298007
     ],
@@ -7115,11 +9915,21 @@
   },
   {
     "spellId": 6931,
-    "name": "Assistance tellurique",
+    "name": {
+      "fr": "Assistance tellurique",
+      "en": "Earthy Assistance",
+      "es": "Asistencia Telúrica",
+      "pt": "Assistência Telúrica"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 2816,
-    "description": "The Foggernaut summons blocks when casting an Earth spell on an empty cell. These blocks protect nearby allies. Blocks' protection zones cannot overlap.",
+    "description": {
+      "fr": "Le Steamer invoque des blocs lorsqu'il lance un sort terre sur une cellule vide. Ces blocs protègent les alliés à proximité. Les zones de protection des blocs ne peuvent pas se superposer.",
+      "en": "The Foggernaut summons blocks when casting an Earth spell on an empty cell. These blocks protect nearby allies. Blocks' protection zones cannot overlap.",
+      "es": "El steamer invoca bloques cuando lanza un hechizo de tierra en una casilla vacía. Estos bloques protegen a los aliados cercanos. Las zonas de protección de los bloques no pueden superponerse.",
+      "pt": "O Steamer invoca blocos quando lança um feitiço de terra em uma célula vazia. Esses blocos protegem os aliados mais próximos. As zonas de proteção dos blocos não podem se sobrepor."
+    },
     "effectIds": [
       344157,
       344217,
@@ -7150,11 +9960,21 @@
   },
   {
     "spellId": 6932,
-    "name": "Substitution mécanique",
+    "name": {
+      "fr": "Substitution mécanique",
+      "en": "Mechanical Substitution",
+      "es": "Sustitución Mecánica",
+      "pt": "Substituição Mecânica"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 5461,
-    "description": "The turret applies additional effects when the Foggernaut casts an Earth or Water spell on it. The first time an effect is triggered during the turn, the Foggernaut recovers AP. In exchange, summoning or upgrading the Turret costs 1 WP.",
+    "description": {
+      "fr": "La tourelle joue des effets supplémentaires lorsque le Steamer lance un sort terre ou eau dessus. La première fois qu'un effet est déclenché dans le tour, le Steamer regagne des PA. En contrepartie, invoquer ou améliorer la Tourelle coûte 1 PW.",
+      "en": "The turret applies additional effects when the Foggernaut casts an Earth or Water spell on it. The first time an effect is triggered during the turn, the Foggernaut recovers AP. In exchange, summoning or upgrading the Turret costs 1 WP.",
+      "es": "La torreta tiene efectos adicionales cuando el steamer lanza un hechizo de tierra o de agua sobre ella. La primera vez que se activa un efecto en el turno, el steamer recupera PA. En contrapartida, invocar o mejorar la torreta cuesta 1 PW.",
+      "pt": "A torre aplica efeitos adicionais quando o Steamer lança um feitiço de terra ou água nela. Na primeira vez que um efeito for acionado no turno, o Steamer ganhará PA. Em compensação, invocar ou melhorar a Torre custa 1 PW."
+    },
     "effectIds": [
       297895
     ],
@@ -7171,11 +9991,21 @@
   },
   {
     "spellId": 6933,
-    "name": "Patience",
+    "name": {
+      "fr": "Patience",
+      "en": "Patience",
+      "es": "Paciencia",
+      "pt": "Paciência"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6939,
-    "description": "The Foggernaut instantly gains 2 non-regenerable Stasis points (SP) on reaching their maximum SP. They can therefore temporarily exceed their maximum SP. In exchange, their max WP decreases at the start of the fight.",
+    "description": {
+      "fr": "Le Steamer gagne instantanément deux Points de Stasis (PS) non-régénérables lorsqu'il atteint son maximum de PS. Il peut ainsi dépasser son nombre maximum de PS temporairement. En contrepartie, il perd des PW max en début de combat.",
+      "en": "The Foggernaut instantly gains 2 non-regenerable Stasis points (SP) on reaching their maximum SP. They can therefore temporarily exceed their maximum SP. In exchange, their max WP decreases at the start of the fight.",
+      "es": "El steamer gana instantáneamente dos puntos de Stasis (PS) no regenerables cuando alcanza su máximo de PS. De esta forma, puede superar su número máximo de PS temporalmente. A cambio, pierde PW máx. al principio del combate.",
+      "pt": "O Steamer ganha instantaneamente dois pontos de Stasis (PS) não regeneráveis ao atingir o máximo de PS. Assim, ele pode ultrapassar temporariamente sua quantidade máxima de PS. Em contrapartida, perde PW máx. no início do combate."
+    },
     "effectIds": [
       395986,
       343859
@@ -7227,11 +10057,21 @@
   },
   {
     "spellId": 6934,
-    "name": "Alliage léger",
+    "name": {
+      "fr": "Alliage léger",
+      "en": "Light Alloy",
+      "es": "Aleación Ligera",
+      "pt": "Liga Leve"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 2819,
-    "description": "Reduces the Foggernaut's movement ability while increasing their positioning ability with their rails.",
+    "description": {
+      "fr": "Réduit la capacité de déplacement du Steamer au profit de sa capacité de placement avec ses rails.",
+      "en": "Reduces the Foggernaut's movement ability while increasing their positioning ability with their rails.",
+      "es": "Reduce la capacidad de desplazamiento del steamer en beneficio de su capacidad de posicionamiento con sus rieles.",
+      "pt": "Reduz a capacidade de deslocamento do Steamer, mas aumenta sua capacidade de posicionamento com seus trilhos."
+    },
     "effectIds": [
       297884
     ],
@@ -7258,11 +10098,21 @@
   },
   {
     "spellId": 6935,
-    "name": "Inversion d'énergie",
+    "name": {
+      "fr": "Inversion d'énergie",
+      "en": "Energy Inversion",
+      "es": "Inversión de Energía",
+      "pt": "Inversão de Energia"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 4300,
-    "description": "The Foggernaut inverts their Wakfu Point and Stasis Point regeneration. They now naturally recover 1 SP at end of turn, and their Turret regenerates WP for them.",
+    "description": {
+      "fr": "Le Steamer inverse sa régénération de Point de Wakfu et Point de Stasis. Il regagne alors naturellement 1 PS en fin de tour, et sa Tourelle lui régénère des PW.",
+      "en": "The Foggernaut inverts their Wakfu Point and Stasis Point regeneration. They now naturally recover 1 SP at end of turn, and their Turret regenerates WP for them.",
+      "es": "El steamer invierte su regeneración de puntos de Wakfu y puntos de Stasis. Recupera de forma natural 1 PS al final del turno, y su torreta le regenera PW.",
+      "pt": "O Steamer inverte sua regeneração de pontos de Wakfu e pontos de Stasis. Sendo assim, ele ganha naturalmente 1 PS no fim do turno, e sua torre gera PW para ele."
+    },
     "effectIds": [
       344043
     ],
@@ -7277,11 +10127,21 @@
   },
   {
     "spellId": 6936,
-    "name": "Revêtement à toute épreuve",
+    "name": {
+      "fr": "Revêtement à toute épreuve",
+      "en": "Heavy Duty Covering",
+      "es": "Revestimiento Absoluto",
+      "pt": "Revestimento a Toda Prova"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 7344,
-    "description": "The Foggernaut gains HP. In exchange, Fogginator inflicts heavy damage on them at end of turn.",
+    "description": {
+      "fr": "Le Steamer gagne des PV. En échange, Steamerator lui inflige de lourds dommages en fin de tour.",
+      "en": "The Foggernaut gains HP. In exchange, Fogginator inflicts heavy damage on them at end of turn.",
+      "es": "El steamer gana PdV. A cambio, el steamerator le inflige grandes daños al final del turno.",
+      "pt": "O Steamer ganha PV. Em troca, Steamerador inflige grandes danos a ele no fim do turno."
+    },
     "effectIds": [
       344011,
       344429
@@ -7320,11 +10180,21 @@
   },
   {
     "spellId": 6937,
-    "name": "Activation",
+    "name": {
+      "fr": "Activation",
+      "en": "Activation",
+      "es": "Activación",
+      "pt": "Ativação"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 5456,
-    "description": "The Foggernaut can use the Turret spell on targets. The effect depends on the Turret's active element. If it is Fire, the Turret deals damage to the target. If it is Water, it switches places with the target. If it is Earth, it applies Armor to the target. The effects are boosted if the spell gets a critical hit.",
+    "description": {
+      "fr": "Le Steamer peut utiliser le sort Tourelle sur des cibles. L'effet dépend de l'élément actif de la Tourelle : Feu, la Tourelle inflige des dommages à la cible. Eau, elle échange de position avec. Terre, elle applique de l'Armure à la cible. Les effets sont augmentés en cas de Coup critique.",
+      "en": "The Foggernaut can use the Turret spell on targets. The effect depends on the Turret's active element. If it is Fire, the Turret deals damage to the target. If it is Water, it switches places with the target. If it is Earth, it applies Armor to the target. The effects are boosted if the spell gets a critical hit.",
+      "es": "El steamer puede utilizar el hechizo Torreta en los objetivos. El efecto depende del elemento activo de la torreta: por ejemplo, fuego, la torreta inflige daños al objetivo. Agua, cambia de posición con el objetivo. Tierra, aplica armadura al objetivo. Los efectos aumentan en caso de golpe crítico.",
+      "pt": "O Steamer pode usar o feitiço Torre sobre os alvos. O efeito depende do elemento ativo da Torre: Fogo, a Torre inflige danos ao alvo. Água, ela troca de lugar com ele. Terra, ela aplica Armadura ao alvo. Os efeitos aumentam em caso de Golpe Crítico."
+    },
     "effectIds": [
       343999
     ],
@@ -7339,11 +10209,21 @@
   },
   {
     "spellId": 6938,
-    "name": "Exécution immédiate",
+    "name": {
+      "fr": "Exécution immédiate",
+      "en": "Immediate Execution",
+      "es": "Ejecución Inmediata",
+      "pt": "Execução Imediata"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6925,
-    "description": "The Foggernaut's Turret is no longer automatically triggered at end of turn. Instead, the Foggernaut can trigger it manually.",
+    "description": {
+      "fr": "La Tourelle du Steamer ne se déclenche plus automatiquement en fin de tour. À la place, le Steamer peut la déclencher manuellement.",
+      "en": "The Foggernaut's Turret is no longer automatically triggered at end of turn. Instead, the Foggernaut can trigger it manually.",
+      "es": "La torreta del steamer ya no se activa automáticamente al final del turno. En su lugar, el steamer puede activarla manualmente.",
+      "pt": "A Torre do Steamer não é mais acionada automaticamente no fim do turno. Em vez disso, o Steamer pode acioná-la manualmente."
+    },
     "effectIds": [
       344024,
       395182,
@@ -7360,11 +10240,21 @@
   },
   {
     "spellId": 6939,
-    "name": "Protection stasifiée",
+    "name": {
+      "fr": "Protection stasifiée",
+      "en": "Stasified Protection",
+      "es": "Protección Stasiada",
+      "pt": "Proteção Estasificada"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 2820,
-    "description": "Leftover SP (after the first one) generated by the Turret are converted into Armor.",
+    "description": {
+      "fr": "Les PS supplémentaires (au-delà du premier) générés par la Tourelle sont transformés en Armure.",
+      "en": "Leftover SP (after the first one) generated by the Turret are converted into Armor.",
+      "es": "Los PS adicionales (más allá del primero) generados por la Torreta se transforman en armadura.",
+      "pt": "Os PS adicionais (além do primeiro) gerados pela Torre são transformados em Armadura."
+    },
     "effectIds": [
       344040
     ],
@@ -7379,11 +10269,21 @@
   },
   {
     "spellId": 6940,
-    "name": "Roues chaudes",
+    "name": {
+      "fr": "Roues chaudes",
+      "en": "Hot Wheels",
+      "es": "Ruedas Calientes",
+      "pt": "Rodas Quentes"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 6933,
-    "description": "The Foggernaut's rails inflict damage on enemies who start or end their turn on them, but Microbots cost 1 SP.",
+    "description": {
+      "fr": "Les rails du Steamer infligent des dommages aux ennemis qui commencent ou finissent leur tour dessus, mais les Microbots coûtent 1 PS.",
+      "en": "The Foggernaut's rails inflict damage on enemies who start or end their turn on them, but Microbots cost 1 SP.",
+      "es": "Los rieles del steamer infligen daños a los enemigos que empiezan o terminan su turno encima, pero los microbots cuestan 1 PS.",
+      "pt": "Os trilhos do Steamer infligem danos aos inimigos que começam ou terminam seu turno sobre eles, mas os Microbots custam 1 PS."
+    },
     "effectIds": [
       343996,
       395004
@@ -7402,11 +10302,21 @@
   },
   {
     "spellId": 6941,
-    "name": "Conquête sereine",
+    "name": {
+      "fr": "Conquête sereine",
+      "en": "Serene Conquest",
+      "es": "Conquista Serena",
+      "pt": "Conquista Serena"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 5245,
-    "description": "The Foggernaut gains an increased Block chance. In exchange, they lose max SP at the start of the fight.",
+    "description": {
+      "fr": "Le Steamer gagne des chances de Parade. En échange, il perd des PS max au début du combat.",
+      "en": "The Foggernaut gains an increased Block chance. In exchange, they lose max SP at the start of the fight.",
+      "es": "El steamer gana probabilidades de anticipación. A cambio, pierde puntos de Stasis al principio del combate.",
+      "pt": "O Steamer ganha chances de Parada. Em troca, ele perde PS máx. no começo do combate."
+    },
     "effectIds": [
       344026,
       344140
@@ -7436,11 +10346,21 @@
   },
   {
     "spellId": 6942,
-    "name": "Tacticien",
+    "name": {
+      "fr": "Bidouillage",
+      "en": "Tinkering",
+      "es": "Chapuza",
+      "pt": "Gambiarra"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 5351,
-    "description": "The turret gains additional effects at the expense of its damage.",
+    "description": {
+      "fr": "La tourelle gagne des effets supplémentaires au détriment de ses dommages.",
+      "en": "The turret gains additional effects at the expense of its damage.",
+      "es": "La torreta gana efectos adicionales en detrimento de sus daños.",
+      "pt": "A torre ganha efeitos adicionais em detrimento de seus danos."
+    },
     "effectIds": [
       344030
     ],
@@ -7455,11 +10375,21 @@
   },
   {
     "spellId": 6943,
-    "name": "Mécanique avancée",
+    "name": {
+      "fr": "Mécanique avancée",
+      "en": "Advanced Mechanics",
+      "es": "Mecánica Avanzada",
+      "pt": "Mecânica Avançada"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 7181,
-    "description": "The Foggernaut can summon two turrets in exchange for some of their direct damage inflicted.",
+    "description": {
+      "fr": "Le Steamer peut invoquer deux tourelles en échange d'une partie de ses dommages directs infligés.",
+      "en": "The Foggernaut can summon two turrets in exchange for some of their direct damage inflicted.",
+      "es": "El steamer puede invocar dos torretas a cambio de una parte de sus daños directos infligidos.",
+      "pt": "O Steamer pode invocar duas torres em troca de parte de seus danos diretos infligidos."
+    },
     "effectIds": [
       344028
     ],
@@ -7474,11 +10404,21 @@
   },
   {
     "spellId": 7810,
-    "name": "Déploiement tactique",
+    "name": {
+      "fr": "Déploiement tactique",
+      "en": "Tactical Deployment",
+      "es": "Despliegue Táctico",
+      "pt": "Acionamento Tático"
+    },
     "breedId": 16,
     "class": "STEAMER",
     "gfxId": 7107,
-    "description": "The Foggernaut can place their Turret without line of sight, but only in a straight line.",
+    "description": {
+      "fr": "Le Steamer peut poser sa Tourelle sans ligne de vue mais seulement en ligne.",
+      "en": "The Foggernaut can place their Turret without line of sight, but only in a straight line.",
+      "es": "El steamer puede poner su torreta sin línea de visión, pero solo en línea.",
+      "pt": "O Steamer pode colocar sua Torre sem linha de visão, mas somente em linha reta."
+    },
     "effectIds": [
       350970,
       395005
@@ -7494,11 +10434,21 @@
   },
   {
     "spellId": 4686,
-    "name": "Rage",
+    "name": {
+      "fr": "Rage",
+      "en": "Fury",
+      "es": "Rabia",
+      "pt": "Raiva"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 4686,
-    "description": "The Eliotrope gains Celestial Gift instantly after casting the Celestial Portal spell. However, the AP bonus from Celestial Gift maxes out at 1 time per turn.",
+    "description": {
+      "fr": "L'Eliotrope obtient le Don céleste instantanément après avoir lancé le sort Portail céleste. Par contre, le bonus de PA de Don céleste est limité à 1 fois par tour.",
+      "en": "The Eliotrope gains Celestial Gift instantly after casting the Celestial Portal spell. However, the AP bonus from Celestial Gift maxes out at 1 time per turn.",
+      "es": "El selotrop obtiene don celestial al momento después de lanzar el hechizo Portal Celestial. Pero el bonus de PA de Don Celestial está limitado a 1 vez por turno.",
+      "pt": "O Eliotrope obtém a Dádiva Celeste instantaneamente depois de lançar o feitiço Portal Celeste. Porém, o bônus de PA da Dádiva Celeste fica limitado a 1 vez por turno."
+    },
     "effectIds": [
       351059,
       395945
@@ -7528,11 +10478,21 @@
   },
   {
     "spellId": 4687,
-    "name": "Traquenard",
+    "name": {
+      "fr": "Traquenard",
+      "en": "Trapster",
+      "es": "Celada",
+      "pt": "Cilada"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 4687,
-    "description": "Celestial Gift provides a very high damage bonus, but only if the target has its back to the Eliotrope.",
+    "description": {
+      "fr": "Le Don céleste offre un bonus de dommages très élevés, mais seulement si la cible est de dos.",
+      "en": "Celestial Gift provides a very high damage bonus, but only if the target has its back to the Eliotrope.",
+      "es": "Don Celestial ofrece un bonus de daños muy elevado, pero solo si el objetivo está de espaldas.",
+      "pt": "A Dádiva Celeste oferece um bônus de danos muito alto, mas somente se o alvo estiver de costas."
+    },
     "effectIds": [
       351733
     ],
@@ -7547,11 +10507,21 @@
   },
   {
     "spellId": 4688,
-    "name": "Effervescence",
+    "name": {
+      "fr": "Effervescence",
+      "en": "Effervescence",
+      "es": "Efervescencia",
+      "pt": "Efervescência"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 7185,
-    "description": "This passive allows the Eliotrope to deal much greater damage with their next spell after changing modes. In exchange, the damage bonus from Calm lasts only one turn.",
+    "description": {
+      "fr": "Ce passif permet à l'Eliotrope d'obtenir un gain conséquent de Dommages infligés pour son prochain sort après avoir changé de mode. En contrepartie, le bonus de dommages de Serein ne dure qu'un seul tour.",
+      "en": "This passive allows the Eliotrope to deal much greater damage with their next spell after changing modes. In exchange, the damage bonus from Calm lasts only one turn.",
+      "es": "Este pasivo permite al selotrop obtener una ganancia considerable de daños infligidos para su próximo hechizo tras haber cambiado de modo. A cambio, el bonus de daños de sereno solo dura un turno.",
+      "pt": "Este passivo permite que o Eliotrope obtenha um ganho considerável de danos infligidos em seu próximo feitiço depois de ter trocado de modo. Porém, os bônus de danos de Sereno durarão apenas um turno."
+    },
     "effectIds": [
       316455
     ],
@@ -7566,11 +10536,21 @@
   },
   {
     "spellId": 4689,
-    "name": "Intermédiaire",
+    "name": {
+      "fr": "Intermédiaire",
+      "en": "Medium",
+      "es": "Medio",
+      "pt": "Intermediário"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 4689,
-    "description": "Celestial Portal no longer costs AP to cast, but Celestial Gift gives an MP bonus instead of an AP bonus.",
+    "description": {
+      "fr": "Portail céleste ne coûte plus de PA à lancer mais Don céleste donne un bonus de PM au lieu d'un bonus de PA.",
+      "en": "Celestial Portal no longer costs AP to cast, but Celestial Gift gives an MP bonus instead of an AP bonus.",
+      "es": "Lanzar Portal Celestial ya no cuesta PA, pero don celestial da un bonus de PM en vez de un bonus de PA.",
+      "pt": "Portal Celeste não custa mais PA para ser lançado, mas Dádiva Celeste concede um bônus de PM em vez de um bônus de PA."
+    },
     "effectIds": [
       351378,
       395960
@@ -7586,11 +10566,21 @@
   },
   {
     "spellId": 4690,
-    "name": "Résilience",
+    "name": {
+      "fr": "Résilience",
+      "en": "Resilience",
+      "es": "Resiliencia",
+      "pt": "Resiliência"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 4690,
-    "description": "The Eliotrope no longer recovers WP upon gaining Celestial Gift. Instead, they gain Armor to absorb incoming attacks.",
+    "description": {
+      "fr": "L'Eliotrope ne regagne plus de PW en obtenant le Don céleste. À la place, il gagne de l'Armure pour absorber les coups adverses.",
+      "en": "The Eliotrope no longer recovers WP upon gaining Celestial Gift. Instead, they gain Armor to absorb incoming attacks.",
+      "es": "El selotrop ya no recupera PW al obtener don celestial. En su lugar, gana armadura para absorber los ataques rivales.",
+      "pt": "O Eliotrope não ganha mais PW ao obter a Dádiva Celeste. Em vez disso, ele ganha armadura para absorver os golpes dos adversários."
+    },
     "effectIds": [
       351727,
       395941
@@ -7606,11 +10596,21 @@
   },
   {
     "spellId": 5056,
-    "name": "Disciple du portail",
+    "name": {
+      "fr": "Disciple du portail",
+      "en": "Portal Disciple",
+      "es": "Discípulo del Portal",
+      "pt": "Discípulo do Portal"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5348,
-    "description": "This passive allows the Eliotrope to create a temporary portal under them when they cast the Exaltation spell. The portal can exceed the limit of 4, but it cannot be moved and will disappear at the end of the turn. In exchange, the Eliotrope can no longer use the Portal spell until the end of their turn.",
+    "description": {
+      "fr": "Ce passif permet à l'Eliotrope de créer un portail temporaire sous sa position lorsqu'il lance le sort Exaltation. Ce portail peut dépasser la limite de 4, mais il ne peut pas être déplacé et il disparaît en fin de tour. En contrepartie, l'Eliotrope ne pourra plus utiliser le sort Portail jusqu'à la fin de son tour.",
+      "en": "This passive allows the Eliotrope to create a temporary portal under them when they cast the Exaltation spell. The portal can exceed the limit of 4, but it cannot be moved and will disappear at the end of the turn. In exchange, the Eliotrope can no longer use the Portal spell until the end of their turn.",
+      "es": "Este pasivo permite al selotrop crear un portal temporal bajo su posición cuando lanza el hechizo Exaltación. Este portal puede superar el límite de 4, pero no puede desplazarse y desaparece al final del turno. A cambio, el selotrop ya no podrá utilizar el hechizo Portal hasta el final de su turno.",
+      "pt": "Este passivo permite que o Eliotrope crie um portal temporário sob sua posição quando ele lança o feitiço Exaltação. Este portal pode ultrapassar o limite de 4, mas não pode ser deslocado e desaparece no fim do turno. Porém, o Eliotrope não poderá mais utilizar o feitiço Portal até o turno acabar."
+    },
     "effectIds": [
       346504,
       346507
@@ -7628,11 +10628,21 @@
   },
   {
     "spellId": 5131,
-    "name": "Transitoire",
+    "name": {
+      "fr": "Transitoire",
+      "en": "Transitory",
+      "es": "Transitorio",
+      "pt": "Transitório"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5352,
-    "description": "If the Eliotrope or an ally goes through a Portal, they gain MP for the current turn. In exchange, they can no longer use portals to move until the following turn. This passive applies to all of the team's portals.",
+    "description": {
+      "fr": "Si l'Eliotrope ou un allié emprunte un Portail, il gagne des PM pour le tour en cours. En contrepartie, il ne peut plus utiliser de portails pour se déplacer jusqu'au tour suivant. Ce passif s'applique à tous les portails de l'équipe.",
+      "en": "If the Eliotrope or an ally goes through a Portal, they gain MP for the current turn. In exchange, they can no longer use portals to move until the following turn. This passive applies to all of the team's portals.",
+      "es": "Si el selotrop o un aliado toma un portal, gana PM durante el turno en curso. A cambio, ya no puede utilizar portales para desplazarse hasta el siguiente turno. Este pasivo se aplica a todos los portales del equipo.",
+      "pt": "Se o Eliotrope ou um aliado atravessa um Portal, ele ganha PM durante o turno atual. Porém, ele não poderá mais utilizar portais para se deslocar até o turno seguinte. Este passivo se aplica a todos os portais da equipe."
+    },
     "effectIds": [
       179730,
       376989
@@ -7651,11 +10661,21 @@
   },
   {
     "spellId": 5132,
-    "name": "Réminiscence",
+    "name": {
+      "fr": "Réminiscence",
+      "en": "Reminiscence",
+      "es": "Reminiscencia",
+      "pt": "Reminiscência"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5132,
-    "description": "The Eliotrope automatically changes modes at end of turn. Also, they can cast Exaltation on another ally from a distance.",
+    "description": {
+      "fr": "L'Eliotrope change de mode automatiquement en fin de tour. En outre, il peut lancer le sort Exaltation sur un autre allié à distance.",
+      "en": "The Eliotrope automatically changes modes at end of turn. Also, they can cast Exaltation on another ally from a distance.",
+      "es": "El selotrop cambia de modo automáticamente al final del turno. Además, puede lanzar el hechizo Exaltación a otro aliado a distancia.",
+      "pt": "O Eliotrope troca de modo automaticamente no fim do turno. Além disso, ele pode lançar o feitiço Exaltação em outro aliado a distância."
+    },
     "effectIds": [
       346468
     ],
@@ -7673,11 +10693,21 @@
   },
   {
     "spellId": 5143,
-    "name": "Portail céleste",
+    "name": {
+      "fr": "Portail céleste",
+      "en": "Celestial Portal",
+      "es": "Portal Celestial",
+      "pt": "Portal Celeste"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5143,
-    "description": "The Eliotrope teleports to the closest portal at the start of the turn.",
+    "description": {
+      "fr": "L'Eliotrope se téléporte sur le portail le plus proche en début de tour.",
+      "en": "The Eliotrope teleports to the closest portal at the start of the turn.",
+      "es": "El selotrop se teletransporta al portal más cercano al principio del turno.",
+      "pt": "O Eliotrope se teletransporta para o portal mais próximo no início do turno."
+    },
     "effectIds": [
       351392
     ],
@@ -7692,11 +10722,21 @@
   },
   {
     "spellId": 7202,
-    "name": "Interstellaire",
+    "name": {
+      "fr": "Interstellaire",
+      "en": "Interstellar",
+      "es": "Interestelar",
+      "pt": "Interestelar"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5101,
-    "description": "Allies that use one of the Eliotrope's portals more than 6 cells away are no longer affected by Long Teleportation, but the starting portal is destroyed. This passive applies to all of the team's portals.",
+    "description": {
+      "fr": "Les alliés qui empruntent un portail de l'Eliotrope à plus de 6 cases de distance ne subissent plus la Longue téléportation, mais le portail de départ est détruit. Ce passif s'applique à tous les portails de l'équipe.",
+      "en": "Allies that use one of the Eliotrope's portals more than 6 cells away are no longer affected by Long Teleportation, but the starting portal is destroyed. This passive applies to all of the team's portals.",
+      "es": "Los aliados que toman un portal del selotrop a más de 6 casillas de distancia ya no sufren Teleportación de Largo Alcance, pero el portal de inicio se destruye. Este pasivo se aplica a todos los portales del equipo.",
+      "pt": "Os aliados que usarem um portal do Eliotrope a mais de 6 células de distância não sofrem mais a penalidade Teletransporte Longo, mas o portal de partida é destruído. Este passivo se aplica a todos os portais da equipe."
+    },
     "effectIds": [
       351440,
       377000
@@ -7714,11 +10754,21 @@
   },
   {
     "spellId": 7203,
-    "name": "Dimension blanche",
+    "name": {
+      "fr": "Dimension blanche",
+      "en": "White Dimension",
+      "es": "Dimensión Blanca",
+      "pt": "Dimensão Branca"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5104,
-    "description": "Fighters around portals gain Critical Hits at the start of the Eliotrope's turn if the Eliotrope is in Calm mode, and lose Critical Hits if the Eliotrope is Exalted.",
+    "description": {
+      "fr": "Les combattants autour des portails gagnent des Coups critiques au début du tour de l'Eliotrope si ce dernier est serein et en perdent s'il est exalté.",
+      "en": "Fighters around portals gain Critical Hits at the start of the Eliotrope's turn if the Eliotrope is in Calm mode, and lose Critical Hits if the Eliotrope is Exalted.",
+      "es": "Los luchadores alrededor de los portales ganan golpes críticos al principio del turno del selotrop si este está en Sereno, y pierden si está Exaltado.",
+      "pt": "Os combatentes que estiverem ao redor dos portais ganham golpes críticos no início do turno do Eliotrope, se este último estiver no modo Sereno, e perdem se ele estiver no modo Exaltado."
+    },
     "effectIds": [
       351391
     ],
@@ -7756,11 +10806,21 @@
   },
   {
     "spellId": 7204,
-    "name": "Quiétude",
+    "name": {
+      "fr": "Quiétude",
+      "en": "Quietude",
+      "es": "Quietud",
+      "pt": "Calmaria"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 880,
-    "description": "The Eliotrope regains AP (instead of gaining a damage inflicted bonus) when the Exaltation spell is cast.",
+    "description": {
+      "fr": "L'Eliotrope regagne des PA au lancer du sort Exaltation au lieu du bonus de Dommages infligés.",
+      "en": "The Eliotrope regains AP (instead of gaining a damage inflicted bonus) when the Exaltation spell is cast.",
+      "es": "El selotrop recupera PA al lanzar el hechizo Exaltación en vez del bonus de daños infligidos.",
+      "pt": "Ao lançar o feitiço Exaltação, o Eliotrope recupera PA em vez do bônus de danos infligidos."
+    },
     "effectIds": [
       346520
     ],
@@ -7775,11 +10835,21 @@
   },
   {
     "spellId": 7205,
-    "name": "Espace-temps",
+    "name": {
+      "fr": "Espace-temps",
+      "en": "Spacetime",
+      "es": "Espaciotiempo",
+      "pt": "Espaço-Tempo"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 4688,
-    "description": "Instead of lasting indefinitely, portals last for 2 turns. This passive applies to all of the team's portals.",
+    "description": {
+      "fr": "Au lieu d'être infinis, les portails durent 2 tours. Ce passif s'applique à tous les portails de l'équipe.",
+      "en": "Instead of lasting indefinitely, portals last for 2 turns. This passive applies to all of the team's portals.",
+      "es": "En vez de ser infinitos, los portales duran 2 turnos. Este pasivo se aplica a todos los portales del equipo.",
+      "pt": "Em vez de serem infinitos, os portais duram 2 turnos. Este passivo se aplica a todos os portais da equipe."
+    },
     "effectIds": [
       316359,
       316467,
@@ -7798,11 +10868,21 @@
   },
   {
     "spellId": 7206,
-    "name": "Porta(i)l",
+    "name": {
+      "fr": "Porta(i)l",
+      "en": "Porta(i)l",
+      "es": "Portalivio",
+      "pt": "Portalidade"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 7206,
-    "description": "The Eliotrope now has just two portals, but they can move them around more easily and at a greater distance. Also, their damage and heals performed through portals are increased.",
+    "description": {
+      "fr": "L'Eliotrope ne possède plus que deux portails, mais il peut les déplacer plus facilement et à plus grande distance. En plus, ses dommages et ses soins réalisés à travers les portails sont augmentés.",
+      "en": "The Eliotrope now has just two portals, but they can move them around more easily and at a greater distance. Also, their damage and heals performed through portals are increased.",
+      "es": "El selotrop solo tiene dos portales, pero los puede desplazar más fácilmente y a mayor distancia. Además, sus daños y curas realizadas a través de los portales aumentan.",
+      "pt": "O Eliotrope só tem dois portais, mas ele pode deslocá-los mais facilmente e por distâncias maiores. Além disso, os danos e curas que realiza através dos portais aumentam."
+    },
     "effectIds": [
       316512
     ],
@@ -7817,11 +10897,21 @@
   },
   {
     "spellId": 7207,
-    "name": "Bouclier de la fin",
+    "name": {
+      "fr": "Bouclier de la fin",
+      "en": "Final Shield",
+      "es": "Escudo del Fin",
+      "pt": "Escudo do Fim"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 7207,
-    "description": "The Eliotrope must place their portals adjacent to a fighter. In return, allies who use their portals are healed and gain AP. This passive applies to all of the team's portals.",
+    "description": {
+      "fr": "L'Eliotrope doit poser ses portails au contact d'un combattant. En échange, les alliés qui empruntent ses portails sont soignés et gagneront des PA. Ce passif s'applique à tous les portails de l'équipe.",
+      "en": "The Eliotrope must place their portals adjacent to a fighter. In return, allies who use their portals are healed and gain AP. This passive applies to all of the team's portals.",
+      "es": "El selotrop debe poner sus portales en contacto con un luchador. A cambio, los aliados que toman sus portales se curan y ganan PA. Este pasivo se aplica a todos los portales del equipo.",
+      "pt": "O Eliotrope deve colocar seus portais em contato com um combatente. Em troca, os aliados que usam seus portais são curados e ganham PA. Este passivo se aplica a todos os portais da equipe."
+    },
     "effectIds": [
       351381,
       377044
@@ -7840,11 +10930,21 @@
   },
   {
     "spellId": 7208,
-    "name": "Épée du début",
+    "name": {
+      "fr": "Épée du début",
+      "en": "Novice Sword",
+      "es": "Espada del Inicio",
+      "pt": "Espada do Início"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 7208,
-    "description": "The Eliotrope can get Celestial Gift by casting spells on adjacent targets. In exchange, the maximum range of all of their spells is reduced.",
+    "description": {
+      "fr": "L'Eliotrope peut obtenir Don céleste en lançant des sorts sur des cibles au contact. En revanche, la portée maximale de tous ses sorts est réduite.",
+      "en": "The Eliotrope can get Celestial Gift by casting spells on adjacent targets. In exchange, the maximum range of all of their spells is reduced.",
+      "es": "El selotrop puede obtener Don Celestial lanzando hechizos a objetivos en contacto. A cambio, el alcance máximo de todos sus hechizos se reduce.",
+      "pt": "O Eliotrope pode obter Dádiva Celeste lançando feitiços em alvos em contato. Em contrapartida, o alcance máximo de todos os seus feitiços é reduzido."
+    },
     "effectIds": [
       351757
     ],
@@ -7859,11 +10959,21 @@
   },
   {
     "spellId": 7209,
-    "name": "Cicatrisation",
+    "name": {
+      "fr": "Cicatrisation",
+      "en": "Healing",
+      "es": "Cicatrización",
+      "pt": "Cicatrização"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5454,
-    "description": "The Eliotrope is healed for part of their missing HP when ending their turn in Calm mode, in exchange for one WP. If they are on a portal, the healing is greater.",
+    "description": {
+      "fr": "L'Eliotrope est soigné d'une partie de ses PV manquants en finissant son tour en Serein en échange d'un PW. S'il se trouve sur un portail, le soin est plus élevé.",
+      "en": "The Eliotrope is healed for part of their missing HP when ending their turn in Calm mode, in exchange for one WP. If they are on a portal, the healing is greater.",
+      "es": "El selotrop se cura una parte de sus PdV faltantes al terminar su turno en Sereno a cambio de un PW. Si se encuentra en un portal, la cura es más alta.",
+      "pt": "O Eliotrope é curado de uma parte de seus PV perdidos quando termina o turno no modo Sereno em troca de um PW. Se ele estiver em um portal, a cura será maior."
+    },
     "effectIds": [
       346513
     ],
@@ -7878,11 +10988,21 @@
   },
   {
     "spellId": 7210,
-    "name": "Concentration",
+    "name": {
+      "fr": "Concentration",
+      "en": "Concentration",
+      "es": "Concentración",
+      "pt": "Concentração"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 7343,
-    "description": "Celestial Portal is more useful and can be cast multiple times per turn. In exchange, it is harder to cast.",
+    "description": {
+      "fr": "Portail céleste gagne en utilité et peut se lancer plusieurs fois par tour. En contrepartie, il est plus difficile à lancer.",
+      "en": "Celestial Portal is more useful and can be cast multiple times per turn. In exchange, it is harder to cast.",
+      "es": "Portal Celestial gana utilidad y puede lanzarse varias veces por turno. A cambio, es más difícil lanzarlo.",
+      "pt": "Portal Celeste ganha mais utilidade e pode ser lançado várias vezes por turno. Em contrapartida, ele se torna mais difícil de lançar."
+    },
     "effectIds": [
       351756
     ],
@@ -7897,11 +11017,21 @@
   },
   {
     "spellId": 7720,
-    "name": "Méditation",
+    "name": {
+      "fr": "Méditation",
+      "en": "Meditation",
+      "es": "Meditación",
+      "pt": "Meditação"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 5131,
-    "description": "The Eliotrope no longer gains damage by starting their turn in Calm mode, but gains MP and elemental resistance instead. Celestial Gift is also consumed if heals are performed, which then boosts healing.",
+    "description": {
+      "fr": "L'Eliotrope ne gagne plus de dommages en commençant son tour en Serein mais des PM et des résistances élémentaires. Le Don céleste se consomme également en cas de soin réalisés, en augmentant ce dernier.",
+      "en": "The Eliotrope no longer gains damage by starting their turn in Calm mode, but gains MP and elemental resistance instead. Celestial Gift is also consumed if heals are performed, which then boosts healing.",
+      "es": "El selotrop ya no gana daños al comenzar su turno en Sereno, sino PM y resistencias elementales. Don Celestial también se consume si se realiza una cura, aumentando esto último.",
+      "pt": "O Eliotrope não ganha mais danos começando o turno no modo Sereno, mas ganha PM e resistências elementares. A Dádiva Celeste também é consumida em caso de curas realizadas, aumentando-as."
+    },
     "effectIds": [
       346518,
       395932
@@ -7929,11 +11059,21 @@
   },
   {
     "spellId": 7814,
-    "name": "Souffle de la déesse",
+    "name": {
+      "fr": "Souffle de la déesse",
+      "en": "Breath of the Goddess",
+      "es": "Aliento de la Diosa",
+      "pt": "Sopro da Deusa"
+    },
     "breedId": 18,
     "class": "ELIOTROPE",
     "gfxId": 6925,
-    "description": "If the Eliotrope casts the Portal spell on an ally while standing on a portal, they switch places, but the caster does not place a new portal.",
+    "description": {
+      "fr": "Si l'Eliotrope lance le sort Portail sur un allié en étant-lui-même sur un portail, il échange de position avec mais ne place pas de nouveau portail.",
+      "en": "If the Eliotrope casts the Portal spell on an ally while standing on a portal, they switch places, but the caster does not place a new portal.",
+      "es": "Si el selotrop lanza el hechizo Portal sobre un aliado estando él mismo en un portal, intercambia de posición con él, pero no pone un portal nuevo.",
+      "pt": "Se o Eliotrope lançar o feitiço Portal em um aliado enquanto ele mesmo estiver em um portal, ele trocará de posição com ele, mas não colocará um novo portal."
+    },
     "effectIds": [
       351726,
       395955
@@ -7961,11 +11101,21 @@
   },
   {
     "spellId": 5579,
-    "name": "Dynamo",
+    "name": {
+      "fr": "Dynamo",
+      "en": "Dynamo",
+      "es": "Dinamo",
+      "pt": "Dínamo"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5579,
-    "description": "The Huppermage's Runes are ephemeral and will disappear at end of turn, allowing them to manage their runes differently.",
+    "description": {
+      "fr": "Les runes de l'Huppermage sont éphémères et disparaissent en fin de tour, lui permettant de gérer ses runes différemment.",
+      "en": "The Huppermage's Runes are ephemeral and will disappear at end of turn, allowing them to manage their runes differently.",
+      "es": "Las runas del hipermago son efímeras y desaparecen al final del turno, permitiéndole gestionar sus runas de otra manera.",
+      "pt": "As runas do Huppermago são efêmeras e desaparecem no fim do turno, permitindo que ele gere suas runas de outra maneira."
+    },
     "effectIds": [
       349503
     ],
@@ -7980,11 +11130,21 @@
   },
   {
     "spellId": 5580,
-    "name": "Initiative de l'âme",
+    "name": {
+      "fr": "Initiative de l'âme",
+      "en": "Soul Initiative",
+      "es": "Iniciativa del Alma",
+      "pt": "Iniciativa da Alma"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5132,
-    "description": "The Huppermage gains 2 AP for the current turn if the first spell they cast is Heart of Light.",
+    "description": {
+      "fr": "L'Huppermage gagne 2 PA pour le tour en cours si le premier sort qu'il lance est Coeur de Lumière.",
+      "en": "The Huppermage gains 2 AP for the current turn if the first spell they cast is Heart of Light.",
+      "es": "El hipermago gana 2 PA para el turno actual si el primer hechizo que lanza es Corazón de Luz.",
+      "pt": "O Huppermago ganha 2 PA para o turno atual se o primeiro feitiço que lançar for Coração de Luz."
+    },
     "effectIds": [
       350551
     ],
@@ -8011,11 +11171,21 @@
   },
   {
     "spellId": 5581,
-    "name": "Distension Élémentaire",
+    "name": {
+      "fr": "Distension Élémentaire",
+      "en": "Elemental Distension",
+      "es": "Distensión Elemental",
+      "pt": "Alongamento Elementar"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5347,
-    "description": "Elemental spells gain 2 Range when the Heart of the same element is active.",
+    "description": {
+      "fr": "Les sorts élémentaires gagnent 2 de Portée lorsque le Coeur du même élément est actif.",
+      "en": "Elemental spells gain 2 Range when the Heart of the same element is active.",
+      "es": "Los hechizos elementales ganan 2 de alcance cuando el corazón del mismo elemento está activo.",
+      "pt": "Os feitiços elementares ganham 2 AL quando o Coração do mesmo elemento está ativo."
+    },
     "effectIds": [
       350525
     ],
@@ -8030,11 +11200,21 @@
   },
   {
     "spellId": 5582,
-    "name": "Liaison Lumineuse",
+    "name": {
+      "fr": "Liaison Lumineuse",
+      "en": "Light Link",
+      "es": "Conexión Luminosa",
+      "pt": "Ligação Luminosa"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 7107,
-    "description": "The Huppermage switches places with their Will-o'-the-Wisp when they summon it.",
+    "description": {
+      "fr": "L'Huppermage échange de position avec son Feu Follet lorsqu'il l'invoque.",
+      "en": "The Huppermage switches places with their Will-o'-the-Wisp when they summon it.",
+      "es": "El hipermago cambia de posición con su fuego fatuo cuando lo invoca.",
+      "pt": "O Huppermago troca de lugar com seu Fogo-Fátuo ao invocá-lo."
+    },
     "effectIds": [
       350527
     ],
@@ -8049,11 +11229,21 @@
   },
   {
     "spellId": 5583,
-    "name": "Universalité",
+    "name": {
+      "fr": "Universalité",
+      "en": "Universality",
+      "es": "Universalidad",
+      "pt": "Universalidade"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5583,
-    "description": "The Huppermage's knowledge allows them to convert their runes into bonuses at the end of the turn, in exchange for some of their Quadramental Breeze.",
+    "description": {
+      "fr": "Les connaissances de l'Huppermage lui permettent de convertir ses Runes en bonus à la fin du tour, en échange d'une partie de sa Brise Quadramentale.",
+      "en": "The Huppermage's knowledge allows them to convert their runes into bonuses at the end of the turn, in exchange for some of their Quadramental Breeze.",
+      "es": "Los conocimientos del hipermago le permiten convertir sus runas en bonus al final del turno, a cambio de una parte de su brisa cuadramental.",
+      "pt": "Os conhecimentos do Huppermago permitem que ele converta suas runas em bônus no fim do turno, em troca de uma parte de sua Brisa Quadramental."
+    },
     "effectIds": [
       349785,
       349448
@@ -8092,11 +11282,21 @@
   },
   {
     "spellId": 5584,
-    "name": "Sauvegarde Runique",
+    "name": {
+      "fr": "Sauvegarde Runique",
+      "en": "Runic Save",
+      "es": "Sobrecarga Rúnica",
+      "pt": "Salvaguarda Rúnica"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 4300,
-    "description": "The Huppermage can save 3 runes onto their Will-o'-the-Wisp, provided they have exactly 1 rune. In return, the Will-o'-the-Wisp spell can only be used once per turn.",
+    "description": {
+      "fr": "L'Huppermage peut sauvegarder 3 Runes sur son Feu Follet à condition de posséder exactement 1 Rune. En échange, Feu Follet ne peut être utilisé qu'une seule fois par tour.",
+      "en": "The Huppermage can save 3 runes onto their Will-o'-the-Wisp, provided they have exactly 1 rune. In return, the Will-o'-the-Wisp spell can only be used once per turn.",
+      "es": "El hipermago puede guardar 3 runas en su fuego fatuo siempre que posea exactamente 1 runa. A cambio, Fuego Fatuo solo puede utilizarse una única vez por turno.",
+      "pt": "O Huppermago pode salvar 3 runas em seu Fogo-Fátuo, contanto que ele tenha exatamente 1 runa. Em troca, Fogo-Fátuo só pode ser usado uma vez por turno."
+    },
     "effectIds": [
       350536
     ],
@@ -8111,11 +11311,21 @@
   },
   {
     "spellId": 5585,
-    "name": "Plénitude",
+    "name": {
+      "fr": "Plénitude",
+      "en": "Fullness",
+      "es": "Plenitud",
+      "pt": "Plenitude"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5585,
-    "description": "With serene efficiency, you catalyze the power of the elements and release them in the form of energy to create spells with astonishing effects.",
+    "description": {
+      "fr": "D'une sereine efficacité, c'est en canalysant le pouvoir des éléments pour le relâcher sous forme de lumière, que vous créez des sorts aux effets éblouissants.",
+      "en": "With serene efficiency, you catalyze the power of the elements and release them in the form of energy to create spells with astonishing effects.",
+      "es": "Con una efectividad serena, permite crear hechizos con efectos deslumbrantes mediante la canalización del poder de los elementos para liberarlos en forma de luz.",
+      "pt": "Com uma serena eficácia, você catalisa o poder dos elementos e o libera sob forma de luz para criar feitiços de efeitos surpreendentes."
+    },
     "effectIds": [
       349344
     ],
@@ -8130,11 +11340,21 @@
   },
   {
     "spellId": 5586,
-    "name": "Profusion Runique",
+    "name": {
+      "fr": "Profusion Runique",
+      "en": "Runic Profusion",
+      "es": "Profusión Rúnica",
+      "pt": "Profusão Rúnica"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5586,
-    "description": "At the end of the turn, the Huppermage increases the abilities of their Light spells for the following turn based on the number of runes they have.",
+    "description": {
+      "fr": "En fin de tour, l'Huppermage augmente la capacité de ses sorts Lumière pour le tour suivant selon le nombre de Runes qu'il possède.",
+      "en": "At the end of the turn, the Huppermage increases the abilities of their Light spells for the following turn based on the number of runes they have.",
+      "es": "Al final del turno, el hipermago aumenta la capacidad de sus hechizos de luz para el siguiente turno según el número de runas que posea.",
+      "pt": "No fim do turno, o Huppermago aumenta a capacidade de seus feitiços de Luz para o turno seguinte de acordo com a quantidade de runas que possui."
+    },
     "effectIds": [
       350667,
       350670
@@ -8152,11 +11372,21 @@
   },
   {
     "spellId": 5587,
-    "name": "Absorption Quadramentale",
+    "name": {
+      "fr": "Absorption Quadramentale",
+      "en": "Quadramental Absorption",
+      "es": "Absorción Cuadramental",
+      "pt": "Absorção Quadramental"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 7193,
-    "description": "The Huppermage gains Force of Will to obstruct their opponents. They generate QB for each reduction (AP, MP, or Range) performed.",
+    "description": {
+      "fr": "L'Huppermage gagne de la Volonté pour entraver ses adversaires. Il génère de la BQ à chaque retrait (PA, PM, Portée) effectué.",
+      "en": "The Huppermage gains Force of Will to obstruct their opponents. They generate QB for each reduction (AP, MP, or Range) performed.",
+      "es": "El hipermago gana voluntad para trabar a sus adversarios. Genera BC en cada retirada (PA, PM, alcance) realizada.",
+      "pt": "O Huppermago ganha Vontade para entravar seus adversários. Ele gera BQ a cada retirada (PA, PM, AL) efetuada."
+    },
     "effectIds": [
       350528,
       350529,
@@ -8187,11 +11417,21 @@
   },
   {
     "spellId": 5588,
-    "name": "Réfraction Élémentaire",
+    "name": {
+      "fr": "Réfraction Élémentaire",
+      "en": "Elemental Refraction",
+      "es": "Refracción Elemental",
+      "pt": "Refração Elementar"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5588,
-    "description": "The Huppermage sacrifices some of the Heart of Light's power so they can cast it several times on the same turn.",
+    "description": {
+      "fr": "L'Huppermage sacrifie une partie de la puissance du Coeur de Lumière pour pouvoir le lancer plusieurs fois dans le même tour.",
+      "en": "The Huppermage sacrifices some of the Heart of Light's power so they can cast it several times on the same turn.",
+      "es": "El hipermago sacrifica una parte de la potencia del corazón de luz para poder lanzarlo varias veces en el mismo turno.",
+      "pt": "O Huppermago sacrifica uma parte da potência do Coração de Luz para poder lançá-lo várias vezes no mesmo turno."
+    },
     "effectIds": [
       350534
     ],
@@ -8206,11 +11446,21 @@
   },
   {
     "spellId": 7797,
-    "name": "Extension des sens",
+    "name": {
+      "fr": "Extension des sens",
+      "en": "Sensextension",
+      "es": "Extensión de los Sentidos",
+      "pt": "Extensão dos Sentidos"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5584,
-    "description": "The Huppermage can regenerate QB under the effects of Heart of Light by meeting certain conditions, but the Heart lasts longer.",
+    "description": {
+      "fr": "L'Huppermage peut régénérer de la BQ sous Coeur de Lumière en respectant certaines conditions, mais le Coeur dure plus longtemps et la régénération de BQ liée aux runes est désactivée.",
+      "en": "The Huppermage can regenerate QB under the effects of Heart of Light by meeting certain conditions, but the Heart lasts longer, and QB regeneration linked to runes is disabled.",
+      "es": "El hipermago puede regenerar BC bajo Corazón de Luz respetando algunas condiciones, pero el corazón dura más tiempo y se desactiva la regeneración de BC relacionada con las runas.",
+      "pt": "O Huppermago pode regenerar a BQ sob Coração de Luz ao cumprir certas condições, mas o Coração dura mais tempo e a regeneração da BQ ligada às runas é desativada."
+    },
     "effectIds": [
       349309
     ],
@@ -8225,11 +11475,21 @@
   },
   {
     "spellId": 7798,
-    "name": "Transcendance Runique",
+    "name": {
+      "fr": "Transcendance Runique",
+      "en": "Runic Transcendence",
+      "es": "Trascendencia Rúnica",
+      "pt": "Transcendência Rúnica"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5587,
-    "description": "The Huppermage doubles their QB regeneration when they have all their runes. Otherwise, their regeneration is halved.",
+    "description": {
+      "fr": "L'Huppermage double sa régénération de BQ lorsqu'il possède toutes ses Runes. Autrement, sa régénération est réduite de moitié.",
+      "en": "The Huppermage doubles their QB regeneration when they have all their runes. Otherwise, their regeneration is halved.",
+      "es": "El hipermago duplica su regeneración de BC cuando tiene todas sus runas. En caso contrario, su regeneración se reduce a la mitad.",
+      "pt": "A regeneração de BQ do Huppermago é dobrada quando ele possui todas as suas runas. Caso contrário, a regeneração é reduzida pela metade."
+    },
     "effectIds": [
       350653
     ],
@@ -8244,11 +11504,21 @@
   },
   {
     "spellId": 7800,
-    "name": "Combinaison Élémentaire",
+    "name": {
+      "fr": "Combinaison Élémentaire",
+      "en": "Elemental Combination",
+      "es": "Combinación Elemental",
+      "pt": "Combinação Elementar"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5348,
-    "description": "The Huppermage increases the abilities of their Light spells by creating elemental combinations.",
+    "description": {
+      "fr": "L'Huppermage augmente la capacité de ses sorts Lumière en créant des combinaisons élémentaires.",
+      "en": "The Huppermage increases the abilities of their Light spells by creating elemental combinations.",
+      "es": "El hipermago aumenta la capacidad de sus hechizos de luz creando combinaciones elementales.",
+      "pt": "O Huppermago aumenta a capacidade dos seus feitiços de Luz criando combinações elementares."
+    },
     "effectIds": [
       350654
     ],
@@ -8265,11 +11535,21 @@
   },
   {
     "spellId": 7801,
-    "name": "Pulsation",
+    "name": {
+      "fr": "Pulsation",
+      "en": "Pulsation",
+      "es": "Pulsación",
+      "pt": "Pulsação"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 7191,
-    "description": "The Will-o'-the-Wisp attracts fighters when placed; it repels them when consumed.",
+    "description": {
+      "fr": "Le Feu Follet attire les combattants lorsqu'il est posé, et les repousse lorsqu'il est consommé.",
+      "en": "The Will-o'-the-Wisp attracts fighters when placed; it repels them when consumed.",
+      "es": "El fuego fatuo atrae a los combatientes cuando es colocado, y los empuja cuando se consume.",
+      "pt": "O Fogo-Fátuo atrai os combatentes quando é colocado e os afasta quando é consumido."
+    },
     "effectIds": [
       349340
     ],
@@ -8284,11 +11564,21 @@
   },
   {
     "spellId": 7802,
-    "name": "Antithèse",
+    "name": {
+      "fr": "Antithèse",
+      "en": "Antithesis",
+      "es": "Antítesis",
+      "pt": "Antítese"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5581,
-    "description": "The Huppermage regenerates QB when generating Runes. However, elemental spells inflict less damage.",
+    "description": {
+      "fr": "L'Huppermage régénère de la BQ lorsqu'il génère des Runes. En contrepartie, les sorts élémentaires infligent moins de dommages.",
+      "en": "The Huppermage regenerates QB when generating Runes. However, elemental spells inflict less damage.",
+      "es": "El hipermago regenera BC cuando genera runas. Como contrapartida, los hechizos elementales infligen menos daños.",
+      "pt": "O Huppermago regenera BQ quando gera runas. Em contrapartida, os feitiços elementares infligem menos danos."
+    },
     "effectIds": [
       349287
     ],
@@ -8303,11 +11593,21 @@
   },
   {
     "spellId": 7803,
-    "name": "Essor de l'âme",
+    "name": {
+      "fr": "Essor de l'âme",
+      "en": "Soul Development",
+      "es": "Vuelo del Alma",
+      "pt": "Expansão da Alma"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5454,
-    "description": "The Huppermage uses the Heart of Light to gain resistance in other elements.",
+    "description": {
+      "fr": "L'Huppermage utilise le Coeur de Lumière pour gagner des résistances dans les autres éléments.",
+      "en": "The Huppermage uses the Heart of Light to gain resistance in other elements.",
+      "es": "El hipermago usa el corazón de luz para ganar resistencias en los otros elementos.",
+      "pt": "O Huppermago utiliza o Coração de Luz para ganhar resistências nos outros elementos."
+    },
     "effectIds": [
       349315
     ],
@@ -8322,11 +11622,21 @@
   },
   {
     "spellId": 7804,
-    "name": "Altruisme de l'âme",
+    "name": {
+      "fr": "Altruisme de l'âme",
+      "en": "Soul Altruism",
+      "es": "Altruismo del Alma",
+      "pt": "Altruísmo da Alma"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5455,
-    "description": "The Huppermage sacrifices the damage granted by Heart of Light to gain heals performed. This passive also allows them to recover Quadramental Breeze each time they heal an ally.",
+    "description": {
+      "fr": "L'Huppermage sacrifie les dommages octroyés par Coeur de Lumière pour gagner des soins réalisés. Ce passif lui permet également de regagner de la Brise Quadramentale à chaque fois qu'il soigne un allié.",
+      "en": "The Huppermage sacrifices the damage granted by Heart of Light to gain heals performed. This passive also allows them to recover Quadramental Breeze each time they heal an ally.",
+      "es": "El hipermago sacrifica los daños concedidos por Corazón de Luz para ganar curas realizadas. Con este pasivo, también puede recuperar brisa cuadramental cada vez que cura a un aliado.",
+      "pt": "O Huppermago sacrifica os danos concedidos por Coração de Luz para ganhar curas realizadas. Este passivo também permite que ele ganhe Brisa Quadramental toda vez que cura um aliado."
+    },
     "effectIds": [
       350535,
       395267
@@ -8342,11 +11652,21 @@
   },
   {
     "spellId": 7805,
-    "name": "Nouveau souffle",
+    "name": {
+      "fr": "Nouveau souffle",
+      "en": "New Breath",
+      "es": "Aire Nuevo",
+      "pt": "Novo Sopro"
+    },
     "breedId": 19,
     "class": "HUPPERMAGE",
     "gfxId": 5582,
-    "description": "The Huppermage has better control of their Will-o'-the-Wisp. However, they can only place one at a time.",
+    "description": {
+      "fr": "L'Huppermage a un meilleur contrôle de son Feu Follet. En contrepartie, il ne peut en poser qu'un seul à la fois.",
+      "en": "The Huppermage has better control of their Will-o'-the-Wisp. However, they can only place one at a time.",
+      "es": "El hipermago controla mejor su fuego fatuo. En cambio, solo puede colocar uno al mismo tiempo.",
+      "pt": "O Huppermago tem um melhor controle de seu Fogo-Fátuo. Em contrapartida, ele só pode colocar um por vez."
+    },
     "effectIds": [
       349131
     ],

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/PassiveCatalogTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/PassiveCatalogTest.kt
@@ -20,7 +20,7 @@ class PassiveCatalogTest {
     @Test
     fun `every passive carries a usable icon gfx and resolves its class`() {
         assertThat(PassiveCatalog.passives).allSatisfy { passive ->
-            assertThat(passive.gfxId).describedAs("${passive.name}: a gfx id for the icon").isPositive
+            assertThat(passive.gfxId).describedAs("${passive.name?.fr}: a gfx id for the icon").isPositive
             assertThat(passive.characterClass).isNotEqualTo(CharacterClass.UNKNOWN)
         }
     }

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellRotationTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/domain/SpellRotationTest.kt
@@ -76,6 +76,86 @@ class SpellRotationTest {
     }
 
     @Test
+    fun `the scenario breakdown applies the positional multiplier per orientation`() {
+        // A fire build with NO rear/berserk mastery: the only thing that changes between positions is the
+        // ×multiplier (face 1.0 / side 1.10 / back 1.25), which the rotation now applies. So side = 1.10×face
+        // and back = 1.25×face — proving the displayed damage finally includes the orientation factor.
+        val character = Character(clazz = CharacterClass.CRA, level = 200, minLevel = 1)
+        val fireItem =
+            me.chosante.common.Equipment(
+                equipmentId = 1,
+                guiId = 1,
+                level = 200,
+                name = I18nText("Amu", "Amu", "Amu", "Amu"),
+                rarity = me.chosante.common.Rarity.COMMON,
+                itemType = me.chosante.common.ItemType.AMULET,
+                characteristics = mapOf(me.chosante.common.Characteristic.MASTERY_ELEMENTARY_FIRE to 500)
+            )
+        val build = BuildCombination(equipments = listOf(fireItem), characterSkills = CharacterSkills(200))
+        val scenario = DamageScenario(element = me.chosante.autobuilder.domain.SpellElement.FIRE)
+
+        val breakdown = SpellRotationOptimizer.scenarioBreakdown(build, character, CharacterClass.CRA, scenario, includeBerserk = false)
+        val face = breakdown.single { it.orientation == Orientation.FACE && !it.berserk }.totalExpectedDamage
+        val side = breakdown.single { it.orientation == Orientation.SIDE && !it.berserk }.totalExpectedDamage
+        val back = breakdown.single { it.orientation == Orientation.BACK && !it.berserk }.totalExpectedDamage
+
+        assertThat(breakdown).hasSize(3)
+        assertThat(face).isGreaterThan(0.0)
+        assertThat(side / face).isCloseTo(
+            1.10,
+            org.assertj.core.api.Assertions
+                .within(1e-6)
+        )
+        assertThat(back / face).isCloseTo(
+            1.25,
+            org.assertj.core.api.Assertions
+                .within(1e-6)
+        )
+    }
+
+    @Test
+    fun `the scenario breakdown adds a back+berserk row only when asked`() {
+        val character = Character(clazz = CharacterClass.CRA, level = 200, minLevel = 1)
+        val build = BuildCombination(equipments = emptyList(), characterSkills = CharacterSkills(200))
+        val scenario = DamageScenario(element = me.chosante.autobuilder.domain.SpellElement.FIRE)
+
+        assertThat(SpellRotationOptimizer.scenarioBreakdown(build, character, CharacterClass.CRA, scenario, includeBerserk = false)).hasSize(3)
+        val withBerserk = SpellRotationOptimizer.scenarioBreakdown(build, character, CharacterClass.CRA, scenario, includeBerserk = true)
+        assertThat(withBerserk).hasSize(4)
+        assertThat(withBerserk.last().berserk).isTrue()
+        assertThat(withBerserk.last().orientation).isEqualTo(Orientation.BACK)
+    }
+
+    @Test
+    fun `the scenario breakdown always includes the configured off-grid combo`() {
+        // A configured side+berserk scenario is not one of the base FACE/SIDE/BACK(+BACK-berserk) rows, yet the
+        // breakdown must still contain it so the result view can highlight the searched scenario.
+        val character = Character(clazz = CharacterClass.CRA, level = 200, minLevel = 1)
+        val build = BuildCombination(equipments = emptyList(), characterSkills = CharacterSkills(200))
+        val scenario =
+            DamageScenario(element = me.chosante.autobuilder.domain.SpellElement.FIRE, orientation = Orientation.SIDE, berserk = true)
+
+        val breakdown = SpellRotationOptimizer.scenarioBreakdown(build, character, CharacterClass.CRA, scenario, includeBerserk = true)
+        assertThat(breakdown).anySatisfy({ assertThat(it.orientation == Orientation.SIDE && it.berserk).isTrue() })
+    }
+
+    @Test
+    fun `the scenario breakdown reuses a supplied total for the configured combo`() {
+        // When the caller already computed the headline rotation, the configured combo's row must reuse that
+        // exact total instead of recomputing it.
+        val character = Character(clazz = CharacterClass.CRA, level = 200, minLevel = 1)
+        val build = BuildCombination(equipments = emptyList(), characterSkills = CharacterSkills(200))
+        val scenario = DamageScenario(element = me.chosante.autobuilder.domain.SpellElement.FIRE, orientation = Orientation.BACK)
+        val sentinel = 123_456.0
+
+        val breakdown =
+            SpellRotationOptimizer.scenarioBreakdown(build, character, CharacterClass.CRA, scenario, includeBerserk = false, configuredRotationTotal = sentinel)
+        assertThat(breakdown.single { it.orientation == Orientation.BACK && !it.berserk }.totalExpectedDamage).isEqualTo(sentinel)
+        // The other (non-configured) rows are computed normally, so they are NOT the sentinel.
+        assertThat(breakdown.single { it.orientation == Orientation.FACE }.totalExpectedDamage).isNotEqualTo(sentinel)
+    }
+
+    @Test
     fun `sequencing ignores a resistance debuff whose enemy target is unconfirmed`() {
         // IOP Focus carries −50 flat resistance but its enemy target is unconfirmed (missingFields contains
         // "resistanceTarget?"), so it must NOT lower the boss's resistance in the valuation (never invent).

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/PassiveSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/PassiveSolverTest.kt
@@ -72,7 +72,7 @@ class PassiveSolverTest {
                     .last()
                     .individual
 
-            assertThat(build.passives.map { it.name })
+            assertThat(build.passives.mapNotNull { it.name?.fr })
                 .describedAs("the forced passive loadout rides on the discovered build")
                 .contains("Ligne")
             val achieved = computeCharacteristicsValues(build, character.baseCharacteristicValues, emptyMap(), emptyMap())
@@ -89,7 +89,7 @@ class PassiveSolverTest {
         val firePassive =
             me.chosante.common.Passive(
                 spellId = -1,
-                name = "Synthetic Fire",
+                name = me.chosante.common.I18nText("Synthetic Fire", "Synthetic Fire", "Synthetic Fire", "Synthetic Fire"),
                 clazz = "FECA",
                 gfxId = 0,
                 flatBuildStats = mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE.name to 50.0)

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2269,11 +2269,37 @@ class WakfuBuildSolverTest {
             assertThat(proven!!.matchPercentage.signum()).isGreaterThan(0)
         }
 
+    @Test
+    @Tag("slow")
+    fun `max-damage proves OPTIMAL with runes and sublimations on the full level-110 pool`(): Unit =
+        runBlocking {
+            // Runes were the provability wall: each socketed item added per-stat integer count vars that blew
+            // up the branch space, so the full GUI config (runes + sublimations ON) never proved. The
+            // single-type rune FOLD (createRuneModel) collapses that to one boolean pick per item, restoring a
+            // PROVEN optimum here — the regression guard for the fold. Real embedded runes + sublimations.
+            val params = fireMaxDamageParams(110).copy(useRunes = true, useSublimations = true)
+            val results =
+                WakfuBuildSolver
+                    .optimize(
+                        params,
+                        fullEpicPool(110),
+                        WakfuBestBuildFinderAlgorithm.runes,
+                        WakfuBestBuildFinderAlgorithm.sublimations,
+                        WakfuBuildSolver.SolverTuning(maxDeterministicTime = 600.0)
+                    ).toList()
+            val proven = results.lastOrNull { it.isOptimal }
+            assertThat(proven)
+                .describedAs("the single-type rune fold must let CP-SAT PROVE the runes+subs lvl-110 optimum (was never proving)")
+                .isNotNull
+            assertThat(proven!!.matchPercentage.signum()).describedAs("the proven build deals real damage").isGreaterThan(0)
+        }
+
     /** Constraint-free max-damage request for [clazz] at [level] against [scenario] (empty targets ⇒ pure damage). */
     private fun maxDamageShape(
         clazz: CharacterClass,
         level: Int,
         scenario: DamageScenario,
+        useRunes: Boolean = false,
     ): WakfuBestBuildParams =
         WakfuBestBuildParams(
             character = Character(clazz, level, 0, CharacterSkills(level)),
@@ -2284,9 +2310,45 @@ class WakfuBuildSolverTest {
             forcedItems = emptyList(),
             excludedItems = emptyList(),
             scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE,
-            useRunes = false,
+            useRunes = useRunes,
             useSublimations = false,
             damageScenario = scenario
+        )
+
+    /**
+     * A socketed, high-stat pool + a mastery/crit-mastery rune set (some colour-doubled) for the rune-aware
+     * soundness lock. The runes let a loose solve fill every socket and drive the scenario-mastery M to its
+     * end-game max — exactly the path the socket-aware [WakfuBuildSolver] rune-overcount tightening bounds, so
+     * an under-estimate there (a silently cut optimum) surfaces as an out-of-range tracked var.
+     */
+    private fun soundnessSocketedPool(): Map<ItemType, List<Equipment>> =
+        listOf(
+            equipment(
+                1,
+                ItemType.AMULET,
+                "Amu",
+                mapOf(Characteristic.MASTERY_ELEMENTARY to 1000, Characteristic.MASTERY_CRITICAL to 600, Characteristic.CRITICAL_HIT to 50),
+                maxShardSlots = 4,
+                level = 245
+            ),
+            equipment(2, ItemType.BELT, "Belt", mapOf(Characteristic.MASTERY_ELEMENTARY to 1000, Characteristic.ACTION_POINT to 10), maxShardSlots = 4, level = 245),
+            equipment(3, ItemType.CHEST_PLATE, "Chest", mapOf(Characteristic.MASTERY_DISTANCE to 900, Characteristic.MASTERY_MELEE to 900), maxShardSlots = 4, level = 245),
+            equipment(4, ItemType.CAPE, "Cape", mapOf(Characteristic.MASTERY_BACK to 800, Characteristic.MASTERY_BERSERK to 800), maxShardSlots = 4, level = 245),
+            equipment(5, ItemType.BOOTS, "Boots", mapOf(Characteristic.MASTERY_ELEMENTARY to 700), maxShardSlots = 3, level = 245),
+            equipment(6, ItemType.HELMET, "Helm", mapOf(Characteristic.MASTERY_CRITICAL to 700, Characteristic.CRITICAL_HIT to 50), maxShardSlots = 4, level = 245),
+            equipment(7, ItemType.RING, "Ring1", mapOf(Characteristic.MASTERY_ELEMENTARY to 500), maxShardSlots = 4, level = 245),
+            equipment(8, ItemType.RING, "Ring2", mapOf(Characteristic.MASTERY_DISTANCE to 500), maxShardSlots = 4, level = 245)
+        ).groupBy { it.itemType }
+
+    /** Mastery + crit-mastery runes spanning colours (some doubled on the pool's slots) for the rune soundness lock. */
+    private fun soundnessRunes(): List<RuneType> =
+        listOf(
+            RuneType(1, I18nText("elem", "elem", "elem", "elem"), RuneColor.RED, Characteristic.MASTERY_ELEMENTARY, listOf(10, 15), 0),
+            RuneType(2, I18nText("dist", "dist", "dist", "dist"), RuneColor.GREEN, Characteristic.MASTERY_DISTANCE, listOf(10, 15), 0),
+            RuneType(3, I18nText("melee", "melee", "melee", "melee"), RuneColor.BLUE, Characteristic.MASTERY_MELEE, listOf(10, 15), 0),
+            RuneType(4, I18nText("back", "back", "back", "back"), RuneColor.RED, Characteristic.MASTERY_BACK, listOf(10, 15), 0),
+            RuneType(5, I18nText("zerk", "zerk", "zerk", "zerk"), RuneColor.GREEN, Characteristic.MASTERY_BERSERK, listOf(10, 15), 0),
+            RuneType(6, I18nText("crit", "crit", "crit", "crit"), RuneColor.BLUE, Characteristic.MASTERY_CRITICAL, listOf(10, 15), 0)
         )
 
     @Test
@@ -2359,6 +2421,88 @@ class WakfuBuildSolverTest {
             assertThat(bounds.filterNot { it.withinBound })
                 .describedAs("$name: each is a var whose reachable bound under-estimated its real value — a silently cut optimum")
                 .isEmpty()
+        }
+
+        // RUNE-AWARE shapes: runes are what the socket-aware scenario-mastery bound (runeMasteryOverCount)
+        // tightens, so a loose solve must fill every socket and still land within the tightened reachable M.
+        // Spans face/rear+berserk (different mastery-term sets) and lvl-245 magnitudes. Without these the
+        // rune-overcount tightening would be unguarded — an under-estimate there silently cuts the optimum.
+        val socketed = soundnessSocketedPool()
+        val runes = soundnessRunes()
+        val runeShapes: List<Pair<String, WakfuBestBuildParams>> =
+            listOf(
+                "cra-fire-110-runes" to
+                    maxDamageShape(
+                        CharacterClass.CRA,
+                        110,
+                        DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                        useRunes = true
+                    ),
+                "iop-fire-110-runes-melee" to
+                    maxDamageShape(
+                        CharacterClass.IOP,
+                        110,
+                        DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.MELEE, orientation = Orientation.FACE),
+                        useRunes = true
+                    ),
+                "cra-rear-berserk-110-runes" to
+                    maxDamageShape(
+                        CharacterClass.CRA,
+                        110,
+                        DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.BACK, berserk = true),
+                        useRunes = true
+                    ),
+                "cra-fire-245-runes" to
+                    maxDamageShape(
+                        CharacterClass.CRA,
+                        245,
+                        DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                        useRunes = true
+                    )
+            )
+        runeShapes.forEach { (name, params) ->
+            val bounds = WakfuBuildSolver.maxDamageVarBoundsForTest(params, socketed, tuning, runes)
+            assertThat(bounds).describedAs("$name: the objective chain must be tracked").isNotEmpty
+            assertThat(bounds.filterNot { it.withinBound })
+                .describedAs("$name: a rune-fed var exceeded its socket-aware reachable bound — runeMasteryOverCount cut the optimum")
+                .isEmpty()
+        }
+    }
+
+    @Test
+    fun `single-type rune fold preserves the max-damage optimum`() {
+        // The fold fills each item with ONE rune type (a boolean pick) instead of a free per-stat count.
+        // Because a rune's value is uniform across an item's sockets (RuneType.valueOn doubles per item-SLOT,
+        // not per socket), single-type fill is provably ≥ any intra-item mix — so the folded optimum must
+        // EQUAL the per-stat COUNT model's optimum (forceRuneCountModel) on the same rune pool. If the fold
+        // ever cut the optimum (e.g. if the model gained per-socket colours), these would diverge. Spans a
+        // face build and a rear+berserk build (more secondary mastery terms competing for the sockets).
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val pool = soundnessSocketedPool()
+        val runes = soundnessRunes()
+        listOf(
+            "face" to
+                maxDamageShape(
+                    CharacterClass.CRA,
+                    110,
+                    DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE),
+                    useRunes = true
+                ),
+            "rear-berserk" to
+                maxDamageShape(
+                    CharacterClass.CRA,
+                    110,
+                    DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.BACK, berserk = true),
+                    useRunes = true
+                )
+        ).forEach { (name, params) ->
+            val fold = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes)
+            val count = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes, forceRuneCountModel = true)
+            assertThat(fold.isOptimal).describedAs("$name: the folded model proves OPTIMAL").isTrue()
+            assertThat(count.isOptimal).describedAs("$name: the count model proves OPTIMAL").isTrue()
+            assertThat(fold.objective)
+                .describedAs("$name: the single-type rune fold must not change the optimum (fold == count)")
+                .isEqualTo(count.objective)
         }
     }
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2116,6 +2116,195 @@ class WakfuBuildSolverTest {
             ).contains("DistSub")
         }
 
+    private fun achievedStats(
+        build: BuildCombination,
+        character: Character,
+    ): Map<Characteristic, Int> =
+        computeCharacteristicsValues(
+            build,
+            character.baseCharacteristicValues,
+            masteryElementsWanted = emptyMap(),
+            resistanceElementsWanted = emptyMap(),
+            scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+        )
+
+    @Test
+    fun `most-masteries does not take a damage-reducing sublimation just to overshoot a met target`(): Unit =
+        runBlocking {
+            // Regression for the reported Enutrof case: most-masteries used to be blind to the % Damage Inflicted
+            // multiplier, so it grabbed Swiftness II (+1 MP, −20% DI) purely to over-satisfy an already-met MP
+            // target — inflating the mastery "match" while cutting ~20% of real damage. Now DI is folded into the
+            // objective, so a −20% DI sub buys nothing the tiny overshoot bonus can justify.
+            val character = Character(CharacterClass.ENUTROF, 1, 1, CharacterSkills(1))
+            val carrier = equipment(1, ItemType.AMULET, "Carrier", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4)
+            val swiftnessLike =
+                sublimation(
+                    20,
+                    SublimationRarity.NORMAL,
+                    SublimationKind.FLAT,
+                    "Swiftness II",
+                    effects =
+                        listOf(
+                            SublimationEffect(Characteristic.DAMAGE_INFLICTED, -20),
+                            SublimationEffect(Characteristic.MOVEMENT_POINT, 1)
+                        ),
+                    slotColorPattern = listOf(1, 2, 3)
+                )
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    // MP base is 3, so the MP target is met WITHOUT the sub; the sub would only overshoot it
+                    // (3→4) for a tiny tie-breaker bonus — far less than the 20% damage it costs.
+                    targetStats =
+                        TargetStats(
+                            listOf(
+                                TargetStat(Characteristic.MASTERY_DISTANCE, 1),
+                                TargetStat(Characteristic.MOVEMENT_POINT, 3)
+                            )
+                        ),
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, listOf(carrier).groupBy { it.itemType }, emptyList(), listOf(swiftnessLike), WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            assertThat(
+                best.individual.sublimations.values
+                    .flatten()
+                    .map { it.name.en }
+            ).doesNotContain("Swiftness II")
+            assertThat(achievedStats(best.individual, character)[Characteristic.DAMAGE_INFLICTED] ?: 0).isGreaterThanOrEqualTo(0)
+        }
+
+    @Test
+    fun `most-masteries rejects a damage-reducing sublimation even when NO mastery is requested`(): Unit =
+        runBlocking {
+            // Backstop case: a most-masteries request with only a required target (MP) and no maximizable mastery.
+            // The DI fold is then structurally 0 (nothing to multiply), so without the backstop the overshoot
+            // tie-breaker would grab the +1 MP / −20% DI sub to over-satisfy MP — the original Enutrof bug in its
+            // pure required-only form. The backstop drops the −DI sub when no mastery is being maximized.
+            val character = Character(CharacterClass.ENUTROF, 1, 1, CharacterSkills(1))
+            val carrier = equipment(1, ItemType.AMULET, "Carrier", mapOf(Characteristic.HP to 50), maxShardSlots = 4)
+            val swiftnessLike =
+                sublimation(
+                    20,
+                    SublimationRarity.NORMAL,
+                    SublimationKind.FLAT,
+                    "Swiftness II",
+                    effects =
+                        listOf(
+                            SublimationEffect(Characteristic.DAMAGE_INFLICTED, -20),
+                            SublimationEffect(Characteristic.MOVEMENT_POINT, 1)
+                        ),
+                    slotColorPattern = listOf(1, 2, 3)
+                )
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = TargetStats(listOf(TargetStat(Characteristic.MOVEMENT_POINT, 3))),
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, listOf(carrier).groupBy { it.itemType }, emptyList(), listOf(swiftnessLike), WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            assertThat(
+                best.individual.sublimations.values
+                    .flatten()
+                    .map { it.name.en }
+            ).doesNotContain("Swiftness II")
+            assertThat(achievedStats(best.individual, character)[Characteristic.DAMAGE_INFLICTED] ?: 0).isGreaterThanOrEqualTo(0)
+        }
+
+    @Test
+    fun `most-masteries maximizes damage inflicted among equal-mastery builds`(): Unit =
+        runBlocking {
+            // DI is now a maximized factor: between two amulets with identical requested mastery, the one that
+            // also carries +% Damage Inflicted wins, because mastery × (1 + DI/100) is higher.
+            val character = Character(CharacterClass.CRA, 50, 50, CharacterSkills(50))
+            val plain = equipment(1, ItemType.AMULET, "Plain", mapOf(Characteristic.MASTERY_DISTANCE to 200))
+            val withDi = equipment(2, ItemType.AMULET, "WithDI", mapOf(Characteristic.MASTERY_DISTANCE to 200, Characteristic.DAMAGE_INFLICTED to 30))
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 1))),
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, listOf(plain, withDi).groupBy { it.itemType }, emptyList(), emptyList(), WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            // The +DI amulet wins (the AMULET slot holds at most one); the build can additionally route the
+            // Major aptitude into DI now that it's maximized, so we assert the DI item was chosen, not an exact total.
+            assertThat(best.individual.equipments.map { it.name.en }).contains("WithDI").doesNotContain("Plain")
+        }
+
+    @Test
+    fun `most-masteries still takes a damage-reducing sublimation when its mastery gain outweighs the DI loss`(): Unit =
+        runBlocking {
+            // The fold is a nuanced tradeoff, not a blanket ban (the old safety filter wrongly rejected this):
+            // a −20% DI sub that ALSO adds a large chunk of the maximized mastery is net-positive for real
+            // damage, so it must be taken. 50 base distance → 550 with the sub; 550 × 0.8 = 440 > 50.
+            val character = Character(CharacterClass.CRA, 50, 50, CharacterSkills(50))
+            val carrier = equipment(1, ItemType.AMULET, "Carrier", mapOf(Characteristic.MASTERY_DISTANCE to 50), maxShardSlots = 4)
+            val bigMasterySub =
+                sublimation(
+                    21,
+                    SublimationRarity.NORMAL,
+                    SublimationKind.FLAT,
+                    "PowerfulButCostly",
+                    effects =
+                        listOf(
+                            SublimationEffect(Characteristic.MASTERY_DISTANCE, 500),
+                            SublimationEffect(Characteristic.DAMAGE_INFLICTED, -20)
+                        ),
+                    slotColorPattern = listOf(1, 2, 3)
+                )
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 1))),
+                    searchDuration = 5.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, listOf(carrier).groupBy { it.itemType }, emptyList(), listOf(bigMasterySub), WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            assertThat(
+                best.individual.sublimations.values
+                    .flatten()
+                    .map { it.name.en }
+            ).contains("PowerfulButCostly")
+        }
+
     private fun assertSolverReachesExhaustiveOptimum(
         equipments: List<Equipment>,
         targetStats: TargetStats,

--- a/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Extract.kt
+++ b/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Extract.kt
@@ -7,7 +7,9 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
+import me.chosante.common.I18nText
 import me.chosante.common.Monster
+import me.chosante.common.SpellLocalization
 import java.io.File
 import kotlin.math.abs
 
@@ -87,13 +89,13 @@ data class DeclaredEffect(
 @Serializable
 data class PassiveEntry(
     val spellId: Int,
-    val name: String?,
+    val name: I18nText?,
     val breedId: Int,
     @SerialName("class") val clazz: String,
     // Spell sprite id (Spell table `gfx_id`). Names the passive's icon PNG (`assets/spells/<gfxId>.png`,
     // extracted from the client's gui.jar — the same set the active-spell icons come from) so the GUI can render it.
     val gfxId: Int,
-    val description: String?,
+    val description: I18nText?,
     val effectIds: List<Int>,
     val declaredEffects: List<DeclaredEffect>,
     val flatBuildStats: Map<String, JsonElement>,
@@ -272,12 +274,36 @@ private class Resolved(
     val permanent: Boolean,
 )
 
+// i18n namespaces in the client text bundle: spell name (3) and spell description (4).
+private const val NS_SPELL_NAME = 3
+private const val NS_SPELL_DESCRIPTION = 4
+
+/**
+ * Per-spell localized name + description for the active class spells, straight from the client i18n bundle
+ * (name = namespace 3, description = namespace 4, all four languages). Joined onto `spells.json` by id in
+ * SpellCatalog so the GUI shows translated spell text — the encyclopedia scrape only carried English
+ * descriptions. Passives carry their own text in spell-passives.json, so they're excluded here.
+ */
+fun buildSpellLocalizations(
+    spells: Table,
+    i18n: I18nBundle,
+): List<SpellLocalization> =
+    spells.records
+        .filter { (it["breed_id"] as Int) in PLAYER_BREEDS && (it["passive"] as Int) != 2 }
+        .sortedWith(compareBy({ it["breed_id"] as Int }, { it["id"] as Int }))
+        .mapNotNull { r ->
+            val id = r["id"] as Int
+            val name = i18n.text(NS_SPELL_NAME, id) ?: return@mapNotNull null
+            SpellLocalization(spellId = id, name = name, description = i18n.text(NS_SPELL_DESCRIPTION, id))
+        }
+
 /** Passives artifact: catalogue + resolved declarative effects + a conservative permanent-stat rollup. */
 fun buildPassives(
     spells: Table,
     effects: Table,
     actions: ActionCatalog,
     names: Map<Int, SpellInfo>,
+    i18n: I18nBundle,
 ): List<PassiveEntry> {
     @Suppress("UNCHECKED_CAST")
     fun intList(v: Any?): List<Int> = (v as List<Any?>).map { it as Int }
@@ -388,13 +414,15 @@ fun buildPassives(
                 }
             }
 
+            // Localized name/description from the client i18n bundle (all four languages); fall back to the
+            // encyclopedia's French text (widened to all languages) only if the bundle lacks the key.
             PassiveEntry(
                 spellId = id,
-                name = names[id]?.nameFr,
+                name = i18n.text(NS_SPELL_NAME, id) ?: names[id]?.nameFr?.let { I18nText(it, it, it, it) },
                 breedId = breed,
                 clazz = BREED_TO_CLASS.getValue(breed),
                 gfxId = gfx,
-                description = names[id]?.descFr,
+                description = i18n.text(NS_SPELL_DESCRIPTION, id) ?: names[id]?.descFr?.let { I18nText(it, it, it, it) },
                 effectIds = effectIds,
                 declaredEffects =
                     resolved.map {

--- a/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Main.kt
+++ b/bdata-extractor/src/main/kotlin/me/chosante/bdataextractor/Main.kt
@@ -11,6 +11,7 @@ import me.chosante.common.Monster
 import me.chosante.common.RuneType
 import me.chosante.common.Spell
 import me.chosante.common.SpellDamageScaling
+import me.chosante.common.SpellLocalization
 import me.chosante.common.Sublimation
 import me.chosante.common.WakfuData
 import me.chosante.common.findRepositoryRoot
@@ -80,9 +81,18 @@ fun main(args: Array<String>) {
     val castJson = json.encodeToString(ListSerializer(CastLimit.serializer()), castLimits)
     verifyAndWrite(File(resources, "spell-cast-limits.json"), castJson, "cast-limits", castLimits.size, force)
 
-    val passives = buildPassives(spells, effects, actions, names)
+    // Localization bundle, loaded once and reused for monsters below: spell name (3) + spell description (4)
+    // for passives, monster name (7) + family (38) for the bestiary.
+    val i18n = I18nBundle.load(install, namespaces = setOf(3, 4, 7, 38))
+    val passives = buildPassives(spells, effects, actions, names, i18n)
     val passivesJson = json.encodeToString(ListSerializer(PassiveEntry.serializer()), passives)
     verifyAndWrite(File(resources, "spell-passives.json"), passivesJson, "passives", passives.size, force)
+
+    // Per-spell localized name + description (i18n namespaces 3 + 4), joined onto spells.json by id in
+    // SpellCatalog so the GUI shows translated spell text instead of the encyclopedia's English-only descriptions.
+    val spellLocalizations = buildSpellLocalizations(spells, i18n)
+    val spellI18nJson = json.encodeToString(ListSerializer(SpellLocalization.serializer()), spellLocalizations)
+    verifyAndWrite(File(resources, "spell-i18n.json"), spellI18nJson, "spell-i18n", spellLocalizations.size, force)
 
     // Spell damage scalings: the per-level [base, inc] formula from bdata, anchored on the encyclopedia's
     // max-level value so SpellDamage scales each hit to the caster's level (the encyclopedia only knows one
@@ -133,7 +143,6 @@ fun main(args: Array<String>) {
     println("Decoding Monster table (42)…")
     val monsterRecords = loadTable(install, Tables.MONSTER, monsterSchema).records
     println("  ${monsterRecords.size} records (size-guard passed)")
-    val i18n = I18nBundle.load(install, namespaces = setOf(7, 38))
     val ranks = loadMonsterRanks(File(resources, "monster-overlay.json"))
     println("Loaded ${ranks.size} boss rank overrides")
     val monsters = buildMonsters(monsterRecords, i18n, ranks)

--- a/common-lib/src/main/kotlin/me/chosante/common/I18nTextOrStringSerializer.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/I18nTextOrStringSerializer.kt
@@ -1,0 +1,38 @@
+package me.chosante.common
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Reads an [I18nText] that may be stored **either** as a localized object `{fr,en,es,pt}` (the current form)
+ * **or** as a legacy plain string. Older saved builds wrote a passive's name/description as a single string;
+ * once those fields became [I18nText] those files would no longer load. A legacy string is widened to the
+ * same text in all four languages so old history keeps loading; new data always writes the object form.
+ *
+ * Used for [Passive.name] / [Passive.description] (via `@Serializable(with = …)`), which is why it lives in
+ * `common-lib` next to [I18nText]. Falls back to the plain object serializer for non-JSON formats.
+ */
+object I18nTextOrStringSerializer : KSerializer<I18nText> {
+    override val descriptor: SerialDescriptor = I18nText.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): I18nText {
+        val json = decoder as? JsonDecoder ?: return I18nText.serializer().deserialize(decoder)
+        val element = json.decodeJsonElement()
+        return if (element is JsonPrimitive && element.isString) {
+            element.content.let { I18nText(fr = it, en = it, es = it, pt = it) }
+        } else {
+            json.json.decodeFromJsonElement(I18nText.serializer(), element)
+        }
+    }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: I18nText,
+    ) {
+        I18nText.serializer().serialize(encoder, value)
+    }
+}

--- a/common-lib/src/main/kotlin/me/chosante/common/Passive.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/Passive.kt
@@ -20,14 +20,19 @@ import kotlin.math.roundToInt
 @Serializable
 data class Passive(
     val spellId: Int,
-    val name: String? = null,
+    // Localized from the client i18n bundle (name = namespace 3, description = namespace 4). Read with a
+    // tolerant serializer so OLDER saved builds — which stored these as a single plain string — still load
+    // (the legacy string is widened to all four languages). See [I18nTextOrStringSerializer].
+    @Serializable(with = I18nTextOrStringSerializer::class)
+    val name: I18nText? = null,
     // Game data stores the class as its readable name ("FECA", …); kept as a String because CharacterClass
     // is not @Serializable. Resolve via [characterClass].
     @SerialName("class") val clazz: String,
     // Spell sprite id — names the icon PNG (`assets/spells/<gfxId>.png`, extracted from the client's gui.jar).
     // Defaulted so a pre-`gfxId` artifact still decodes (lenient JSON skips extra keys, not missing ones).
     val gfxId: Int = 0,
-    val description: String? = null,
+    @Serializable(with = I18nTextOrStringSerializer::class)
+    val description: I18nText? = null,
     // Permanent, unconditional, flat positive stats (keyed by Characteristic name). Decoded as Double to
     // tolerate the extractor's number formatting; folded to Int via [flatStats].
     val flatBuildStats: Map<String, Double> = emptyMap(),

--- a/common-lib/src/main/kotlin/me/chosante/common/SpellDamage.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/SpellDamage.kt
@@ -10,8 +10,8 @@ import kotlin.math.max
  * the expected hit, using Wakfu's exact single-hit formula:
  *
  * ```
- * hit   = Base × (1 + ΣMastery/100) × (1 + ΣDamageInflicted/100) × (1 − Res%/100)
- * crit  = Base_crit × 1.25 × (1 + (ΣMastery + criticalMastery)/100) × (1 + ΣDI/100) × (1 − Res%/100)
+ * hit   = Base × (1 + ΣMastery/100) × (1 + ΣDamageInflicted/100) × (1 − Res%/100) × Orientation
+ * crit  = Base_crit × 1.25 × (1 + (ΣMastery + criticalMastery)/100) × (1 + ΣDI/100) × (1 − Res%/100) × Orientation
  * E[hit] = (1 − p)·hit + p·crit                       // p = usable crit rate
  * ```
  *
@@ -52,6 +52,10 @@ object SpellDamage {
      * @param rangeBand secondary mastery to fold in (melee/distance), or `null` to ignore it.
      * @param rearMastery include [Characteristic.MASTERY_BACK] (a back hit).
      * @param berserkMastery include [Characteristic.MASTERY_BERSERK] (caster at/below 50% HP).
+     * @param orientationMultiplierPercent the positional damage multiplier as a percent (100 = face, 110 =
+     *   side, 125 = back). In Wakfu a hit from behind deals ×1.25 *and* grants rear mastery, so a back-hit
+     *   scenario passes `orientationMultiplierPercent = 125` together with `rearMastery = true`. Defaults to
+     *   100 (face), leaving existing neutral calls unchanged.
      * @param targetResistancePercent target's effective elemental resistance % (signed; negative =
      *   weakness), clamped to ≤ [MAX_RESISTANCE_PERCENT]. A flat multiplier — does not change relative
      *   build ranking, only the displayed number.
@@ -67,6 +71,7 @@ object SpellDamage {
         rangeBand: RangeBand? = null,
         rearMastery: Boolean = false,
         berserkMastery: Boolean = false,
+        orientationMultiplierPercent: Int = 100,
         targetResistancePercent: Int = 0,
         critCapPercent: Int = 100,
     ): Result? {
@@ -94,9 +99,12 @@ object SpellDamage {
         val resistanceFactor =
             1.0 - targetResistancePercent.coerceIn(-100, MAX_RESISTANCE_PERCENT) / 100.0
         val diFactor = 1.0 + damageInflicted / 100.0
+        // Positional multiplier (face 1.0 / side 1.10 / back 1.25), a flat factor on every hit — mirrors
+        // FindMaxDamageScoring's orientation factor. Floored at 0 to never flip the sign of a hit.
+        val orientationFactor = max(orientationMultiplierPercent, 0) / 100.0
 
-        val nonCrit = base * (1.0 + mastery / 100.0) * diFactor * resistanceFactor
-        val crit = baseCrit * CRIT_MULTIPLIER * (1.0 + (mastery + critMastery) / 100.0) * diFactor * resistanceFactor
+        val nonCrit = base * (1.0 + mastery / 100.0) * diFactor * resistanceFactor * orientationFactor
+        val crit = baseCrit * CRIT_MULTIPLIER * (1.0 + (mastery + critMastery) / 100.0) * diFactor * resistanceFactor * orientationFactor
         val expected = (1.0 - critRate) * nonCrit + critRate * crit
         return Result(expected = expected, nonCrit = nonCrit, crit = crit)
     }

--- a/common-lib/src/main/kotlin/me/chosante/common/SpellLocalization.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/SpellLocalization.kt
@@ -1,0 +1,17 @@
+package me.chosante.common
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-spell localized name + description, decoded from the local client's i18n bundle (name = namespace 3,
+ * description = namespace 4) by `bdata-extractor` into `spell-i18n.json`. Joined onto the encyclopedia-scraped
+ * `spells.json` by [spellId] in `SpellCatalog`, so the GUI shows fully-translated spell text — the
+ * encyclopedia scrape only ever carried English descriptions (all four language slots held the same English
+ * string), whereas the client bundle has real fr/en/es/pt.
+ */
+@Serializable
+data class SpellLocalization(
+    val spellId: Int,
+    val name: I18nText,
+    val description: I18nText? = null,
+)

--- a/common-lib/src/main/kotlin/me/chosante/common/skills/Major.kt
+++ b/common-lib/src/main/kotlin/me/chosante/common/skills/Major.kt
@@ -176,8 +176,9 @@ sealed class MajorCharacteristic(
             // +10 points of "% Damage Inflicted" per assigned point. Modeled as a FIXED contribution to
             // the dedicated DAMAGE_INFLICTED stat (a percentage measured in points, like mastery is a flat
             // number), NOT as a percent on elemental mastery: in the Wakfu damage formula "% damage" is a
-            // separate multiplicative factor (1 + ΣDI/100), distinct from mastery. Only the max-damage mode
-            // reads DAMAGE_INFLICTED, so this aptitude is inert in the most-masteries / precision modes.
+            // separate multiplicative factor (1 + ΣDI/100), distinct from mastery. Both the max-damage mode and
+            // the most-masteries mode read DAMAGE_INFLICTED (the latter maximizes mastery × (1 + DI/100)), so
+            // this aptitude is inert only in the precision mode (which hits exact requested targets).
             unitValue = 10,
             unitType = UnitType.FIXED,
             characteristic = Characteristic.DAMAGE_INFLICTED,

--- a/common-lib/src/test/kotlin/me/chosante/common/SpellDamageTest.kt
+++ b/common-lib/src/test/kotlin/me/chosante/common/SpellDamageTest.kt
@@ -117,6 +117,19 @@ class SpellDamageTest {
     }
 
     @Test
+    fun `the orientation multiplier scales every hit (a back hit also folds in rear mastery)`() {
+        val stats = mapOf(Characteristic.MASTERY_BACK to 100)
+        // Face (default 100%) ignores rear mastery: raw base hit.
+        assertEquals(60.0, SpellDamage.expectedDamage(blazingArrow, stats, maxLevel)!!.nonCrit, 1e-9)
+        // Side: ×1.10 positional, still no rear mastery.
+        assertEquals(66.0, SpellDamage.expectedDamage(blazingArrow, stats, maxLevel, orientationMultiplierPercent = 110)!!.nonCrit, 1e-9)
+        // Back: ×1.25 positional AND +100% rear mastery → 60 × 2 × 1.25 = 150.
+        val back =
+            SpellDamage.expectedDamage(blazingArrow, stats, maxLevel, rearMastery = true, orientationMultiplierPercent = 125)!!
+        assertEquals(150.0, back.nonCrit, 1e-9)
+    }
+
+    @Test
     fun `critDamage falls back to the normal base when the spell exposes none`() {
         val noCritBase = blazingArrow.copy(critDamage = null)
         val r = SpellDamage.expectedDamage(noCritBase, mapOf(Characteristic.CRITICAL_HIT to 100), maxLevel)!!

--- a/docs/MAX_DAMAGE_PROVABLE_OPTIMUM.md
+++ b/docs/MAX_DAMAGE_PROVABLE_OPTIMUM.md
@@ -341,9 +341,11 @@ prefilter stays on for multi-element requests (3.8 s vs 72 s), but no longer mis
 - [ ] **Dominance pruning** — implement, measure model-size + det-time drop, prove soundness on samples.
       (Now the lever for ~1–3 s, esp. to cut the lvl-245 ~3.5 min proof.)
 - [ ] **Warm-start hint** — measure det-time with/without.
-- [ ] Does the free model still prove with **runes + subs** enabled (more vars/products)? The tracked chain
-      stays sound with them on (sub-conversion `moved` falls back to the guard ⇒ only looser, never unsound),
-      but provability is unverified — measure.
+- [x] Does the free model still prove with **runes + subs** enabled? **MEASURED: NO** with the old per-stat
+      integer rune counts (CRA fire lvl-110, full pool: never proved in **7 min**; runes are the dominant cost —
+      subs-only proved in ~66 s, runes-only didn't in 150 s). **FIXED by the single-type rune fold (§9).** Now
+      proves in **~82–106 s walltime** / det-time 600, same optimum. (The choosable subs are all fine: 0 are
+      conversions, and the 3 `SECONDARY_MASTERIES_AT_MOST` ones have value=0 ⇒ all-elemental, no intra-item mix.)
 - [ ] Production (`tuning==null`, wall-clock, cores−1 workers) timing vs the tuning-path numbers here.
 - [x] Higher-level pools (245) — proves at `maxDeterministicTime=600` (~3.5 min walltime). Budget/fallback
       threshold tuning (graceful "best found" when a pool can't prove in the wall-clock budget) still open.
@@ -383,6 +385,49 @@ to the winning element so each probe is a fast single-element solve), and is the
 `maxDamageHeuristicPhases`. Locked by `MaxDamageSearchTest "boss multi-element loop proves the optimum via
 per-element enumeration"`. NOTE: `solveProbe` must tie-break toward `isOptimal` (CP-SAT emits the optimal build
 un-proven first, then proven — a plain `maxBy{score}` returns the un-proven copy and loses the proof).
+
+---
+
+## 8b. Landed (2026-06-24): the single-type rune FOLD cracks runes+subs provability
+
+**The wall.** With runes+subs ON (the GUI default) the free max-damage solve never proved (CRA fire lvl-110,
+full pool: no proof in **7 min**). Isolation: **runes** are the dominant cost (subs-only proved ~66 s;
+runes-only didn't in 150 s). The old rune model gave every socketable POOL item one INTEGER count var per rune
+stat (0..slots), Σ ≤ slots·equipped — hundreds of integer vars whose branching the proof can't close.
+
+**Two domain levers (sound, shipped, but not enough alone):**
+1. `fillSocketsForMaxDamage` — for max-damage the socket cap becomes Σ = slots·equipped (full fill). The generic
+   elemental-mastery rune is non-secondary and only raises the (constraint-free) objective, and overshooting a
+   required target is never penalised (`requiredConstraintPenaltyFactor` caps actual at target), so the optimum
+   always fills its sockets; pinning equality removes the underfill assignments. Cut combinations, didn't prove.
+2. `runeMasteryOverCount` — the scenario-mastery `preM` naive sum double-counts runes ACROSS its mastery stats
+   (each stat's reach assumes its rune fills every socket, but sockets are shared). Subtract that provable
+   over-count (`naiveRuneSum − socketAwareMax`, per-slot best) to tighten M's declared upper bound. Tightened
+   the bound, still didn't prove (the integer var COUNT was the wall).
+
+**The fix — single-type rune fold (`createRuneModel`).** Key fact: `RuneType.valueOn` doubles per item-SLOT,
+uniform across an item's sockets (NOT per socket), so a rune's value on an item is fixed ⇒ filling an item
+entirely with its single best-value type is ≥ any intra-item MIX (the objective is linear in each mastery for a
+fixed build; the per-item choice is build-dependent only through which marginal wins). So intra-item mixing is
+freedom the optimum never uses. Replace the per-(item,stat) integer counts with ONE BOOLEAN PICK per stat per
+item, Σ picks = equipped; a pick contributes `slots·coeff`, leaf seeded 0..1. Collapsing the integers to
+booleans is what lets CP-SAT PROVE: **runes+subs now proves in ~82–106 s** (same optimum the count model
+reaches but can't certify). Gated to where single-type is provably optimal: max-damage, no forced runes, and no
+`SECONDARY_MASTERIES_AT_MOST` sub with value>0 in play (there an intra-item secondary/elemental mix can be
+optimal — but every choosable such sub has value=0; a forced one falls back to the count model). The other
+modes / no-rune / forced-rune paths keep the count model byte-identical.
+
+**Verification.** `single-type rune fold preserves the max-damage optimum` (fold optimum == count optimum on a
+socketed rune pool, via the `forceRuneCountModel` seam) + the rune-aware `max-damage reachable bounds hold`
+panel (now socketed + runes) + a head-to-head (fold proves 6598 in 82 s; count reaches the SAME 6598 unproven
+in 200 s) + the slow det-time lock `max-damage proves OPTIMAL with runes and sublimations on the full level-110
+pool` + a 5-dimension adversarial review (all sound, 0 confirmed issues). Caveat: the fold's optimality is tied
+to per-item (not per-socket) doubling — revisit if the rune model ever gains per-socket colours.
+
+**Not "seconds".** Runes+subs is now ~bare-model proof time (~1.5 min); the ~1–3 s target still needs §7
+dominance-pruning (separate). A one-off run once showed a best-found 6752 vs the proven 6598 — a pre-existing
+PROXY-vs-sequenced-rotation gap (the CP throughput proxy ≠ the displayed rotation DP), not a fold regression
+(the head-to-head count run reached 6598 too); closing that gap is separate work.
 
 ---
 

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/Hairline.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/Hairline.kt
@@ -1,0 +1,16 @@
+package me.chosante.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import me.chosante.ui.theme.WColor
+
+/** A 1.dp full-width divider line in the theme's hairline colour, shared by the result/request panels. */
+@Composable
+internal fun Hairline() {
+    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/InfoTip.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/InfoTip.kt
@@ -1,0 +1,72 @@
+package me.chosante.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.chosante.ui.theme.WColor
+import me.chosante.ui.theme.WTypography
+
+/**
+ * A small circular "i" affordance that reveals [text] in a styled tooltip on hover — the same
+ * [TooltipArea] mechanism the passives result card uses (so the look and reveal delay match). Reused
+ * wherever a number needs a one-line "what does this mean" explainer, e.g. the spell "expected hit".
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun InfoTip(
+    text: String,
+    modifier: Modifier = Modifier,
+    size: Dp = 14.dp,
+) {
+    TooltipArea(
+        delayMillis = 250,
+        tooltip = {
+            Box(
+                modifier =
+                    Modifier
+                        .widthIn(max = 320.dp)
+                        .clip(RoundedCornerShape(7.dp))
+                        .background(WColor.raised)
+                        .border(1.dp, WColor.border, RoundedCornerShape(7.dp))
+                        .padding(horizontal = 10.dp, vertical = 8.dp)
+            ) {
+                Text(text = text, style = WTypography.labelSmall.copy(color = WColor.text))
+            }
+        }
+    ) {
+        Box(
+            modifier =
+                modifier
+                    .size(size)
+                    .clip(CircleShape)
+                    .border(1.dp, WColor.faint, CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "i",
+                style =
+                    WTypography.labelSmall.copy(
+                        color = WColor.muted,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 10.sp
+                    )
+            )
+        }
+    }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/Modals.kt
@@ -562,7 +562,7 @@ private fun SublimationPickerModal(onPick: (Sublimation) -> Unit) {
         }
     var query by remember { mutableStateOf("") }
     val filtered =
-        remember(query, results) {
+        remember(query, results, lang) {
             val q = query.trim()
             if (q.isBlank()) {
                 results
@@ -570,7 +570,7 @@ private fun SublimationPickerModal(onPick: (Sublimation) -> Unit) {
                 results.filter { sub ->
                     sub.name.fr.contains(q, ignoreCase = true) ||
                         sub.name.en.contains(q, ignoreCase = true) ||
-                        sub.rawText?.contains(q, ignoreCase = true) == true
+                        sublimationEffectText(sub, lang).contains(q, ignoreCase = true)
                 }
             }.sortedBy { (if (lang == Lang.FR) it.name.fr else it.name.en).lowercase() }
                 .take(120)
@@ -629,7 +629,7 @@ private fun SublimationResultRow(
                 style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.muted)
             )
         }
-        sub.rawText?.takeIf { it.isNotBlank() }?.let { effect ->
+        sublimationEffectText(sub, lang).takeIf { it.isNotBlank() }?.let { effect ->
             Text(
                 text = effect,
                 style = WTypography.labelSmall.copy(color = WColor.muted),
@@ -649,17 +649,21 @@ private fun PassivePickerModal(
     val all = remember(clazz) { PassiveCatalog.forClass(clazz) }
     var query by remember { mutableStateOf("") }
     val filtered =
-        remember(query, all) {
+        remember(query, all, lang) {
             val q = query.trim()
             if (q.isBlank()) {
                 all
             } else {
                 all.filter { passive ->
-                    passive.name?.contains(q, ignoreCase = true) == true ||
-                        passive.description?.contains(q, ignoreCase = true) == true
+                    passive.name?.localized(lang)?.contains(q, ignoreCase = true) == true ||
+                        passive.description?.localized(lang)?.contains(q, ignoreCase = true) == true
                 }
-            }.sortedBy { it.name?.lowercase().orEmpty() }
-                .take(120)
+            }.sortedBy {
+                it.name
+                    ?.localized(lang)
+                    ?.lowercase()
+                    .orEmpty()
+            }.take(120)
         }
     ModalCard(title = tr(Tr.REQUIRE_PASSIVE_TITLE)) {
         SearchField(query = query, onQueryChange = { query = it }, placeholder = tr(Tr.SEARCH_PASSIVES))
@@ -687,6 +691,7 @@ private fun PassiveResultRow(
     passive: me.chosante.common.Passive,
     onClick: () -> Unit,
 ) {
+    val lang = LocalLang.current
     Row(
         modifier =
             Modifier
@@ -702,12 +707,12 @@ private fun PassiveResultRow(
         PassiveIcon(gfxId = passive.gfxId, size = 28.dp)
         Column(verticalArrangement = Arrangement.spacedBy(3.dp), modifier = Modifier.weight(1f)) {
             Text(
-                text = passive.name ?: passive.spellId.toString(),
+                text = passive.name?.localized(lang) ?: passive.spellId.toString(),
                 style = WTypography.bodyMedium.copy(color = WColor.text, fontWeight = FontWeight.Medium),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            passive.description?.takeIf { it.isNotBlank() }?.let { effect ->
+            passive.description?.localized(lang)?.takeIf { it.isNotBlank() }?.let { effect ->
                 Text(
                     text = effect,
                     style = WTypography.labelSmall.copy(color = WColor.muted),

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/SpellVisuals.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/SpellVisuals.kt
@@ -1,0 +1,81 @@
+package me.chosante.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import me.chosante.common.I18nText
+import me.chosante.common.SpellElement
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.Tr
+import me.chosante.ui.i18n.tr
+import me.chosante.ui.theme.WColor
+
+/**
+ * Shared spell-presentation helpers used by both the "Class spells" tab and the build-comparison screen,
+ * so the element colours, localized names and icon tile stay identical in both places. A spell's icon is
+ * the same `assets/spells/<id>.png` sprite the passive icon uses ([PassiveIcon]).
+ */
+internal fun SpellElement?.elementColor(): Color =
+    when (this) {
+        SpellElement.FIRE -> WColor.fire
+        SpellElement.WATER -> WColor.water
+        SpellElement.EARTH -> WColor.earth
+        SpellElement.AIR -> WColor.air
+        null -> WColor.muted
+    }
+
+@Composable
+internal fun SpellElement.elementLabel(): String =
+    tr(
+        when (this) {
+            SpellElement.FIRE -> Tr.ELEMENT_FIRE
+            SpellElement.WATER -> Tr.ELEMENT_WATER
+            SpellElement.EARTH -> Tr.ELEMENT_EARTH
+            SpellElement.AIR -> Tr.ELEMENT_AIR
+        }
+    )
+
+/** The text in the active [lang], falling back to the other language when the preferred one is blank. */
+internal fun I18nText.localized(lang: Lang): String = (if (lang == Lang.FR) fr else en).ifBlank { if (lang == Lang.FR) en else fr }
+
+/** A spell's icon sprite in an element-tinted rounded tile. Renders an empty tile when the asset is absent. */
+@Composable
+internal fun SpellIcon(
+    iconId: Int?,
+    element: SpellElement?,
+    size: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val color = element.elementColor()
+    Box(
+        modifier =
+            modifier
+                .size(size)
+                .clip(RoundedCornerShape(9.dp))
+                .background(color.copy(alpha = 0.14f))
+                .border(1.dp, color.copy(alpha = 0.45f), RoundedCornerShape(9.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        val bitmap = iconId?.let { rememberClasspathBitmap("assets/spells/$it.png") }
+        if (bitmap != null) {
+            Image(
+                bitmap = bitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.size(size).padding(4.dp)
+            )
+        }
+    }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/SublimationText.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/SublimationText.kt
@@ -1,0 +1,85 @@
+package me.chosante.ui.components
+
+import me.chosante.common.Characteristic
+import me.chosante.common.ScenarioGate
+import me.chosante.common.Sublimation
+import me.chosante.common.SublimationCondition
+import me.chosante.common.SublimationConditionType
+import me.chosante.common.SublimationConversion
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.label
+
+private val PERCENT_CHARACS =
+    setOf(Characteristic.DAMAGE_INFLICTED, Characteristic.BLOCK_PERCENTAGE, Characteristic.CRITICAL_HIT)
+
+/**
+ * Localized effect text for a sublimation, synthesized from its **structured** [Sublimation.condition] /
+ * [Sublimation.effects] / [Sublimation.conversion] using the GUI's already-translated [Characteristic]
+ * labels. The in-game sublimation tooltip is rendered client-side (no static localized string exists), and
+ * the baked [Sublimation.rawText] is English-only — so we rebuild the text per language here, mirroring the
+ * extractor's English `synthesizeRawText`. Falls back to the English [Sublimation.rawText] for the
+ * combat-conditional subs that carry no structured effects.
+ */
+internal fun sublimationEffectText(
+    sub: Sublimation,
+    lang: Lang,
+): String {
+    val parts = ArrayList<String>()
+    sub.condition?.let { parts.add(conditionText(it, lang)) }
+    sub.conversion?.let { parts.add(conversionText(it, lang)) }
+    sub.effects.forEach { e ->
+        val unit = if (e.characteristic in PERCENT_CHARACS) "%" else ""
+        val sign = if (e.value >= 0) "+" else ""
+        parts.add("$sign${e.value}$unit ${e.characteristic.label(lang)}${gateText(e.scenarioGate, lang)}")
+    }
+    return if (parts.isEmpty()) sub.rawText.orEmpty() else parts.joinToString("  |  ")
+}
+
+private fun gateText(
+    gate: ScenarioGate?,
+    lang: Lang,
+): String {
+    if (gate == null) return ""
+    val tags = ArrayList<String>()
+    if (gate.berserk == true) tags.add(if (lang == Lang.FR) "berserk" else "berserk")
+    if (gate.ranged == true) tags.add(if (lang == Lang.FR) "à distance" else "ranged")
+    gate.minCharacterLevel?.let { tags.add(if (lang == Lang.FR) "niv $it+" else "lvl $it+") }
+    return if (tags.isEmpty()) "" else " (" + tags.joinToString(" + ") + ")"
+}
+
+private fun conversionText(
+    c: SublimationConversion,
+    lang: Lang,
+): String =
+    if (lang == Lang.FR) {
+        "Convertit ${c.percent}% de ${c.from.label(lang)} en ${c.to.label(lang)}"
+    } else {
+        "Convert ${c.percent}% of ${c.from.label(lang)} into ${c.to.label(lang)}"
+    }
+
+private fun conditionText(
+    c: SublimationCondition,
+    lang: Lang,
+): String {
+    val fr = lang == Lang.FR
+    return when (c.type) {
+        SublimationConditionType.AP_AT_MOST -> if (fr) "Si PA ≤ ${c.value}" else "If AP ≤ ${c.value}"
+        SublimationConditionType.AP_AT_LEAST -> if (fr) "Si PA ≥ ${c.value}" else "If AP ≥ ${c.value}"
+        SublimationConditionType.AP_EXACT -> if (fr) "Si PA = ${c.value}" else "If AP = ${c.value}"
+        SublimationConditionType.AP_ODD -> if (fr) "Si PA impairs" else "If odd AP"
+        SublimationConditionType.CRIT_AT_MOST -> if (fr) "Si Coup Critique ≤ ${c.value}%" else "If Critical Hit ≤ ${c.value}%"
+        SublimationConditionType.CRIT_AT_LEAST -> if (fr) "Si Coup Critique ≥ ${c.value}%" else "If Critical Hit ≥ ${c.value}%"
+        SublimationConditionType.BLOCK_AT_LEAST -> if (fr) "Si Parade ≥ ${c.value}%" else "If Block ≥ ${c.value}%"
+        SublimationConditionType.RANGE_AT_MOST -> if (fr) "Si Portée ≤ ${c.value}" else "If Range ≤ ${c.value}"
+        SublimationConditionType.RANGE_AT_LEAST -> if (fr) "Si Portée ≥ ${c.value}" else "If Range ≥ ${c.value}"
+        SublimationConditionType.RANGE_EXACT -> if (fr) "Si Portée = ${c.value}" else "If Range = ${c.value}"
+        SublimationConditionType.DODGE_LT_PCT_OF_LEVEL -> if (fr) "Si Esquive < ${c.value}% du niveau" else "If Dodge < ${c.value}% of level"
+        SublimationConditionType.SECONDARY_MASTERIES_AT_MOST -> if (fr) "Si maîtrises secondaires ≤ ${c.value}" else "If secondary masteries ≤ ${c.value}"
+        SublimationConditionType.WEAPON_TYPE_EQUIPPED -> if (fr) "Si ${c.text} équipé" else "If ${c.text} equipped"
+        SublimationConditionType.HIGHEST_ELEM_MASTERY_GT_REAR ->
+            if (fr) "Si la plus haute maîtrise élémentaire > maîtrise dos" else "If highest elemental mastery > rear mastery"
+        SublimationConditionType.HIGHEST_ELEM_MASTERY_GT_HEALING ->
+            if (fr) "Si la plus haute maîtrise élémentaire > maîtrise soin" else "If highest elemental mastery > healing mastery"
+        SublimationConditionType.OTHER -> if (fr) "Conditionnel" else "Conditional"
+    }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/CompareScreen.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/CompareScreen.kt
@@ -7,7 +7,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,17 +37,25 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import me.chosante.common.Characteristic
+import me.chosante.autobuilder.domain.BuildSpellDamage
+import me.chosante.autobuilder.domain.SpellCatalog
+import me.chosante.common.Character
+import me.chosante.common.Spell
 import me.chosante.common.history.HistoryEntry
 import me.chosante.ui.components.BreedIcon
 import me.chosante.ui.components.CharacteristicIcon
+import me.chosante.ui.components.InfoTip
 import me.chosante.ui.components.ItemThumbnail
+import me.chosante.ui.components.SpellIcon
+import me.chosante.ui.components.elementLabel
+import me.chosante.ui.components.localized
+import me.chosante.ui.i18n.Lang
 import me.chosante.ui.i18n.LocalLang
 import me.chosante.ui.i18n.Tr
 import me.chosante.ui.i18n.label
 import me.chosante.ui.i18n.tr
-import me.chosante.ui.state.CompareSlot
+import me.chosante.ui.state.MAX_COMPARE_SLOTS
+import me.chosante.ui.state.MIN_COMPARE_SLOTS
 import me.chosante.ui.state.UiState
 import me.chosante.ui.state.formatCompact
 import me.chosante.ui.state.isEngineInternalStat
@@ -52,23 +64,34 @@ import me.chosante.ui.theme.WDimens
 import me.chosante.ui.theme.WType
 import me.chosante.ui.theme.WTypography
 
+/** Fixed width of a per-build value column, shared by the stat and spell-damage tables so they align. */
+private val COMPARE_CELL = 80.dp
+
+/** Column label (A, B, C, D) for compare slot [index] — ties a side column to its table column. */
+private fun columnLetter(index: Int): String = ('A' + index).toString()
+
 /**
- * Side-by-side comparison of two saved builds, A | B. Each side is picked from the library; the
- * table below shows every stat where they differ with a per-row "best" marker. Cheap to render:
- * each side reads its stored `achieved` map (the same data the live Stats panel shows) — no engine
- * recomputation.
+ * Side-by-side comparison of two to four saved builds (one column each). Each column is picked from the
+ * library; below them, the stat table shows every characteristic the builds carry, and the spell-damage
+ * table shows each class spell's expected hit per build — the best cell highlighted in both. Cheap to
+ * render: the stat table reads each build's stored `achieved` map; the spell table reconstructs each build
+ * once and reuses [BuildSpellDamage]. The spell table is same-class only (spell kits differ by class).
  */
 @Composable
 fun CompareScreen(
     ui: UiState,
-    onPick: (CompareSlot, String) -> Unit,
-    onClearSlot: (CompareSlot) -> Unit,
+    onPick: (Int, String) -> Unit,
+    onClear: (Int) -> Unit,
+    onAdd: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val entryA = ui.savedBuilds.firstOrNull { it.id == ui.compareA }
-    val entryB = ui.savedBuilds.firstOrNull { it.id == ui.compareB }
     val scroll = rememberScrollState()
+    // The filled columns, paired with their A/B/C/D label, in slot order — what the tables compare.
+    val columns =
+        ui.compareSlots.mapIndexedNotNull { index, id ->
+            ui.savedBuilds.firstOrNull { it.id == id }?.let { columnLetter(index) to it }
+        }
     Column(
         modifier =
             modifier
@@ -83,28 +106,29 @@ fun CompareScreen(
             Spacer(modifier = Modifier.width(14.dp))
             Text(text = tr(Tr.COMPARE_TITLE), style = WTypography.headlineLarge.copy(fontWeight = FontWeight.Bold))
         }
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(WDimens.gap)) {
-            SideColumn(
-                slot = CompareSlot.A,
-                entry = entryA,
-                builds = ui.savedBuilds,
-                placeholder = tr(Tr.COMPARE_PICK_A),
-                onPick = onPick,
-                onClear = onClearSlot,
-                modifier = Modifier.weight(1f)
-            )
-            SideColumn(
-                slot = CompareSlot.B,
-                entry = entryB,
-                builds = ui.savedBuilds,
-                placeholder = tr(Tr.COMPARE_PICK_B),
-                onPick = onPick,
-                onClear = onClearSlot,
-                modifier = Modifier.weight(1f)
-            )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(WDimens.gap),
+            verticalAlignment = Alignment.Top
+        ) {
+            ui.compareSlots.forEachIndexed { index, id ->
+                SideColumn(
+                    index = index,
+                    entry = ui.savedBuilds.firstOrNull { it.id == id },
+                    builds = ui.savedBuilds,
+                    canRemove = ui.compareSlots.size > MIN_COMPARE_SLOTS,
+                    onPick = onPick,
+                    onClear = onClear,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+            if (ui.compareSlots.size < MAX_COMPARE_SLOTS) {
+                AddColumnTile(onClick = onAdd)
+            }
         }
-        if (entryA != null && entryB != null) {
-            ComparisonTable(entryA = entryA, entryB = entryB)
+        if (columns.size >= MIN_COMPARE_SLOTS) {
+            ComparisonTable(columns = columns)
+            SpellDamageTable(columns = columns)
         } else {
             Text(
                 text = tr(Tr.COMPARE_EMPTY),
@@ -115,14 +139,15 @@ fun CompareScreen(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SideColumn(
-    slot: CompareSlot,
+    index: Int,
     entry: HistoryEntry?,
     builds: List<HistoryEntry>,
-    placeholder: String,
-    onPick: (CompareSlot, String) -> Unit,
-    onClear: (CompareSlot) -> Unit,
+    canRemove: Boolean,
+    onPick: (Int, String) -> Unit,
+    onClear: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -134,7 +159,18 @@ private fun SideColumn(
                 .padding(WDimens.pad),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        BuildPicker(slot = slot, current = entry, builds = builds, placeholder = placeholder, onPick = onPick, onClear = onClear)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            LetterBadge(columnLetter(index))
+            BuildPicker(
+                index = index,
+                current = entry,
+                builds = builds,
+                canRemove = canRemove,
+                onPick = onPick,
+                onClear = onClear,
+                modifier = Modifier.weight(1f)
+            )
+        }
         if (entry != null) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                 BreedIcon(clazz = entry.restoredClass(), size = 20.dp)
@@ -153,32 +189,47 @@ private fun SideColumn(
                 text = headline + if (entry.result.optimal) " · ${tr(Tr.OPTIMAL_PROVEN)}" else "",
                 style = WTypography.labelMedium.copy(color = if (entry.result.optimal) WColor.success else WColor.text)
             )
-            Row(
+            FlowRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
+                verticalArrangement = Arrangement.spacedBy(3.dp)
             ) {
                 entry.result.equipments.take(14).forEach { equipment ->
-                    Box(modifier = Modifier.weight(1f, fill = false)) {
-                        ItemThumbnail(equipment = equipment, size = 26.dp)
-                    }
+                    ItemThumbnail(equipment = equipment, size = 22.dp)
                 }
             }
         }
     }
 }
 
+/** The A/B/C/D chip identifying a compare column (matches the table column headers). */
+@Composable
+private fun LetterBadge(letter: String) {
+    Box(
+        modifier =
+            Modifier
+                .size(22.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(WColor.raised)
+                .border(1.dp, WColor.border, RoundedCornerShape(6.dp)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = letter, style = WTypography.labelSmall.copy(fontFamily = WType.mono, color = WColor.accent, fontWeight = FontWeight.Bold))
+    }
+}
+
 @Composable
 private fun BuildPicker(
-    slot: CompareSlot,
+    index: Int,
     current: HistoryEntry?,
     builds: List<HistoryEntry>,
-    placeholder: String,
-    onPick: (CompareSlot, String) -> Unit,
-    onClear: (CompareSlot) -> Unit,
+    canRemove: Boolean,
+    onPick: (Int, String) -> Unit,
+    onClear: (Int) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var expanded by remember { mutableStateOf(false) }
-    Box {
+    Box(modifier = modifier) {
         Row(
             modifier =
                 Modifier
@@ -192,15 +243,17 @@ private fun BuildPicker(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = current?.name ?: placeholder,
+                text = current?.name ?: tr(Tr.COMPARE_PICK),
                 style = WTypography.bodyMedium.copy(color = if (current == null) WColor.faint else WColor.text, fontWeight = FontWeight.Medium),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)
             )
-            if (current != null) {
+            // ✕ both empties a base column and removes an extra one (the model decides which); shown for a
+            // filled column, or for any column once there are extras to remove.
+            if (current != null || canRemove) {
                 Box(
-                    modifier = Modifier.size(22.dp).clip(RoundedCornerShape(6.dp)).clickable { onClear(slot) },
+                    modifier = Modifier.size(22.dp).clip(RoundedCornerShape(6.dp)).clickable { onClear(index) },
                     contentAlignment = Alignment.Center
                 ) {
                     Text(text = "✕", style = WTypography.labelSmall.copy(color = WColor.muted))
@@ -225,7 +278,7 @@ private fun BuildPicker(
                         )
                     },
                     onClick = {
-                        onPick(slot, build.id)
+                        onPick(index, build.id)
                         expanded = false
                     }
                 )
@@ -235,19 +288,27 @@ private fun BuildPicker(
 }
 
 @Composable
-private fun ComparisonTable(
-    entryA: HistoryEntry,
-    entryB: HistoryEntry,
-) {
-    val lang = LocalLang.current
-    val rows =
-        remember(entryA, entryB) {
-            val keys = (entryA.result.achieved.keys + entryB.result.achieved.keys).filterNot { it.isEngineInternalStat() }
-            keys
-                .map { key -> Triple(key, entryA.result.achieved[key] ?: 0, entryB.result.achieved[key] ?: 0) }
-                .filter { (_, a, b) -> a != 0 || b != 0 }
-                .sortedBy { it.first.ordinal }
-        }
+private fun AddColumnTile(onClick: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .width(150.dp)
+                .heightIn(min = 92.dp)
+                .clip(RoundedCornerShape(WDimens.radius))
+                .background(WColor.surface)
+                .border(1.dp, WColor.border, RoundedCornerShape(WDimens.radius))
+                .clickable(onClick = onClick)
+                .padding(WDimens.pad),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "+", style = WTypography.headlineLarge.copy(color = WColor.faint))
+        Text(text = tr(Tr.COMPARE_ADD), style = WTypography.labelSmall.copy(color = WColor.muted))
+    }
+}
+
+@Composable
+private fun CompareCard(content: @Composable ColumnScope.() -> Unit) {
     Column(
         modifier =
             Modifier
@@ -255,137 +316,207 @@ private fun ComparisonTable(
                 .clip(RoundedCornerShape(WDimens.radius))
                 .background(WColor.surface)
                 .border(1.dp, WColor.hairline, RoundedCornerShape(WDimens.radius))
-                .padding(WDimens.pad)
-    ) {
+                .padding(WDimens.pad),
+        content = content
+    )
+}
+
+@Composable
+private fun ComparisonTable(columns: List<Pair<String, HistoryEntry>>) {
+    val lang = LocalLang.current
+    val entries = columns.map { it.second }
+    val rows =
+        remember(columns.map { it.second.id }) {
+            val keys = entries.flatMap { it.result.achieved.keys }.toSet().filterNot { it.isEngineInternalStat() }
+            keys
+                .map { key -> key to entries.map { entry -> entry.result.achieved[key] ?: 0 } }
+                .filter { (_, values) -> values.any { it != 0 } }
+                .sortedBy { it.first.ordinal }
+        }
+    CompareCard {
         Row(modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
             Text(text = tr(Tr.COMPARE_STAT), style = WTypography.labelMedium.copy(color = WColor.muted), modifier = Modifier.weight(1f))
-            Text(text = "A", style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted), modifier = Modifier.width(72.dp))
-            Text(text = "B", style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted), modifier = Modifier.width(72.dp))
-            Text(text = tr(Tr.COMPARE_BETTER), style = WTypography.labelMedium.copy(color = WColor.muted), modifier = Modifier.width(60.dp))
+            columns.forEach { (letter, _) ->
+                Text(text = letter, style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted), modifier = Modifier.width(COMPARE_CELL))
+            }
         }
-        // Headline: the value the engine actually maximized (specialized summed + min of elements).
-        // This is the row that says which build the solver judges better — unlike the per-stat rows
-        // below, where a build can win several elemental lines yet lose overall.
-        EngineScoreRow(aValue = entryA.requestedMasteryTotal(), bValue = entryB.requestedMasteryTotal())
+        // Headline: the value the engine actually maximized (specialized summed + min of elements) — the
+        // row that says which build the solver judges best overall, unlike the per-stat rows below.
+        ValueRow(values = entries.map { it.requestedMasteryTotal() }, bold = true) {
+            Text(
+                text = tr(Tr.COMPARE_ENGINE_SCORE),
+                style = WTypography.bodyMedium.copy(color = WColor.text, fontWeight = FontWeight.Bold),
+                modifier = Modifier.weight(1f)
+            )
+        }
         Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
-        rows.forEachIndexed { index, (characteristic, aValue, bValue) ->
+        rows.forEachIndexed { index, (characteristic, values) ->
             if (index > 0) {
                 Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
             }
-            ComparisonRow(characteristic = characteristic, label = characteristic.label(lang), aValue = aValue, bValue = bValue)
+            ValueRow(values = values, bold = false) {
+                CharacteristicIcon(characteristic = characteristic, size = 16.dp)
+                Spacer(modifier = Modifier.width(9.dp))
+                Text(
+                    text = characteristic.label(lang),
+                    style = WTypography.bodyMedium.copy(color = WColor.text),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+            }
         }
     }
 }
 
+/**
+ * One table row: a [leading] label (filling the width) followed by an integer value cell per build, the
+ * best cell(s) highlighted green. Ties highlight nothing (matching the original two-build behaviour).
+ * [bold] forces every cell bold (used for the headline engine-score row).
+ */
 @Composable
-private fun EngineScoreRow(
-    aValue: Int,
-    bValue: Int,
+private fun ValueRow(
+    values: List<Int>,
+    bold: Boolean,
+    leading: @Composable RowScope.() -> Unit,
 ) {
-    val winner =
-        when {
-            aValue > bValue -> CompareSlot.A
-            bValue > aValue -> CompareSlot.B
-            else -> null
-        }
-    Row(modifier = Modifier.fillMaxWidth().padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = tr(Tr.COMPARE_ENGINE_SCORE),
-            style = WTypography.bodyMedium.copy(color = WColor.text, fontWeight = FontWeight.Bold),
-            modifier = Modifier.weight(1f)
-        )
-        EngineValueCell(value = aValue, highlighted = winner == CompareSlot.A)
-        EngineValueCell(value = bValue, highlighted = winner == CompareSlot.B)
-        Box(modifier = Modifier.width(60.dp), contentAlignment = Alignment.Center) {
-            Text(
-                text =
-                    when (winner) {
-                        CompareSlot.A -> "◀ A"
-                        CompareSlot.B -> "B ▶"
-                        null -> tr(Tr.COMPARE_EQUAL)
-                    },
-                style = WTypography.labelMedium.copy(color = if (winner == null) WColor.muted else WColor.success, fontFamily = WType.mono, lineHeight = 16.sp)
-            )
-        }
-    }
-}
-
-@Composable
-private fun EngineValueCell(
-    value: Int,
-    highlighted: Boolean,
-) {
-    Text(
-        text = value.formatCompact(),
-        style =
-            WTypography.bodyMedium.copy(
-                fontFamily = WType.mono,
-                fontWeight = FontWeight.Bold,
-                color = if (highlighted) WColor.success else WColor.text
-            ),
-        modifier = Modifier.width(72.dp)
-    )
-}
-
-@Composable
-private fun ComparisonRow(
-    characteristic: Characteristic,
-    label: String,
-    aValue: Int,
-    bValue: Int,
-) {
-    val winner =
-        when {
-            aValue > bValue -> CompareSlot.A
-            bValue > aValue -> CompareSlot.B
-            else -> null
-        }
+    val best = values.maxOrNull() ?: 0
+    val tie = values.all { it == best }
     Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
-        CharacteristicIcon(characteristic = characteristic, size = 16.dp)
-        Spacer(modifier = Modifier.width(9.dp))
-        Text(
-            text = label,
-            style = WTypography.bodyMedium.copy(color = WColor.text),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f)
-        )
-        ValueCell(value = aValue, highlighted = winner == CompareSlot.A)
-        ValueCell(value = bValue, highlighted = winner == CompareSlot.B)
-        Box(modifier = Modifier.width(60.dp), contentAlignment = Alignment.Center) {
-            Text(
-                text =
-                    when (winner) {
-                        CompareSlot.A -> "◀ A"
-                        CompareSlot.B -> "B ▶"
-                        null -> tr(Tr.COMPARE_EQUAL)
-                    },
-                style =
-                    WTypography.labelMedium.copy(
-                        color = if (winner == null) WColor.muted else WColor.success,
-                        fontFamily = WType.mono,
-                        lineHeight = 16.sp
-                    )
-            )
+        leading()
+        values.forEach { value ->
+            NumberCell(text = value.formatCompact(), highlighted = value == best && !tie, bold = bold)
         }
     }
 }
 
 @Composable
-private fun ValueCell(
-    value: Int,
+private fun NumberCell(
+    text: String,
     highlighted: Boolean,
+    bold: Boolean,
 ) {
     Text(
-        text = value.formatCompact(),
+        text = text,
         style =
             WTypography.bodyMedium.copy(
                 fontFamily = WType.mono,
-                fontWeight = if (highlighted) FontWeight.Bold else FontWeight.Normal,
+                fontWeight = if (highlighted || bold) FontWeight.Bold else FontWeight.Normal,
                 color = if (highlighted) WColor.success else WColor.text
             ),
-        modifier = Modifier.width(72.dp)
+        modifier = Modifier.width(COMPARE_CELL)
     )
+}
+
+/** Spell damage of every compared build, computed once off the UI thread. [mixedClass] short-circuits the table. */
+private data class SpellDamageData(
+    val mixedClass: Boolean,
+    val spells: List<Spell>,
+    val damageByEntry: List<Map<Int, Double>>,
+)
+
+/**
+ * Reconstructs each compared build and scores every class damage spell via [BuildSpellDamage] — the same
+ * neutral 0%-resistance maths the Class spells tab uses, so the numbers agree. Returns [SpellDamageData.mixedClass]
+ * when the builds aren't all the same class (their spell kits differ, so a per-spell comparison is meaningless).
+ * Spells are pre-sorted by the strongest build's hit, so the heaviest hitters lead.
+ */
+private fun computeSpellDamage(entries: List<HistoryEntry>): SpellDamageData {
+    if (entries.map { it.restoredClass() }.toSet().size > 1) {
+        return SpellDamageData(mixedClass = true, spells = emptyList(), damageByEntry = emptyList())
+    }
+    val clazz = entries.firstOrNull()?.restoredClass() ?: return SpellDamageData(false, emptyList(), emptyList())
+    val spells = SpellCatalog.damageSpells(clazz)
+    val damageByEntry =
+        entries.map { entry ->
+            val build = entry.toBuildCombination()
+            val character = Character(entry.restoredClass(), entry.request.level, entry.request.minLevel, build.characterSkills)
+            spells.associate { spell -> spell.id to (BuildSpellDamage.expectedDamage(spell, build, character)?.expected ?: 0.0) }
+        }
+    val ordered = spells.sortedByDescending { spell -> damageByEntry.maxOfOrNull { it[spell.id] ?: 0.0 } ?: 0.0 }
+    return SpellDamageData(mixedClass = false, spells = ordered, damageByEntry = damageByEntry)
+}
+
+/**
+ * Per-spell expected damage of each compared build, side by side: one row per damage spell, one value column
+ * per build, the best cell(s) highlighted. The spell is listed once (not repeated per build) so it scales to
+ * several builds. Only meaningful for same-class builds; a mixed-class selection shows a note instead.
+ */
+@Composable
+private fun SpellDamageTable(columns: List<Pair<String, HistoryEntry>>) {
+    val lang = LocalLang.current
+    val entries = columns.map { it.second }
+    val data = remember(columns.map { it.second.id }) { computeSpellDamage(entries) }
+    val showColumns = !data.mixedClass && data.spells.isNotEmpty()
+    CompareCard {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(text = tr(Tr.COMPARE_SPELL_DAMAGE), style = WTypography.labelMedium.copy(color = WColor.muted))
+            Spacer(modifier = Modifier.width(6.dp))
+            InfoTip(text = tr(Tr.SPELL_EXPECTED_HIT_INFO))
+            if (showColumns) {
+                Spacer(modifier = Modifier.weight(1f))
+                columns.forEach { (letter, _) ->
+                    Text(text = letter, style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted), modifier = Modifier.width(COMPARE_CELL))
+                }
+            }
+        }
+        when {
+            data.mixedClass ->
+                Text(text = tr(Tr.COMPARE_SPELLS_MIXED_CLASS), style = WTypography.bodySmall.copy(color = WColor.muted))
+
+            data.spells.isEmpty() ->
+                Text(text = tr(Tr.CLASS_SPELLS_EMPTY), style = WTypography.bodySmall.copy(color = WColor.muted))
+
+            else ->
+                data.spells.forEachIndexed { index, spell ->
+                    if (index > 0) {
+                        Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
+                    }
+                    SpellDamageRow(
+                        spell = spell,
+                        values = data.damageByEntry.map { it[spell.id] ?: 0.0 },
+                        lang = lang
+                    )
+                }
+        }
+    }
+}
+
+@Composable
+private fun SpellDamageRow(
+    spell: Spell,
+    values: List<Double>,
+    lang: Lang,
+) {
+    val bestLong = values.maxOfOrNull { it.toLong() } ?: 0L
+    val tie = values.all { it.toLong() == bestLong }
+    val elementLabel = spell.element?.elementLabel()
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SpellIcon(iconId = spell.iconId, element = spell.element, size = 26.dp)
+        Spacer(modifier = Modifier.width(9.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = spell.name.localized(lang),
+                style = WTypography.bodyMedium.copy(color = WColor.text),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            val meta = listOfNotNull(elementLabel, spell.apCost?.let { "$it AP" }).joinToString(" · ")
+            if (meta.isNotEmpty()) {
+                Text(text = meta, style = WTypography.labelSmall.copy(color = WColor.muted, fontFamily = WType.mono))
+            }
+        }
+        values.forEach { v ->
+            val vl = v.toLong()
+            NumberCell(text = if (vl > 0) vl.formatCompact() else "—", highlighted = vl == bestLong && vl > 0 && !tie, bold = false)
+        }
+    }
 }
 
 @Composable

--- a/gui-compose/src/main/kotlin/me/chosante/ui/history/CompareScreen.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/history/CompareScreen.kt
@@ -38,12 +38,16 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.chosante.autobuilder.domain.BuildSpellDamage
+import me.chosante.autobuilder.domain.RangeBand
 import me.chosante.autobuilder.domain.SpellCatalog
+import me.chosante.autobuilder.domain.toSpellDamageRangeBand
 import me.chosante.common.Character
+import me.chosante.common.Characteristic
 import me.chosante.common.Spell
 import me.chosante.common.history.HistoryEntry
 import me.chosante.ui.components.BreedIcon
 import me.chosante.ui.components.CharacteristicIcon
+import me.chosante.ui.components.Hairline
 import me.chosante.ui.components.InfoTip
 import me.chosante.ui.components.ItemThumbnail
 import me.chosante.ui.components.SpellIcon
@@ -321,17 +325,51 @@ private fun CompareCard(content: @Composable ColumnScope.() -> Unit) {
     )
 }
 
+/**
+ * The damage-driver masteries, listed first in the compare table so a player can read off *why* two builds
+ * differ in spell damage. Shown only when at least one build has a non-zero value (no all-zero clutter).
+ */
+private val COMPARE_DAMAGE_MASTERIES =
+    listOf(
+        Characteristic.MASTERY_ELEMENTARY_WATER,
+        Characteristic.MASTERY_ELEMENTARY_FIRE,
+        Characteristic.MASTERY_ELEMENTARY_EARTH,
+        Characteristic.MASTERY_ELEMENTARY_WIND,
+        Characteristic.MASTERY_DISTANCE,
+        Characteristic.MASTERY_MELEE,
+        Characteristic.MASTERY_BACK,
+        Characteristic.MASTERY_BERSERK,
+        Characteristic.MASTERY_CRITICAL,
+        Characteristic.MASTERY_HEALING
+    )
+
+/**
+ * The two global damage multipliers, **always** shown (even at 0) so a damage gap they cause — e.g. a
+ * −20% Damage Inflicted from a sublimation — is never hidden by the "non-zero only" rule.
+ */
+private val COMPARE_DAMAGE_ALWAYS =
+    listOf(Characteristic.DAMAGE_INFLICTED, Characteristic.CRITICAL_HIT)
+
 @Composable
 private fun ComparisonTable(columns: List<Pair<String, HistoryEntry>>) {
     val lang = LocalLang.current
     val entries = columns.map { it.second }
-    val rows =
+    val (damageRows, otherRows) =
         remember(columns.map { it.second.id }) {
-            val keys = entries.flatMap { it.result.achieved.keys }.toSet().filterNot { it.isEngineInternalStat() }
-            keys
-                .map { key -> key to entries.map { entry -> entry.result.achieved[key] ?: 0 } }
-                .filter { (_, values) -> values.any { it != 0 } }
-                .sortedBy { it.first.ordinal }
+            fun valuesOf(key: Characteristic) = entries.map { entry -> entry.result.achieved[key] ?: 0 }
+            val damage =
+                COMPARE_DAMAGE_MASTERIES.filter { key -> valuesOf(key).any { it != 0 } }.map { it to valuesOf(it) } +
+                    COMPARE_DAMAGE_ALWAYS.map { it to valuesOf(it) }
+            val damageKeys = damage.map { it.first }.toSet()
+            val others =
+                entries
+                    .flatMap { it.result.achieved.keys }
+                    .toSet()
+                    .filterNot { it.isEngineInternalStat() || it in damageKeys }
+                    .map { key -> key to valuesOf(key) }
+                    .filter { (_, values) -> values.any { it != 0 } }
+                    .sortedBy { it.first.ordinal }
+            damage to others
         }
     CompareCard {
         Row(modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
@@ -349,23 +387,48 @@ private fun ComparisonTable(columns: List<Pair<String, HistoryEntry>>) {
                 modifier = Modifier.weight(1f)
             )
         }
-        Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
-        rows.forEachIndexed { index, (characteristic, values) ->
-            if (index > 0) {
-                Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
-            }
-            ValueRow(values = values, bold = false) {
-                CharacteristicIcon(characteristic = characteristic, size = 16.dp)
-                Spacer(modifier = Modifier.width(9.dp))
-                Text(
-                    text = characteristic.label(lang),
-                    style = WTypography.bodyMedium.copy(color = WColor.text),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
+        CompareGroupLabel(text = tr(Tr.COMPARE_GROUP_DAMAGE))
+        damageRows.forEachIndexed { index, (characteristic, values) ->
+            if (index > 0) Hairline()
+            StatValueRow(characteristic = characteristic, values = values, lang = lang)
+        }
+        if (otherRows.isNotEmpty()) {
+            CompareGroupLabel(text = tr(Tr.COMPARE_GROUP_OTHER))
+            otherRows.forEachIndexed { index, (characteristic, values) ->
+                if (index > 0) Hairline()
+                StatValueRow(characteristic = characteristic, values = values, lang = lang)
             }
         }
+    }
+}
+
+/** A small muted subheading separating the compare-table stat groups (Damage / Other). */
+@Composable
+private fun CompareGroupLabel(text: String) {
+    Text(
+        text = text,
+        style = WTypography.labelMedium.copy(color = WColor.muted),
+        modifier = Modifier.padding(top = 10.dp, bottom = 2.dp)
+    )
+}
+
+/** One stat row: the characteristic's icon + localized label, then its per-build value cells. */
+@Composable
+private fun StatValueRow(
+    characteristic: Characteristic,
+    values: List<Int>,
+    lang: Lang,
+) {
+    ValueRow(values = values, bold = false) {
+        CharacteristicIcon(characteristic = characteristic, size = 16.dp)
+        Spacer(modifier = Modifier.width(9.dp))
+        Text(
+            text = characteristic.label(lang),
+            style = WTypography.bodyMedium.copy(color = WColor.text),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
     }
 }
 
@@ -413,13 +476,18 @@ private data class SpellDamageData(
     val mixedClass: Boolean,
     val spells: List<Spell>,
     val damageByEntry: List<Map<Int, Double>>,
+    /** The range band each build's numbers credit (its own saved scenario), shown per column for transparency. */
+    val rangeBands: List<RangeBand> = emptyList(),
 )
 
 /**
- * Reconstructs each compared build and scores every class damage spell via [BuildSpellDamage] — the same
- * neutral 0%-resistance maths the Class spells tab uses, so the numbers agree. Returns [SpellDamageData.mixedClass]
- * when the builds aren't all the same class (their spell kits differ, so a per-spell comparison is meaningless).
- * Spells are pre-sorted by the strongest build's hit, so the heaviest hitters lead.
+ * Reconstructs each compared build and scores every class damage spell via [BuildSpellDamage], crediting
+ * **each build's own range band** (distance/melee, from its saved scenario) so a distance build isn't
+ * understated by dropping its biggest secondary mastery — at the cost of builds with different bands not
+ * being perfectly apples-to-apples (the band used is shown per column). Resistance/rear/berserk stay neutral,
+ * matching the Class spells tab. Returns [SpellDamageData.mixedClass] when the builds aren't all the same
+ * class (their spell kits differ, so a per-spell comparison is meaningless). Spells are pre-sorted by the
+ * strongest build's hit, so the heaviest hitters lead.
  */
 private fun computeSpellDamage(entries: List<HistoryEntry>): SpellDamageData {
     if (entries.map { it.restoredClass() }.toSet().size > 1) {
@@ -427,14 +495,16 @@ private fun computeSpellDamage(entries: List<HistoryEntry>): SpellDamageData {
     }
     val clazz = entries.firstOrNull()?.restoredClass() ?: return SpellDamageData(false, emptyList(), emptyList())
     val spells = SpellCatalog.damageSpells(clazz)
+    val rangeBands = entries.map { it.restoredScenario().rangeBand }
     val damageByEntry =
-        entries.map { entry ->
+        entries.mapIndexed { index, entry ->
             val build = entry.toBuildCombination()
             val character = Character(entry.restoredClass(), entry.request.level, entry.request.minLevel, build.characterSkills)
-            spells.associate { spell -> spell.id to (BuildSpellDamage.expectedDamage(spell, build, character)?.expected ?: 0.0) }
+            val band = rangeBands[index].toSpellDamageRangeBand()
+            spells.associate { spell -> spell.id to (BuildSpellDamage.expectedDamage(spell, build, character, rangeBand = band)?.expected ?: 0.0) }
         }
     val ordered = spells.sortedByDescending { spell -> damageByEntry.maxOfOrNull { it[spell.id] ?: 0.0 } ?: 0.0 }
-    return SpellDamageData(mixedClass = false, spells = ordered, damageByEntry = damageByEntry)
+    return SpellDamageData(mixedClass = false, spells = ordered, damageByEntry = damageByEntry, rangeBands = rangeBands)
 }
 
 /**
@@ -458,8 +528,15 @@ private fun SpellDamageTable(columns: List<Pair<String, HistoryEntry>>) {
             InfoTip(text = tr(Tr.SPELL_EXPECTED_HIT_INFO))
             if (showColumns) {
                 Spacer(modifier = Modifier.weight(1f))
-                columns.forEach { (letter, _) ->
-                    Text(text = letter, style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted), modifier = Modifier.width(COMPARE_CELL))
+                columns.forEachIndexed { index, (letter, _) ->
+                    // Each column credits its own build's range band; surface it so a distance-vs-melee gap is explained.
+                    val band = data.rangeBands.getOrNull(index)
+                    Column(modifier = Modifier.width(COMPARE_CELL), horizontalAlignment = Alignment.Start) {
+                        Text(text = letter, style = WTypography.labelMedium.copy(fontFamily = WType.mono, color = WColor.muted))
+                        if (band != null) {
+                            Text(text = band.label(lang), style = WTypography.labelSmall.copy(color = WColor.faint))
+                        }
+                    }
                 }
             }
         }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -358,13 +358,18 @@ enum class Tr(
 
     // Compare view
     COMPARE_TITLE("Compare builds", "Comparer les builds"),
-    COMPARE_PICK_A("Pick build A", "Choisir le build A"),
-    COMPARE_PICK_B("Pick build B", "Choisir le build B"),
+    COMPARE_PICK("Pick a build", "Choisir un build"),
+    COMPARE_ADD("Add build", "Ajouter un build"),
     COMPARE_BETTER("Best", "Meilleur"),
     COMPARE_EQUAL("=", "="),
-    COMPARE_EMPTY("Pick two builds to compare them side by side.", "Choisis deux builds à comparer côte à côte."),
+    COMPARE_EMPTY("Pick at least two builds to compare them side by side.", "Choisis au moins deux builds à comparer côte à côte."),
     COMPARE_STAT("Stat", "Stat"),
     COMPARE_ENGINE_SCORE("Mastery score (engine)", "Score maîtrises (moteur)"),
+    COMPARE_SPELL_DAMAGE("Spell damage", "Dégâts des sorts"),
+    COMPARE_SPELLS_MIXED_CLASS(
+        "Spell damage compares only builds of the same class — these are different classes.",
+        "Les dégâts des sorts ne comparent que des builds de la même classe — ici les classes diffèrent."
+    ),
 
     // What's-new dialog (once-per-version release notes)
     WHATS_NEW_TITLE("What's new in", "Nouveautés de la version"),
@@ -372,6 +377,40 @@ enum class Tr(
     WHATS_NEW_FIXES("Bug Fixes", "Corrections"),
     WHATS_NEW_PERF("Performance Improvements", "Améliorations de performance"),
     WHATS_NEW_GOT_IT("Got it", "Compris"),
+
+    // Class spells & passives tab (build-result region)
+    TAB_DISCOVERED_BUILD("Discovered build", "Build découvert"),
+    TAB_CLASS_SPELLS("Class spells & passives", "Sorts & passifs"),
+    CLASS_SPELLS_TITLE("Class spells", "Sorts de la classe"),
+    CLASS_SPELLS_PASSIVES("Passives", "Passifs"),
+    PASSIVE_IN_BUILD("in build", "dans le build"),
+    CLASS_SPELLS_EMPTY("This class has no damage spells in the data.", "Cette classe n'a aucun sort de dégâts dans les données."),
+    CLASS_SPELLS_NO_BUILD(
+        "No build yet — showing each spell's base hit at this level. Run a search to see this build's damage.",
+        "Pas encore de build — dégâts de base affichés à ce niveau. Lance une recherche pour voir les dégâts de ce build."
+    ),
+    SPELL_EXPECTED_HIT("expected hit", "dégâts moyens"),
+    SPELL_BASE_HIT("base hit", "dégâts de base"),
+    SPELL_NONCRIT("non-crit", "non-crit"),
+    SPELL_CRIT("crit", "crit"),
+    SPELL_ALWAYS_CRITS("always crits · 100% crit", "toujours crit · 100% crit"),
+    SPELL_PER_TURN_SUFFIX("turn", "tour"),
+    SPELL_EXPECTED_HIT_INFO(
+        "Expected hit: the average damage of one cast. It blends a non-crit and a crit hit, weighted by " +
+            "this build's crit chance, from its elemental mastery, % damage inflicted and critical mastery — " +
+            "against a 0%-resistance target.",
+        "Dégâts moyens : la moyenne d'un lancer. Mélange un coup normal et un coup critique, pondérés par les " +
+            "chances de coup critique du build, d'après sa maîtrise élémentaire, ses % de dégâts infligés et sa " +
+            "maîtrise critique — contre une cible à 0% de résistance."
+    ),
+    SPELL_BASE_HIT_INFO(
+        "Base hit at this level, before the build's masteries. Run a search to see this build's expected damage.",
+        "Dégâts de base à ce niveau, avant les maîtrises du build. Lance une recherche pour voir les dégâts attendus de ce build."
+    ),
+    ELEMENT_FIRE("Fire", "Feu"),
+    ELEMENT_WATER("Water", "Eau"),
+    ELEMENT_EARTH("Earth", "Terre"),
+    ELEMENT_AIR("Air", "Air"),
     ;
 
     fun value(lang: Lang): String =

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -3,6 +3,8 @@ package me.chosante.ui.i18n
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
+import me.chosante.autobuilder.domain.Orientation
+import me.chosante.autobuilder.domain.RangeBand
 import me.chosante.common.Characteristic
 import me.chosante.common.ItemType
 import me.chosante.common.Rarity
@@ -365,6 +367,8 @@ enum class Tr(
     COMPARE_EMPTY("Pick at least two builds to compare them side by side.", "Choisis au moins deux builds à comparer côte à côte."),
     COMPARE_STAT("Stat", "Stat"),
     COMPARE_ENGINE_SCORE("Mastery score (engine)", "Score maîtrises (moteur)"),
+    COMPARE_GROUP_DAMAGE("Damage", "Dégâts"),
+    COMPARE_GROUP_OTHER("Other", "Autres"),
     COMPARE_SPELL_DAMAGE("Spell damage", "Dégâts des sorts"),
     COMPARE_SPELLS_MIXED_CLASS(
         "Spell damage compares only builds of the same class — these are different classes.",
@@ -397,12 +401,19 @@ enum class Tr(
     SPELL_PER_TURN_SUFFIX("turn", "tour"),
     SPELL_EXPECTED_HIT_INFO(
         "Expected hit: the average damage of one cast. It blends a non-crit and a crit hit, weighted by " +
-            "this build's crit chance, from its elemental mastery, % damage inflicted and critical mastery — " +
-            "against a 0%-resistance target.",
+            "this build's crit chance, from its elemental mastery, its distance/melee mastery, % damage " +
+            "inflicted and critical mastery — against a 0%-resistance target.",
         "Dégâts moyens : la moyenne d'un lancer. Mélange un coup normal et un coup critique, pondérés par les " +
-            "chances de coup critique du build, d'après sa maîtrise élémentaire, ses % de dégâts infligés et sa " +
-            "maîtrise critique — contre une cible à 0% de résistance."
+            "chances de coup critique du build, d'après sa maîtrise élémentaire, sa maîtrise distance/mêlée, ses " +
+            "% de dégâts infligés et sa maîtrise critique — contre une cible à 0% de résistance."
     ),
+    SPELL_DAMAGE_RANGE_NOTE("incl. %s mastery", "incl. maîtrise %s"),
+    SPELL_DAMAGE_DIST_MELEE_HINT(
+        "Distance and melee mastery both present — a hit uses only one (the scenario's), never both.",
+        "Maîtrise distance et mêlée toutes deux présentes — un coup n'en utilise qu'une (celle du scénario), jamais les deux."
+    ),
+    SPELL_VARIANT_BERSERK("berserk", "berserk"),
+    SCENARIO_DAMAGE_BREAKDOWN("Damage by position", "Dégâts par position"),
     SPELL_BASE_HIT_INFO(
         "Base hit at this level, before the build's masteries. Run a search to see this build's expected damage.",
         "Dégâts de base à ce niveau, avant les maîtrises du build. Lance une recherche pour voir les dégâts attendus de ce build."
@@ -483,6 +494,21 @@ fun Characteristic.label(lang: Lang): String {
         Characteristic.FISHERMAN_HARVEST_QUANTITY_PERCENTAGE -> if (fr) "Récolte Pêcheur %" else "Fisherman Harvest %"
     }
 }
+
+/** Localized display name for an attack's range band (the secondary mastery it credits). */
+fun RangeBand.label(lang: Lang): String =
+    when (this) {
+        RangeBand.MELEE -> if (lang == Lang.FR) "Mêlée" else "Melee"
+        RangeBand.DISTANCE -> if (lang == Lang.FR) "Distance" else "Distance"
+    }
+
+/** Localized display name for an attack orientation (the positional damage multiplier). */
+fun Orientation.label(lang: Lang): String =
+    when (this) {
+        Orientation.FACE -> if (lang == Lang.FR) "Face" else "Face"
+        Orientation.SIDE -> if (lang == Lang.FR) "Côté" else "Side"
+        Orientation.BACK -> if (lang == Lang.FR) "Dos" else "Back"
+    }
 
 /** Localized display name for an item rarity. */
 fun Rarity.label(lang: Lang): String =

--- a/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/paperdoll/PaperdollPanel.kt
@@ -66,6 +66,7 @@ import me.chosante.ui.components.RarityIcon
 import me.chosante.ui.components.iconResourcePath
 import me.chosante.ui.components.itemResourcePath
 import me.chosante.ui.components.rememberClasspathBitmap
+import me.chosante.ui.components.sublimationEffectText
 import me.chosante.ui.i18n.Lang
 import me.chosante.ui.i18n.LocalLang
 import me.chosante.ui.i18n.Tr
@@ -646,23 +647,29 @@ private fun ItemTooltip(
                 }
             }
         }
-        val socketRunes = socketLayout(equipment, runes, subs).filter { it.second != null }
-        if (socketRunes.isNotEmpty()) {
+        val socketCells = socketLayout(equipment, runes, subs)
+        if (socketCells.isNotEmpty()) {
             Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
             Text(
                 text = tr(Tr.RUNES),
                 style = WTypography.labelSmall.copy(color = WColor.faint, fontWeight = FontWeight.SemiBold)
             )
+            // Show EVERY socket the item has (filled show their shard, free ones show empty), matching the card,
+            // then list the runes that fill them.
+            Row(horizontalArrangement = Arrangement.spacedBy(5.dp), verticalAlignment = Alignment.CenterVertically) {
+                socketCells.forEach { (color, _) -> RuneShape(color = color, size = 14.dp) }
+            }
             // Group by (stat, socket colour) so a hosted sublimation's pattern shows in the runes too — e.g. one
             // green + three red distance runes — exactly matching the card. Enchantment level is gated by the
             // carrier item's level (Ankama's table).
-            socketRunes
+            socketCells
+                .filter { it.second != null }
                 .groupBy { (color, rune) -> rune!!.characteristic to color }
                 .forEach { (statColor, cells) ->
                     val rune = cells.first().second!!
                     TooltipRuneRow(
                         rune = rune,
-                        color = statColor.second,
+                        color = statColor.second ?: rune.color,
                         count = cells.size,
                         level = rune.maxLevel(equipment.level),
                         lang = lang
@@ -692,7 +699,7 @@ private fun ItemTooltip(
                         // A normal sub's required 3-socket colour pattern (epic/relic carry none).
                         sub.colors.forEach { color -> RuneShape(color = color, size = 13.dp) }
                     }
-                    sub.rawText?.takeIf { it.isNotBlank() }?.let {
+                    sublimationEffectText(sub, lang).takeIf { it.isNotBlank() }?.let {
                         Text(
                             text = it,
                             style = WTypography.labelSmall.copy(color = WColor.muted)
@@ -712,26 +719,27 @@ private fun RuneColor.displayColor(): Color =
     }
 
 /**
- * The per-socket display layout for an item's enchantments, as `(socket colour, rune in it)` cells.
- * A hosted normal sublimation paints its ordered colour pattern on the first sockets — so the pattern is
- * ALWAYS drawn (that is how the sub is satisfied: users see the green/red/… sockets that host it) — and the
- * remaining free sockets take the colour of the rune that fills them. Golden runes (colour-agnostic) make this
- * always reachable: a rune in a pattern socket shows the pattern colour, a rune in a free socket shows its own
- * (doubling) colour. Capped at the item's socket count; a pattern cell with no rune (more pattern than runes)
- * carries a null rune. This single source drives both the paperdoll card shards and the hover tooltip so they
- * always agree.
+ * The per-socket display layout for an item's enchantments, as `(socket colour, rune in it)` cells — ONE cell
+ * per socket the item has ([Equipment.maxShardSlots]), so the card and tooltip always show ALL of an item's
+ * sockets (the bug fixed here: it used to stop at `max(pattern, runes)`, hiding free sockets — e.g. a 4-socket
+ * amulet with a 3-colour sublimation pattern + 1 rune only drew 3). A hosted normal sublimation paints its
+ * ordered colour pattern on the first sockets — so the pattern is ALWAYS drawn (that is how the sub is
+ * satisfied: users see the green/red/… sockets that host it) — each remaining socket takes the colour of the
+ * rune that fills it, and any still-free socket stays EMPTY (`null` colour = white wildcard). Golden runes
+ * (colour-agnostic) make the pattern always reachable: a rune in a pattern socket shows the pattern colour, a
+ * rune in a free socket shows its own (doubling) colour. This single source drives both the paperdoll card
+ * shards and the hover tooltip so they always agree.
  */
-private fun socketLayout(
+internal fun socketLayout(
     equipment: Equipment,
     runes: List<RuneType>,
     subs: List<Sublimation>,
-): List<Pair<RuneColor, RuneType?>> {
+): List<Pair<RuneColor?, RuneType?>> {
     val pattern = subs.flatMap { it.colors }
     val slots = equipment.maxShardSlots.coerceAtLeast(0)
-    val cellCount = maxOf(pattern.size, runes.size).coerceAtMost(slots)
-    return (0 until cellCount).map { i ->
+    return (0 until slots).map { i ->
         val rune = runes.getOrNull(i)
-        val color = pattern.getOrNull(i) ?: rune?.color ?: RuneColor.RED
+        val color: RuneColor? = pattern.getOrNull(i) ?: rune?.color
         color to rune
     }
 }
@@ -745,10 +753,23 @@ private fun socketLayout(
  */
 @Composable
 private fun RuneShape(
-    color: RuneColor,
+    color: RuneColor?,
     size: Dp,
     modifier: Modifier = Modifier,
 ) {
+    if (color == null) {
+        // A free / empty socket (white wildcard). The client has no white shard asset, so draw a neutral
+        // hollow shard so the user still sees that the socket exists (and is unfilled).
+        Box(
+            modifier =
+                modifier
+                    .size(size)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(WColor.surface)
+                    .border(1.5.dp, WColor.border, RoundedCornerShape(999.dp))
+        )
+        return
+    }
     val asset =
         when (color) {
             RuneColor.RED -> "assets/runes/shard_red.png"

--- a/gui-compose/src/main/kotlin/me/chosante/ui/request/RequestPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/request/RequestPanel.kt
@@ -58,6 +58,7 @@ import me.chosante.common.Characteristic
 import me.chosante.common.Monster
 import me.chosante.common.Rarity
 import me.chosante.ui.components.BossResistanceChips
+import me.chosante.ui.components.Hairline
 import me.chosante.ui.components.MonsterIcon
 import me.chosante.ui.components.RarityIcon
 import me.chosante.ui.components.StatGlyphIcon
@@ -484,19 +485,6 @@ private fun SpellElement.label(lang: Lang): String =
         SpellElement.WATER -> if (lang == Lang.FR) "Eau" else "Water"
         SpellElement.EARTH -> if (lang == Lang.FR) "Terre" else "Earth"
         SpellElement.AIR -> if (lang == Lang.FR) "Air" else "Air"
-    }
-
-private fun RangeBand.label(lang: Lang): String =
-    when (this) {
-        RangeBand.MELEE -> if (lang == Lang.FR) "Mêlée" else "Melee"
-        RangeBand.DISTANCE -> if (lang == Lang.FR) "Distance" else "Distance"
-    }
-
-private fun Orientation.label(lang: Lang): String =
-    when (this) {
-        Orientation.FACE -> if (lang == Lang.FR) "Face" else "Face"
-        Orientation.SIDE -> if (lang == Lang.FR) "Côté" else "Side"
-        Orientation.BACK -> if (lang == Lang.FR) "Dos" else "Back"
     }
 
 @Composable
@@ -1482,11 +1470,6 @@ private fun NumberField(
             }
         }
     )
-}
-
-@Composable
-private fun Hairline() {
-    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
 }
 
 private data class TargetInputSection(

--- a/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/shell/AppShell.kt
@@ -1,14 +1,22 @@
 package me.chosante.ui.shell
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -17,10 +25,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
@@ -33,7 +44,9 @@ import me.chosante.ui.i18n.Tr
 import me.chosante.ui.i18n.tr
 import me.chosante.ui.paperdoll.PaperdollPanel
 import me.chosante.ui.request.RequestPanel
+import me.chosante.ui.spells.ClassSpellsPanel
 import me.chosante.ui.state.BuildSearchModel
+import me.chosante.ui.state.BuilderTab
 import me.chosante.ui.state.Modal
 import me.chosante.ui.state.Phase
 import me.chosante.ui.state.PickerMode
@@ -42,6 +55,7 @@ import me.chosante.ui.state.folderCounts
 import me.chosante.ui.state.statCatalog
 import me.chosante.ui.stats.StatsPanel
 import me.chosante.ui.theme.WColor
+import me.chosante.ui.theme.WTypography
 import java.awt.Cursor
 
 @Composable
@@ -131,7 +145,8 @@ fun AppShell(
                             CompareScreen(
                                 ui = ui,
                                 onPick = model::setCompareSlot,
-                                onClearSlot = model::clearCompareSlot,
+                                onClear = model::clearCompareSlot,
+                                onAdd = model::addCompareSlot,
                                 onBack = { model.goToScreen(Screen.Library) }
                             )
                     }
@@ -236,37 +251,113 @@ private fun BuilderBody(
             )
         }
         ResizableSeparator(onDelta = onRequestWidthDelta)
-        ShellColumn(
-            title = tr(Tr.ZONE_BUILD),
-            hint =
-                when (ui.phase) {
-                    Phase.Idle -> tr(Tr.ZONE_BUILD_IDLE)
-                    Phase.Searching -> tr(Tr.ZONE_BUILD_SEARCHING)
-                    Phase.Done -> tr(Tr.ZONE_BUILD_DONE)
-                },
-            modifier = Modifier.weight(1f)
-        ) {
-            PaperdollPanel(
-                ui = ui,
-                onForceItem = model::forceItem,
-                onExcludeItem = model::excludeItem,
-                onEditRunes = model::openItemRunePicker
+        // The result region carries a tab strip (discovered build vs the class's spells & passives) above
+        // its content: the build tab keeps the resizable paperdoll | stats split, the spells tab is full-width.
+        Column(modifier = Modifier.weight(1f).fillMaxHeight().background(WColor.bg)) {
+            ResultTabHeader(
+                current = ui.builderTab,
+                phaseHint =
+                    if (ui.builderTab == BuilderTab.BUILD) {
+                        when (ui.phase) {
+                            Phase.Idle -> tr(Tr.ZONE_BUILD_IDLE)
+                            Phase.Searching -> tr(Tr.ZONE_BUILD_SEARCHING)
+                            Phase.Done -> tr(Tr.ZONE_BUILD_DONE)
+                        }
+                    } else {
+                        ""
+                    },
+                onSelect = model::setBuilderTab
             )
+            when (ui.builderTab) {
+                BuilderTab.BUILD ->
+                    Row(modifier = Modifier.fillMaxWidth().weight(1f).background(WColor.hairline)) {
+                        Box(modifier = Modifier.weight(1f).fillMaxHeight().background(WColor.bg)) {
+                            PaperdollPanel(
+                                ui = ui,
+                                onForceItem = model::forceItem,
+                                onExcludeItem = model::excludeItem,
+                                onEditRunes = model::openItemRunePicker
+                            )
+                        }
+                        ResizableSeparator(onDelta = onStatsWidthDelta)
+                        Box(modifier = Modifier.width(statsWidth).fillMaxHeight().background(WColor.bg)) {
+                            StatsPanel(
+                                ui = ui,
+                                onOpenZenith = model::openZenithBuild,
+                                onCopyZenith = model::copyZenithLink,
+                                onSaveBuild = model::requestSaveBuild,
+                                onExport = model::exportBuild
+                            )
+                        }
+                    }
+
+                BuilderTab.SPELLS ->
+                    ClassSpellsPanel(ui = ui, modifier = Modifier.fillMaxWidth().weight(1f))
+            }
         }
-        ResizableSeparator(onDelta = onStatsWidthDelta)
-        ShellColumn(
-            title = tr(Tr.ZONE_STATS),
-            hint = tr(Tr.ZONE_STATS_HINT),
-            modifier = Modifier.width(statsWidth)
+    }
+}
+
+/** Tab strip atop the result region: discovered build vs the class's spells & passives. */
+@Composable
+private fun ResultTabHeader(
+    current: BuilderTab,
+    phaseHint: String,
+    onSelect: (BuilderTab) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().background(WColor.bg)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().height(48.dp).padding(horizontal = 14.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            StatsPanel(
-                ui = ui,
-                onOpenZenith = model::openZenithBuild,
-                onCopyZenith = model::copyZenithLink,
-                onSaveBuild = model::requestSaveBuild,
-                onExport = model::exportBuild
-            )
+            Row(
+                modifier =
+                    Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(WColor.bg)
+                        .border(1.dp, WColor.border, RoundedCornerShape(8.dp))
+                        .padding(3.dp),
+                horizontalArrangement = Arrangement.spacedBy(3.dp)
+            ) {
+                ResultTab(label = tr(Tr.TAB_DISCOVERED_BUILD), selected = current == BuilderTab.BUILD) {
+                    onSelect(BuilderTab.BUILD)
+                }
+                ResultTab(label = tr(Tr.TAB_CLASS_SPELLS), selected = current == BuilderTab.SPELLS) {
+                    onSelect(BuilderTab.SPELLS)
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            if (phaseHint.isNotEmpty()) {
+                Text(text = phaseHint, style = WTypography.labelSmall.copy(color = WColor.muted))
+            }
         }
+        Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
+    }
+}
+
+@Composable
+private fun ResultTab(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(if (selected) WColor.raised else Color.Transparent)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 14.dp, vertical = 6.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = label,
+            style =
+                WTypography.labelMedium.copy(
+                    color = if (selected) WColor.text else WColor.muted,
+                    fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal
+                )
+        )
     }
 }
 

--- a/gui-compose/src/main/kotlin/me/chosante/ui/spells/ClassSpellsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/spells/ClassSpellsPanel.kt
@@ -28,8 +28,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.chosante.autobuilder.domain.BuildSpellDamage
+import me.chosante.autobuilder.domain.Orientation
 import me.chosante.autobuilder.domain.PassiveCatalog
 import me.chosante.autobuilder.domain.SpellCatalog
+import me.chosante.autobuilder.domain.toSpellDamageRangeBand
 import me.chosante.common.Character
 import me.chosante.common.Characteristic
 import me.chosante.common.Passive
@@ -57,10 +59,12 @@ import me.chosante.ui.theme.WTypography
 /**
  * The "Class spells & passives" tab of the result region: every damage spell of the current class with
  * the **expected damage the discovered build would deal** with it (via [BuildSpellDamage]), plus the
- * class's passive pool (with the build's selected passives flagged). Damage is the neutral yardstick — a
- * 0%-resistance target, no positional / rear / berserk bonus — so the numbers are stable and comparable;
- * the "i" tooltip on each spell spells that out. Before any search runs (no [UiState.build]) it falls back
- * to each spell's build-independent base hit at the character level.
+ * class's passive pool (with the build's selected passives flagged). Damage credits the build's elemental,
+ * critical and **range-band (distance/melee) mastery** plus % damage inflicted, against a neutral
+ * 0%-resistance target with no rear/berserk bonus — so a distance build is no longer under-shown by
+ * dropping its biggest mastery. The range band comes from the current attack [scenario][UiState.scenario]
+ * (shown as a small label); the "i" tooltip spells the rest out. Before any search runs (no
+ * [UiState.build]) it falls back to each spell's build-independent base hit at the character level.
  */
 @Composable
 fun ClassSpellsPanel(
@@ -74,18 +78,51 @@ fun ClassSpellsPanel(
             build?.let { Character(ui.clazz, ui.level, ui.minLevel).copy(characterSkills = it.characterSkills) }
         }
     val critRate = (ui.achieved[Characteristic.CRITICAL_HIT] ?: 0).coerceIn(0, 100)
+    // Credit the build's own range band (the secondary mastery it plays with) so distance/melee builds
+    // aren't understated; the headline stays a neutral FACE hit so spells remain comparable, with the
+    // back/berserk scenarios shown as extra lines.
+    val rangeBand = ui.scenario.rangeBand
+    // Only offer the berserk variant when the build actually carries berserk mastery (otherwise it equals
+    // the neutral hit and is just noise).
+    val hasBerserk = (ui.achieved[Characteristic.MASTERY_BERSERK] ?: 0) > 0
     val entries =
-        remember(ui.clazz, ui.level, build, ui.achieved) {
+        remember(ui.clazz, ui.level, ui.minLevel, build, ui.achieved, rangeBand) {
+            val band = rangeBand.toSpellDamageRangeBand()
             SpellCatalog
                 .damageSpells(ui.clazz)
                 .map { spell ->
-                    val damage =
-                        if (build != null && character != null) {
-                            BuildSpellDamage.expectedDamage(spell = spell, build = build, character = character)
+                    // Resolve the build's stats ONCE per spell; the face/back/berserk variants share them and
+                    // differ only by the flags passed to SpellDamage, so this avoids 3× the stat resolution.
+                    val stats = if (build != null && character != null) BuildSpellDamage.resolveStats(spell, build, character) else null
+
+                    fun hit(
+                        rear: Boolean,
+                        berserk: Boolean,
+                        orientation: Int,
+                    ): SpellDamage.Result? =
+                        if (stats != null && character != null) {
+                            SpellDamage.expectedDamage(
+                                spell = spell,
+                                stats = stats,
+                                characterLevel = character.level,
+                                rangeBand = band,
+                                rearMastery = rear,
+                                berserkMastery = berserk,
+                                orientationMultiplierPercent = orientation
+                            )
                         } else {
                             null
                         }
-                    SpellEntry(spell = spell, damage = damage, baseHit = spell.baseDamageAt(ui.level))
+                    SpellEntry(
+                        spell = spell,
+                        // Neutral reference: face hit, the build's range band, no rear/berserk.
+                        damage = hit(rear = false, berserk = false, orientation = 100),
+                        // Back hit: ×1.25 positional multiplier AND rear mastery (Wakfu couples them).
+                        back = hit(rear = true, berserk = false, orientation = 125),
+                        // Berserk: caster at/below 50% HP folds in berserk mastery (face).
+                        berserk = if (hasBerserk) hit(rear = false, berserk = true, orientation = 100) else null,
+                        baseHit = spell.baseDamageAt(ui.level)
+                    )
                 }.sortedByDescending { it.damage?.expected ?: it.baseHit?.toDouble() ?: 0.0 }
         }
     val scroll = rememberScrollState()
@@ -99,6 +136,23 @@ fun ClassSpellsPanel(
         verticalArrangement = Arrangement.spacedBy(WDimens.gap)
     ) {
         SectionTitle(title = tr(Tr.CLASS_SPELLS_TITLE), trailing = entries.size.toString())
+        if (build != null) {
+            // Transparency: say which secondary mastery the per-spell numbers credit (distance vs melee),
+            // since the build's range band, not an apples-to-apples neutral, drives the figures.
+            Text(
+                text = tr(Tr.SPELL_DAMAGE_RANGE_NOTE).format(rangeBand.label(lang).lowercase()),
+                style = WTypography.labelSmall.copy(color = WColor.faint)
+            )
+            // A hit is ranged OR melee, never both: if a build carries both masteries, only the scenario's
+            // band counts here — flag it so the displayed damage isn't read as crediting the wasted one.
+            val hasBothBands = (ui.achieved[Characteristic.MASTERY_DISTANCE] ?: 0) > 0 && (ui.achieved[Characteristic.MASTERY_MELEE] ?: 0) > 0
+            if (hasBothBands) {
+                Text(
+                    text = tr(Tr.SPELL_DAMAGE_DIST_MELEE_HINT),
+                    style = WTypography.labelSmall.copy(color = WColor.warning)
+                )
+            }
+        }
         if (build == null) {
             Text(
                 text = tr(Tr.CLASS_SPELLS_NO_BUILD),
@@ -116,10 +170,16 @@ fun ClassSpellsPanel(
     }
 }
 
-/** A damage spell paired with its build-scoped expected hit ([damage]) and a build-independent fallback. */
+/**
+ * A damage spell paired with its build-scoped expected hits: the neutral face [damage] (the headline and
+ * the build-independent [baseHit] fallback), plus the [back] (rear hit, ×1.25 + rear mastery) and optional
+ * [berserk] (≤50% HP) scenario variants shown as extra lines.
+ */
 private data class SpellEntry(
     val spell: Spell,
     val damage: SpellDamage.Result?,
+    val back: SpellDamage.Result? = null,
+    val berserk: SpellDamage.Result? = null,
     val baseHit: Int?,
 )
 
@@ -252,6 +312,7 @@ private fun DamageBlock(
             InfoTip(text = tr(Tr.SPELL_EXPECTED_HIT_INFO), modifier = Modifier.padding(bottom = 2.dp))
         }
         CritBreakdown(damage = damage, critRate = critRate)
+        ScenarioVariants(entry = entry)
     } else {
         val base = entry.baseHit ?: return
         Row(verticalAlignment = Alignment.Bottom) {
@@ -269,6 +330,26 @@ private fun DamageBlock(
             InfoTip(text = tr(Tr.SPELL_BASE_HIT_INFO), modifier = Modifier.padding(bottom = 2.dp))
         }
     }
+}
+
+/**
+ * Other-scenario expected hits below the neutral headline: the **back** hit (×1.25 positional + rear
+ * mastery) and, when the build carries berserk mastery, the **berserk** hit (≤50% HP). Lets the player
+ * read off how much a spell gains from positioning / low-HP play without switching the whole view.
+ */
+@Composable
+private fun ScenarioVariants(entry: SpellEntry) {
+    val lang = LocalLang.current
+    val parts =
+        buildList {
+            entry.back?.let { add("${Orientation.BACK.label(lang).lowercase()} ${it.expected.toLong().formatCompact()}") }
+            entry.berserk?.let { add("${tr(Tr.SPELL_VARIANT_BERSERK)} ${it.expected.toLong().formatCompact()}") }
+        }
+    if (parts.isEmpty()) return
+    Text(
+        text = parts.joinToString("  ·  "),
+        style = WTypography.labelSmall.copy(color = WColor.faint, fontFamily = WType.mono)
+    )
 }
 
 /**

--- a/gui-compose/src/main/kotlin/me/chosante/ui/spells/ClassSpellsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/spells/ClassSpellsPanel.kt
@@ -1,0 +1,421 @@
+package me.chosante.ui.spells
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.chosante.autobuilder.domain.BuildSpellDamage
+import me.chosante.autobuilder.domain.PassiveCatalog
+import me.chosante.autobuilder.domain.SpellCatalog
+import me.chosante.common.Character
+import me.chosante.common.Characteristic
+import me.chosante.common.Passive
+import me.chosante.common.Spell
+import me.chosante.common.SpellDamage
+import me.chosante.common.SpellElement
+import me.chosante.ui.components.InfoTip
+import me.chosante.ui.components.PassiveIcon
+import me.chosante.ui.components.SpellIcon
+import me.chosante.ui.components.elementColor
+import me.chosante.ui.components.elementLabel
+import me.chosante.ui.components.localized
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import me.chosante.ui.i18n.Tr
+import me.chosante.ui.i18n.label
+import me.chosante.ui.i18n.tr
+import me.chosante.ui.state.UiState
+import me.chosante.ui.state.formatCompact
+import me.chosante.ui.theme.WColor
+import me.chosante.ui.theme.WDimens
+import me.chosante.ui.theme.WType
+import me.chosante.ui.theme.WTypography
+
+/**
+ * The "Class spells & passives" tab of the result region: every damage spell of the current class with
+ * the **expected damage the discovered build would deal** with it (via [BuildSpellDamage]), plus the
+ * class's passive pool (with the build's selected passives flagged). Damage is the neutral yardstick — a
+ * 0%-resistance target, no positional / rear / berserk bonus — so the numbers are stable and comparable;
+ * the "i" tooltip on each spell spells that out. Before any search runs (no [UiState.build]) it falls back
+ * to each spell's build-independent base hit at the character level.
+ */
+@Composable
+fun ClassSpellsPanel(
+    ui: UiState,
+    modifier: Modifier = Modifier,
+) {
+    val lang = LocalLang.current
+    val build = ui.build
+    val character =
+        remember(ui.clazz, ui.level, ui.minLevel, build) {
+            build?.let { Character(ui.clazz, ui.level, ui.minLevel).copy(characterSkills = it.characterSkills) }
+        }
+    val critRate = (ui.achieved[Characteristic.CRITICAL_HIT] ?: 0).coerceIn(0, 100)
+    val entries =
+        remember(ui.clazz, ui.level, build, ui.achieved) {
+            SpellCatalog
+                .damageSpells(ui.clazz)
+                .map { spell ->
+                    val damage =
+                        if (build != null && character != null) {
+                            BuildSpellDamage.expectedDamage(spell = spell, build = build, character = character)
+                        } else {
+                            null
+                        }
+                    SpellEntry(spell = spell, damage = damage, baseHit = spell.baseDamageAt(ui.level))
+                }.sortedByDescending { it.damage?.expected ?: it.baseHit?.toDouble() ?: 0.0 }
+        }
+    val scroll = rememberScrollState()
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(WColor.bg)
+                .verticalScroll(scroll)
+                .padding(WDimens.pad),
+        verticalArrangement = Arrangement.spacedBy(WDimens.gap)
+    ) {
+        SectionTitle(title = tr(Tr.CLASS_SPELLS_TITLE), trailing = entries.size.toString())
+        if (build == null) {
+            Text(
+                text = tr(Tr.CLASS_SPELLS_NO_BUILD),
+                style = WTypography.bodySmall.copy(color = WColor.muted)
+            )
+        }
+        if (entries.isEmpty()) {
+            Text(
+                text = tr(Tr.CLASS_SPELLS_EMPTY),
+                style = WTypography.bodySmall.copy(color = WColor.muted)
+            )
+        }
+        SpellGrid(entries = entries, critRate = critRate, hasBuild = build != null, lang = lang)
+        PassivesSection(ui = ui, lang = lang)
+    }
+}
+
+/** A damage spell paired with its build-scoped expected hit ([damage]) and a build-independent fallback. */
+private data class SpellEntry(
+    val spell: Spell,
+    val damage: SpellDamage.Result?,
+    val baseHit: Int?,
+)
+
+@Composable
+private fun SpellGrid(
+    entries: List<SpellEntry>,
+    critRate: Int,
+    hasBuild: Boolean,
+    lang: Lang,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val columns =
+            when {
+                maxWidth >= 920.dp -> 3
+                maxWidth >= 560.dp -> 2
+                else -> 1
+            }
+        Column(verticalArrangement = Arrangement.spacedBy(WDimens.gap)) {
+            entries.chunked(columns).forEach { rowEntries ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(WDimens.gap)
+                ) {
+                    rowEntries.forEach { entry ->
+                        SpellCard(
+                            entry = entry,
+                            critRate = critRate,
+                            hasBuild = hasBuild,
+                            lang = lang,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    repeat(columns - rowEntries.size) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpellCard(
+    entry: SpellEntry,
+    critRate: Int,
+    hasBuild: Boolean,
+    lang: Lang,
+    modifier: Modifier = Modifier,
+) {
+    val spell = entry.spell
+    Column(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(WDimens.radius))
+                .background(WColor.surface)
+                .border(1.dp, WColor.hairline, RoundedCornerShape(WDimens.radius))
+                .padding(13.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SpellIcon(iconId = spell.iconId, element = spell.element, size = 40.dp)
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = spell.name.localized(lang),
+                    style = WTypography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(3.dp))
+                ElementBadge(element = spell.element)
+            }
+        }
+        SpellMetaRow(spell = spell)
+        DamageBlock(entry = entry, critRate = critRate, hasBuild = hasBuild)
+        spell.description?.localized(lang)?.takeIf { it.isNotBlank() }?.let { desc ->
+            Text(
+                text = desc,
+                style = WTypography.labelSmall.copy(color = WColor.muted, lineHeight = 15.sp),
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpellMetaRow(spell: Spell) {
+    val perTurn = tr(Tr.SPELL_PER_TURN_SUFFIX)
+    val parts =
+        buildList {
+            spell.apCost?.let { add("$it AP") }
+            spell.wpCost?.takeIf { it > 0 }?.let { add("$it WP") }
+            val lo = spell.rangeMin
+            val hi = spell.rangeMax
+            if (lo != null || hi != null) {
+                val low = lo ?: hi
+                val high = hi ?: lo
+                add(if (low == high) "$low" else "$low–$high")
+            }
+            spell.maxCastsThisTurn?.let { add("$it/$perTurn") }
+        }
+    if (parts.isEmpty()) return
+    Text(
+        text = parts.joinToString("  ·  "),
+        style = WTypography.labelSmall.copy(color = WColor.muted, fontFamily = WType.mono)
+    )
+}
+
+@Composable
+private fun DamageBlock(
+    entry: SpellEntry,
+    critRate: Int,
+    hasBuild: Boolean,
+) {
+    val damage = entry.damage
+    if (hasBuild && damage != null) {
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                text = damage.expected.toLong().formatCompact(),
+                style = WTypography.headlineMedium.copy(color = WColor.accent, fontFamily = WType.mono)
+            )
+            Spacer(modifier = Modifier.width(7.dp))
+            Text(
+                text = tr(Tr.SPELL_EXPECTED_HIT),
+                style = WTypography.labelSmall.copy(color = WColor.muted),
+                modifier = Modifier.padding(bottom = 2.dp)
+            )
+            Spacer(modifier = Modifier.width(5.dp))
+            InfoTip(text = tr(Tr.SPELL_EXPECTED_HIT_INFO), modifier = Modifier.padding(bottom = 2.dp))
+        }
+        CritBreakdown(damage = damage, critRate = critRate)
+    } else {
+        val base = entry.baseHit ?: return
+        Row(verticalAlignment = Alignment.Bottom) {
+            Text(
+                text = base.toLong().formatCompact(),
+                style = WTypography.headlineMedium.copy(color = WColor.text, fontFamily = WType.mono)
+            )
+            Spacer(modifier = Modifier.width(7.dp))
+            Text(
+                text = tr(Tr.SPELL_BASE_HIT),
+                style = WTypography.labelSmall.copy(color = WColor.muted),
+                modifier = Modifier.padding(bottom = 2.dp)
+            )
+            Spacer(modifier = Modifier.width(5.dp))
+            InfoTip(text = tr(Tr.SPELL_BASE_HIT_INFO), modifier = Modifier.padding(bottom = 2.dp))
+        }
+    }
+}
+
+/**
+ * The non-crit / crit split, shown **only when the crit chance is strictly between 0% and 100%** —
+ * exactly when both outcomes can happen. At 100% every cast crits (`expected == crit`); at 0% the
+ * expected hit just is the non-crit value, so in both edge cases the single headline number says it all.
+ */
+@Composable
+private fun CritBreakdown(
+    damage: SpellDamage.Result,
+    critRate: Int,
+) {
+    val text =
+        when {
+            critRate >= 100 -> tr(Tr.SPELL_ALWAYS_CRITS)
+            critRate <= 0 -> return
+            else ->
+                "${tr(Tr.SPELL_NONCRIT)} ${damage.nonCrit.toLong().formatCompact()}  ·  " +
+                    "${tr(Tr.SPELL_CRIT)} ${damage.crit.toLong().formatCompact()}  ·  " +
+                    "$critRate% ${tr(Tr.SPELL_CRIT)}"
+        }
+    Text(
+        text = text,
+        style = WTypography.labelSmall.copy(color = WColor.faint, fontFamily = WType.mono)
+    )
+}
+
+@Composable
+private fun PassivesSection(
+    ui: UiState,
+    lang: Lang,
+) {
+    // The class's whole passive pool (so the "& passives" tab is never empty), with the ones the current
+    // build selected flagged. Passives carry no spell damage, so this is a reference list, not a hit table.
+    val passives = remember(ui.clazz) { PassiveCatalog.forClass(ui.clazz) }
+    if (passives.isEmpty()) return
+    val selectedIds =
+        remember(ui.build) {
+            ui.build
+                ?.passives
+                .orEmpty()
+                .map { it.spellId }
+                .toSet()
+        }
+    val trailing = if (selectedIds.isEmpty()) passives.size.toString() else "${selectedIds.size}/${passives.size}"
+    SectionTitle(title = tr(Tr.CLASS_SPELLS_PASSIVES), trailing = trailing)
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(WDimens.radius))
+                .background(WColor.surface)
+                .border(1.dp, WColor.hairline, RoundedCornerShape(WDimens.radius))
+                .padding(WDimens.pad),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        passives.forEach { passive ->
+            PassiveRow(passive = passive, selected = passive.spellId in selectedIds, lang = lang)
+        }
+    }
+}
+
+@Composable
+private fun PassiveRow(
+    passive: Passive,
+    selected: Boolean,
+    lang: Lang,
+) {
+    Row(verticalAlignment = Alignment.Top) {
+        PassiveIcon(gfxId = passive.gfxId, size = 24.dp)
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(
+                    text = passive.name?.localized(lang) ?: passive.spellId.toString(),
+                    style = WTypography.bodySmall.copy(color = WColor.text),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (selected) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(WColor.success.copy(alpha = 0.18f))
+                                .padding(horizontal = 7.dp, vertical = 2.dp)
+                    ) {
+                        Text(text = tr(Tr.PASSIVE_IN_BUILD), style = WTypography.labelSmall.copy(color = WColor.success))
+                    }
+                }
+            }
+            passive.description?.localized(lang)?.takeIf { it.isNotBlank() }?.let { desc ->
+                Text(
+                    text = desc,
+                    style = WTypography.labelSmall.copy(color = WColor.muted, lineHeight = 15.sp),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+        val flat = passive.flatStats.entries.joinToString("  ") { "+${it.value} ${it.key.label(lang)}" }
+        if (flat.isNotBlank()) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = flat,
+                style = WTypography.labelSmall.copy(color = WColor.accent2, fontFamily = WType.mono),
+                maxLines = 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(
+    title: String,
+    trailing: String? = null,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(text = title, style = WTypography.headlineMedium)
+        Spacer(modifier = Modifier.width(10.dp))
+        Box(modifier = Modifier.weight(1f).height(1.dp).background(WColor.hairline))
+        if (trailing != null) {
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = trailing,
+                style = WTypography.labelSmall.copy(color = WColor.muted, fontFamily = WType.mono)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ElementBadge(element: SpellElement?) {
+    element ?: return
+    val color = element.elementColor()
+    Box(
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(color.copy(alpha = 0.16f))
+                .padding(horizontal = 7.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = element.elementLabel(),
+            style = WTypography.labelSmall.copy(color = color, fontWeight = FontWeight.Medium)
+        )
+    }
+}

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -18,6 +18,7 @@ import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.domain.DamageScenario
 import me.chosante.autobuilder.domain.PassiveCatalog
 import me.chosante.autobuilder.domain.SpellElement
+import me.chosante.autobuilder.domain.SpellRotation
 import me.chosante.autobuilder.domain.SpellRotationOptimizer
 import me.chosante.autobuilder.domain.TargetStat
 import me.chosante.autobuilder.domain.TargetStats
@@ -327,7 +328,8 @@ class BuildSearchModel(
                 optimal = false,
                 build = null,
                 achieved = emptyMap(),
-                spellRotation = null
+                spellRotation = null,
+                scenarioDamages = emptyList()
             )
     }
 
@@ -364,7 +366,8 @@ class BuildSearchModel(
                 optimal = false,
                 build = null,
                 achieved = emptyMap(),
-                spellRotation = null
+                spellRotation = null,
+                scenarioDamages = emptyList()
             )
     }
 
@@ -730,6 +733,7 @@ class BuildSearchModel(
                 build = null,
                 achieved = emptyMap(),
                 spellRotation = null,
+                scenarioDamages = emptyList(),
                 lastLandedEquipmentId = null,
                 zenith = ZenithState.Idle,
                 zenithUrl = null,
@@ -757,6 +761,12 @@ class BuildSearchModel(
                     }
                 try {
                     var hasResult = false
+                    // The per-position damage breakdown is a result-level detail that runs 3-4 extra rotations,
+                    // so it's computed ONCE for the final build after the stream settles (below) — not on every
+                    // streamed improvement. These capture the last build/achieved/headline-rotation for that.
+                    var finalBuild: BuildCombination? = null
+                    var finalAchieved: Map<Characteristic, Int> = emptyMap()
+                    var finalRotation: SpellRotation? = null
                     buildFinder(params)
                         .conflate()
                         .collect { result ->
@@ -804,6 +814,9 @@ class BuildSearchModel(
                                 } else {
                                     null
                                 }
+                            finalBuild = result.individual
+                            finalAchieved = achieved
+                            finalRotation = spellRotation
                             withContext(mainDispatcher) {
                                 val landedEquipmentId = newlyLandedEquipmentId(ui.build, result.individual)
                                 ui =
@@ -831,11 +844,28 @@ class BuildSearchModel(
                                 }
                             }
                         }
+                    // Compute the per-position breakdown ONCE for the final build, still off the UI thread
+                    // (we're on Dispatchers.Default here), reusing the final headline rotation for the
+                    // configured combo so only the OTHER positions pay a rotation.
+                    val finalBuildSnapshot = finalBuild
+                    val scenarioDamages =
+                        if (snapshot.mode == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE && finalBuildSnapshot != null) {
+                            SpellRotationOptimizer.scenarioBreakdown(
+                                finalBuildSnapshot,
+                                character,
+                                character.clazz,
+                                damageScenario,
+                                includeBerserk = (finalAchieved[Characteristic.MASTERY_BERSERK] ?: 0) > 0,
+                                configuredRotationTotal = finalRotation?.totalExpectedDamage
+                            )
+                        } else {
+                            emptyList()
+                        }
                     withContext(mainDispatcher) {
                         if (ui.phase == Phase.Searching && hasResult) {
                             // Snap the time-based bar to a clean 100% on completion (the solver may
                             // have proven the optimum well before the wall-clock budget ran out).
-                            ui = ui.copy(phase = Phase.Done, progress = 100, lastLandedEquipmentId = null)
+                            ui = ui.copy(phase = Phase.Done, progress = 100, scenarioDamages = scenarioDamages, lastLandedEquipmentId = null)
                         } else if (ui.phase == Phase.Searching) {
                             ui =
                                 ui.copy(
@@ -1124,12 +1154,13 @@ class BuildSearchModel(
         job?.cancel()
         val loadedBuild = entry.toBuildCombination()
         // Recompute the spell rotation for a loaded max-damage build (else the Rotation card would show a
-        // rotation left over from a prior search, or nothing). Cheap — no solver, just the rotation DP.
+        // rotation left over from a prior search, or nothing). Cheap — no solver, just one rotation DP.
+        val isMaxDamage = entry.restoredMode() == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE
+        val restoredCharacter =
+            me.chosante.common.Character(entry.restoredClass(), entry.request.level, entry.request.minLevel, loadedBuild.characterSkills)
         val rotation =
-            if (entry.restoredMode() == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE) {
-                val character =
-                    me.chosante.common.Character(entry.restoredClass(), entry.request.level, entry.request.minLevel, loadedBuild.characterSkills)
-                SpellRotationOptimizer.bestSequencedRotation(loadedBuild, character, character.clazz, entry.restoredScenario())
+            if (isMaxDamage) {
+                SpellRotationOptimizer.bestSequencedRotation(loadedBuild, restoredCharacter, restoredCharacter.clazz, entry.restoredScenario())
             } else {
                 null
             }
@@ -1154,6 +1185,7 @@ class BuildSearchModel(
                 optimal = entry.result.optimal,
                 build = loadedBuild,
                 spellRotation = rotation,
+                scenarioDamages = emptyList(),
                 achieved = entry.result.achieved,
                 lastLandedEquipmentId = null,
                 zenith = if (entry.zenithUrl != null) ZenithState.Ready else ZenithState.Idle,
@@ -1164,6 +1196,25 @@ class BuildSearchModel(
                 activeBuildName = entry.name,
                 searchLocked = true
             )
+        // The per-position breakdown runs 3-4 more rotations, so compute it OFF the UI thread (the rotation
+        // card already renders from `rotation` above) and patch it in when ready — only if this build is still
+        // the active one, so a quick load-another-build doesn't get a stale breakdown.
+        if (isMaxDamage && rotation != null) {
+            scope.launch(Dispatchers.Default) {
+                val breakdown =
+                    SpellRotationOptimizer.scenarioBreakdown(
+                        loadedBuild,
+                        restoredCharacter,
+                        restoredCharacter.clazz,
+                        entry.restoredScenario(),
+                        includeBerserk = (entry.result.achieved[Characteristic.MASTERY_BERSERK] ?: 0) > 0,
+                        configuredRotationTotal = rotation.totalExpectedDamage
+                    )
+                withContext(mainDispatcher) {
+                    if (ui.activeBuildId == entry.id) ui = ui.copy(scenarioDamages = breakdown)
+                }
+            }
+        }
     }
 
     /** Opens the import dialog, where a build exported via [exportBuild] is pasted. See [importBuild]. */

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -562,7 +562,8 @@ class BuildSearchModel(
      * is ignored.
      */
     fun pickPassive(passive: me.chosante.common.Passive) {
-        val name = passive.name ?: return
+        // forcedPassives stores the canonical FRENCH name (the engine matches passives by French).
+        val name = passive.name?.fr ?: return
         val slots =
             me.chosante.autobuilder.domain.PassiveCatalog
                 .slotsForLevel(ui.level)
@@ -1004,6 +1005,11 @@ class BuildSearchModel(
 
     fun goToScreen(screen: Screen) {
         ui = ui.copy(screen = screen)
+    }
+
+    /** Switch the result region between the discovered build and the class's spells & passives. */
+    fun setBuilderTab(tab: BuilderTab) {
+        ui = ui.copy(builderTab = tab)
     }
 
     // --- Library organize (search / sort / filter / group) ---
@@ -1521,28 +1527,38 @@ class BuildSearchModel(
         ui = ui.copy(modal = Modal.ConfirmDelete(id, name))
     }
 
-    /** Opens the compare view with [id] pre-selected as side A. */
+    /** Opens the compare view with [id] pre-selected in the first column. */
     fun startCompare(id: String) {
-        ui = ui.copy(screen = Screen.Compare, compareA = id, compareB = null, modal = null)
+        ui = ui.copy(screen = Screen.Compare, compareSlots = listOf(id, null), modal = null)
     }
 
+    /** Pin build [id] into compare column [index] (no-op if the index is out of range). */
     fun setCompareSlot(
-        slot: CompareSlot,
+        index: Int,
         id: String,
     ) {
+        if (index !in ui.compareSlots.indices) return
+        ui = ui.copy(compareSlots = ui.compareSlots.mapIndexed { i, slot -> if (i == index) id else slot })
+    }
+
+    /**
+     * The ✕ on compare column [index]: removes the column when more than the two base columns exist,
+     * otherwise just empties it — so there are always at least [MIN_COMPARE_SLOTS] columns to compare.
+     */
+    fun clearCompareSlot(index: Int) {
+        if (index !in ui.compareSlots.indices) return
         ui =
-            when (slot) {
-                CompareSlot.A -> ui.copy(compareA = id)
-                CompareSlot.B -> ui.copy(compareB = id)
+            if (ui.compareSlots.size > MIN_COMPARE_SLOTS) {
+                ui.copy(compareSlots = ui.compareSlots.filterIndexed { i, _ -> i != index })
+            } else {
+                ui.copy(compareSlots = ui.compareSlots.mapIndexed { i, slot -> if (i == index) null else slot })
             }
     }
 
-    fun clearCompareSlot(slot: CompareSlot) {
-        ui =
-            when (slot) {
-                CompareSlot.A -> ui.copy(compareA = null)
-                CompareSlot.B -> ui.copy(compareB = null)
-            }
+    /** Append an empty compare column, up to [MAX_COMPARE_SLOTS]. */
+    fun addCompareSlot() {
+        if (ui.compareSlots.size >= MAX_COMPARE_SLOTS) return
+        ui = ui.copy(compareSlots = ui.compareSlots + null)
     }
 
     fun deleteBuild(id: String) {
@@ -1558,8 +1574,7 @@ class BuildSearchModel(
                         activeBuildId = if (wasActive) null else ui.activeBuildId,
                         activeBuildName = if (wasActive) null else ui.activeBuildName,
                         searchLocked = if (wasActive) false else ui.searchLocked,
-                        compareA = if (ui.compareA == id) null else ui.compareA,
-                        compareB = if (ui.compareB == id) null else ui.compareB,
+                        compareSlots = ui.compareSlots.map { if (it == id) null else it },
                         knownTags = computeKnownTags(all),
                         libraryFolder = ui.libraryFolder.coercedTo(all),
                         librarySelectedTags = ui.librarySelectedTags.coercedToTags(all)

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -3,6 +3,7 @@ package me.chosante.ui.state
 import androidx.compose.ui.graphics.Color
 import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.domain.DamageScenario
+import me.chosante.autobuilder.domain.ScenarioDamage
 import me.chosante.autobuilder.domain.SpellElement
 import me.chosante.autobuilder.domain.SpellRotation
 import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
@@ -205,6 +206,9 @@ data class UiState(
     val achieved: Map<Characteristic, Int> = emptyMap(),
     /** Best spells to cast for the build's AP, in max-damage mode only (else null). Computed off-thread. */
     val spellRotation: SpellRotation? = null,
+    // Max-damage only: per-turn damage under each attack position (face/side/back/+berserk), for the result
+    // breakdown. Empty in the other modes and until a max-damage build is found.
+    val scenarioDamages: List<ScenarioDamage> = emptyList(),
     /** Active tab of the result region: the discovered build, or the class's spells & passives. */
     val builderTab: BuilderTab = BuilderTab.BUILD,
     val lastLandedEquipmentId: Int? = null,

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -48,11 +48,18 @@ enum class Screen {
     Compare,
 }
 
-/** The two sides of the compare view. */
-enum class CompareSlot {
-    A,
-    B,
+/**
+ * Tabs of the build-result region (everything right of the request inputs): the discovered build's
+ * paperdoll + stats, or a reference view of the current class's damage spells & chosen passives.
+ */
+enum class BuilderTab {
+    BUILD,
+    SPELLS,
 }
+
+/** The compare view holds between two and four build columns. */
+const val MIN_COMPARE_SLOTS = 2
+const val MAX_COMPARE_SLOTS = 4
 
 /** Ordering options for the build library. See [organizeLibrary]. */
 enum class LibrarySort {
@@ -166,7 +173,9 @@ data class UiState(
     val maxRarity: Rarity = Rarity.EPIC,
     /** Rarities the user toggled off; excluded from the search. At least one rarity always stays allowed. */
     val excludedRarities: Set<Rarity> = emptySet(),
-    val duration: String = "20",
+    // 120s: long enough for max-damage (incl. runes+sublimations) to reach a PROVEN optimum at high level
+    // (~80–110s after the rune fold); shorter modes still finish early and stream their result well before.
+    val duration: String = "120",
     val stopAtMatch: Boolean = false,
     val forcedItems: List<ItemChip> = emptyList(),
     val excludedItems: List<ItemChip> = emptyList(),
@@ -196,6 +205,8 @@ data class UiState(
     val achieved: Map<Characteristic, Int> = emptyMap(),
     /** Best spells to cast for the build's AP, in max-damage mode only (else null). Computed off-thread. */
     val spellRotation: SpellRotation? = null,
+    /** Active tab of the result region: the discovered build, or the class's spells & passives. */
+    val builderTab: BuilderTab = BuilderTab.BUILD,
     val lastLandedEquipmentId: Int? = null,
     val zenith: ZenithState = ZenithState.Idle,
     val zenithUrl: String? = null,
@@ -215,9 +226,12 @@ data class UiState(
      * act (it pops [Modal.ConfirmReSearch] first). Cleared once the user confirms or starts fresh.
      */
     val searchLocked: Boolean = false,
-    /** The two builds pinned for the side-by-side compare view (entry ids), A then B. */
-    val compareA: String? = null,
-    val compareB: String? = null,
+    /**
+     * Builds pinned for the side-by-side compare view, in column order (entry ids; `null` = an empty
+     * slot still showing its picker). Starts with two slots; the user can add up to four and remove
+     * extras back down to two. See [me.chosante.ui.state.BuildSearchModel.setCompareSlot].
+     */
+    val compareSlots: List<String?> = listOf(null, null),
     /**
      * Id of the build just created by [me.chosante.ui.state.BuildSearchModel.duplicateBuild]. The
      * library briefly highlights that card (and scrolls it into view) so it's obvious where the copy

--- a/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
@@ -44,7 +44,9 @@ import me.chosante.ui.components.PassiveIcon
 import me.chosante.ui.components.StatGlyphIcon
 import me.chosante.ui.components.VerticalScrollHints
 import me.chosante.ui.components.iconResourcePath
+import me.chosante.ui.components.localized
 import me.chosante.ui.components.rememberClasspathBitmap
+import me.chosante.ui.components.sublimationEffectText
 import me.chosante.ui.i18n.Lang
 import me.chosante.ui.i18n.LocalLang
 import me.chosante.ui.i18n.Tr
@@ -1009,7 +1011,7 @@ private fun SublimationsResult(ui: UiState) {
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(text = sub.rarity.name, style = WTypography.labelSmall.copy(color = WColor.muted, fontFamily = WType.mono))
                     }
-                    sub.rawText?.takeIf { it.isNotBlank() }?.let {
+                    sublimationEffectText(sub, ui.lang).takeIf { it.isNotBlank() }?.let {
                         Text(text = it, style = WTypography.labelSmall.copy(color = WColor.muted))
                     }
                 }
@@ -1024,13 +1026,14 @@ private fun SublimationsResult(ui: UiState) {
 private fun PassivesResult(ui: UiState) {
     val passives = ui.build?.passives.orEmpty()
     if (passives.isEmpty()) return
+    val lang = LocalLang.current
     ResultCard(title = tr(Tr.CHOSEN_PASSIVES), trailing = passives.size.toString()) {
         Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             passives.forEach { passive ->
                 androidx.compose.foundation.TooltipArea(
                     delayMillis = 300,
                     tooltip = {
-                        passive.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                        passive.description?.localized(lang)?.takeIf { it.isNotBlank() }?.let { desc ->
                             Box(
                                 modifier =
                                     Modifier
@@ -1052,7 +1055,7 @@ private fun PassivesResult(ui: UiState) {
                     ) {
                         PassiveIcon(gfxId = passive.gfxId, size = 24.dp)
                         Text(
-                            text = passive.name ?: passive.spellId.toString(),
+                            text = passive.name?.localized(lang) ?: passive.spellId.toString(),
                             style = WTypography.labelMedium.copy(color = WColor.text),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
@@ -40,6 +40,7 @@ import me.chosante.common.skills.Assignable
 import me.chosante.common.skills.CharacterSkills
 import me.chosante.common.skills.SkillCharacteristic
 import me.chosante.ui.components.CharacteristicIcon
+import me.chosante.ui.components.Hairline
 import me.chosante.ui.components.PassiveIcon
 import me.chosante.ui.components.StatGlyphIcon
 import me.chosante.ui.components.VerticalScrollHints
@@ -294,6 +295,7 @@ private fun SpellRotationCard(ui: UiState) {
                 style = WTypography.bodyMedium.copy(fontFamily = WType.mono)
             )
         }
+        ScenarioBreakdown(ui = ui)
         // Turns-to-kill against the targeted boss (its HP scaled by the difficulty multiplier; display only).
         ui.selectedBoss?.takeIf { rotation.totalExpectedDamage > 0 }?.let { boss ->
             val turns =
@@ -326,6 +328,52 @@ private fun SpellRotationCard(ui: UiState) {
                 text = tr(Tr.SPELL_ROTATION_NOTE),
                 style = WTypography.labelSmall.copy(color = WColor.faint),
                 modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+/**
+ * Per-turn damage of the discovered build under each attack position (face / side / back / + berserk) — the
+ * levers the max-damage mode optimizes — so the player can read off what positioning is worth. The row
+ * matching the searched scenario is highlighted; the others differ only by the positional ×multiplier and
+ * the rear / berserk mastery they fold in.
+ */
+@Composable
+private fun ScenarioBreakdown(ui: UiState) {
+    val breakdown = ui.scenarioDamages
+    if (breakdown.isEmpty()) return
+    val lang = LocalLang.current
+    Hairline()
+    Text(
+        text = tr(Tr.SCENARIO_DAMAGE_BREAKDOWN),
+        style = WTypography.labelMedium.copy(color = WColor.muted),
+        modifier = Modifier.padding(top = 6.dp, bottom = 2.dp)
+    )
+    breakdown.forEach { entry ->
+        val active = entry.orientation == ui.scenario.orientation && entry.berserk == ui.scenario.berserk
+        val label = entry.orientation.label(lang) + if (entry.berserk) " + ${tr(Tr.SPELL_VARIANT_BERSERK)}" else ""
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = label,
+                style =
+                    WTypography.bodySmall.copy(
+                        color = if (active) WColor.accent else WColor.text,
+                        fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal
+                    ),
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = entry.totalExpectedDamage.toLong().formatCompact(),
+                style =
+                    WTypography.bodySmall.copy(
+                        fontFamily = WType.mono,
+                        color = if (active) WColor.accent else WColor.text,
+                        fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal
+                    )
             )
         }
     }
@@ -1119,11 +1167,6 @@ private fun Meter(
                     .background(color)
         )
     }
-}
-
-@Composable
-private fun Hairline() {
-    Box(modifier = Modifier.fillMaxWidth().height(1.dp).background(WColor.hairline))
 }
 
 private enum class StatStatus(

--- a/gui-compose/src/test/kotlin/me/chosante/ui/components/SublimationTextTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/components/SublimationTextTest.kt
@@ -1,0 +1,52 @@
+package me.chosante.ui.components
+
+import me.chosante.common.Characteristic
+import me.chosante.common.I18nText
+import me.chosante.common.Sublimation
+import me.chosante.common.SublimationCondition
+import me.chosante.common.SublimationConditionType
+import me.chosante.common.SublimationEffect
+import me.chosante.common.SublimationKind
+import me.chosante.common.SublimationRarity
+import me.chosante.ui.i18n.Lang
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The sublimation effect text is re-synthesized from structured data with localized [Characteristic]
+ * labels (the baked rawText is English-only). These lock the localization and the English fallback.
+ */
+class SublimationTextTest {
+    private val conditionalSub =
+        Sublimation(
+            stateId = 1,
+            name = I18nText("Sub", "Sub", "Sub", "Sub"),
+            rarity = SublimationRarity.EPIC,
+            kind = SublimationKind.STATIC_CONDITIONAL,
+            condition = SublimationCondition(SublimationConditionType.AP_AT_MOST, value = 10),
+            effects = listOf(SublimationEffect(Characteristic.DAMAGE_INFLICTED, 15)),
+            rawText = "If AP ≤ 10 | +15% Damage Inflicted"
+        )
+
+    @Test
+    fun `synthesizes a localized condition and percent effect`() {
+        val fr = sublimationEffectText(conditionalSub, Lang.FR)
+        val en = sublimationEffectText(conditionalSub, Lang.EN)
+        assertThat(fr).contains("Si PA ≤ 10").contains("+15%")
+        assertThat(en).contains("If AP ≤ 10").contains("+15%")
+        // The stat label and the condition are both translated, so the two languages differ.
+        assertThat(fr).isNotEqualTo(en)
+    }
+
+    @Test
+    fun `falls back to the english rawText when there are no structured effects`() {
+        val combatSub =
+            conditionalSub.copy(
+                kind = SublimationKind.COMBAT_CONDITIONAL,
+                condition = null,
+                effects = emptyList(),
+                rawText = "Some in-combat effect"
+            )
+        assertThat(sublimationEffectText(combatSub, Lang.FR)).isEqualTo("Some in-combat effect")
+    }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/CompareScreenUiTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/CompareScreenUiTest.kt
@@ -1,0 +1,134 @@
+package me.chosante.ui.history
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import me.chosante.common.Characteristic
+import me.chosante.common.Rarity
+import me.chosante.common.history.HistoryEntry
+import me.chosante.common.history.RequestSnapshot
+import me.chosante.common.history.ResultSnapshot
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import me.chosante.ui.state.UiState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Headless widget tests for the multi-build compare screen: renders the real [CompareScreen] with stub
+ * saved builds and drives real clicks (Add, ✕) — verifying the per-spell damage table, the same-class
+ * guard, and the N-column add/remove wiring that the PNG screenshot smoke-test can't reach.
+ *
+ * The stub builds carry no equipment, so both columns compute the same base-only spell damage; the numeric
+ * difference between real builds is covered elsewhere. These tests assert the table renders and the
+ * controls fire.
+ */
+@OptIn(ExperimentalTestApi::class)
+class CompareScreenUiTest {
+    private fun entry(
+        id: String,
+        name: String,
+        clazz: String,
+    ): HistoryEntry =
+        HistoryEntry(
+            id = id,
+            name = name,
+            createdAt = 0L,
+            dataVersion = "test",
+            request =
+                RequestSnapshot(
+                    clazz = clazz,
+                    level = 110,
+                    minLevel = 0,
+                    mode = "FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT",
+                    maxRarity = Rarity.EPIC,
+                    duration = "20",
+                    stopAtMatch = false,
+                    targets = emptyList(),
+                    forcedItems = emptyList(),
+                    excludedItems = emptyList()
+                ),
+            result =
+                ResultSnapshot(
+                    equipments = emptyList(),
+                    skills = emptyMap(),
+                    achieved = mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 500),
+                    match = 100.0,
+                    optimal = true
+                )
+        )
+
+    @Test
+    fun `same-class builds render the spell-damage table and Add fires`() =
+        runComposeUiTest {
+            var added = false
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    CompareScreen(
+                        ui =
+                            UiState(
+                                savedBuilds = listOf(entry("a", "Build A", "CRA"), entry("b", "Build B", "CRA")),
+                                compareSlots = listOf("a", "b")
+                            ),
+                        onPick = { _, _ -> },
+                        onClear = { },
+                        onAdd = { added = true },
+                        onBack = { }
+                    )
+                }
+            }
+            onNodeWithText("Spell damage").assertExists()
+            onNodeWithText("Mastery score (engine)").assertExists()
+            onNodeWithText("Add build").performClick()
+            assertThat(added).isTrue()
+        }
+
+    @Test
+    fun `mixed classes replace the per-spell rows with a note`() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    CompareScreen(
+                        ui =
+                            UiState(
+                                savedBuilds = listOf(entry("a", "Cra", "CRA"), entry("b", "Eni", "ENUTROF")),
+                                compareSlots = listOf("a", "b")
+                            ),
+                        onPick = { _, _ -> },
+                        onClear = { },
+                        onAdd = { },
+                        onBack = { }
+                    )
+                }
+            }
+            assertThat(onAllNodesWithText("different classes", substring = true).fetchSemanticsNodes()).isNotEmpty()
+        }
+
+    @Test
+    fun `clicking a column clear fires onClear with that column index`() =
+        runComposeUiTest {
+            var cleared = -1
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    CompareScreen(
+                        // Three columns → the ✕ shows on each; clicking the first reports index 0.
+                        ui =
+                            UiState(
+                                savedBuilds = listOf(entry("a", "Build A", "CRA"), entry("b", "Build B", "CRA")),
+                                compareSlots = listOf("a", "b", "a")
+                            ),
+                        onPick = { _, _ -> },
+                        onClear = { cleared = it },
+                        onAdd = { },
+                        onBack = { }
+                    )
+                }
+            }
+            onAllNodesWithText("✕").onFirst().performClick()
+            assertThat(cleared).isEqualTo(0)
+        }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/CompareScreenUiTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/CompareScreenUiTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
 import me.chosante.common.Characteristic
 import me.chosante.common.Rarity
+import me.chosante.common.history.DamageScenarioSnapshot
 import me.chosante.common.history.HistoryEntry
 import me.chosante.common.history.RequestSnapshot
 import me.chosante.common.history.ResultSnapshot
@@ -33,6 +34,8 @@ class CompareScreenUiTest {
         id: String,
         name: String,
         clazz: String,
+        achieved: Map<Characteristic, Int> = mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 500),
+        rangeBand: String = "DISTANCE",
     ): HistoryEntry =
         HistoryEntry(
             id = id,
@@ -50,13 +53,14 @@ class CompareScreenUiTest {
                     stopAtMatch = false,
                     targets = emptyList(),
                     forcedItems = emptyList(),
-                    excludedItems = emptyList()
+                    excludedItems = emptyList(),
+                    scenario = DamageScenarioSnapshot(rangeBand = rangeBand)
                 ),
             result =
                 ResultSnapshot(
                     equipments = emptyList(),
                     skills = emptyMap(),
-                    achieved = mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 500),
+                    achieved = achieved,
                     match = 100.0,
                     optimal = true
                 )
@@ -106,6 +110,64 @@ class CompareScreenUiTest {
                 }
             }
             assertThat(onAllNodesWithText("different classes", substring = true).fetchSemanticsNodes()).isNotEmpty()
+        }
+
+    @Test
+    fun `damage group surfaces the damage-inflicted difference between builds`() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    CompareScreen(
+                        // One build carries a −20% Damage Inflicted (the most-masteries bait); the other 0. The
+                        // grouped Damage section must surface the row so the softer-hitting build is explainable.
+                        ui =
+                            UiState(
+                                savedBuilds =
+                                    listOf(
+                                        entry("a", "Soft", "CRA", achieved = mapOf(Characteristic.DAMAGE_INFLICTED to -20, Characteristic.MASTERY_DISTANCE to 300)),
+                                        entry("b", "Hard", "CRA", achieved = mapOf(Characteristic.MASTERY_DISTANCE to 300))
+                                    ),
+                                compareSlots = listOf("a", "b")
+                            ),
+                        onPick = { _, _ -> },
+                        onClear = { },
+                        onAdd = { },
+                        onBack = { }
+                    )
+                }
+            }
+            onNodeWithText("Damage").assertExists()
+            onNodeWithText("Damage Inflicted").assertExists()
+            onNodeWithText("Distance Mastery").assertExists()
+        }
+
+    @Test
+    fun `each column shows its own range band in the spell-damage header`() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    CompareScreen(
+                        ui =
+                            UiState(
+                                savedBuilds =
+                                    listOf(
+                                        entry("a", "Ranged", "CRA", rangeBand = "DISTANCE"),
+                                        entry("b", "Melee", "CRA", rangeBand = "MELEE")
+                                    ),
+                                compareSlots = listOf("a", "b")
+                            ),
+                        onPick = { _, _ -> },
+                        onClear = { },
+                        onAdd = { },
+                        onBack = { }
+                    )
+                }
+            }
+            // Each column credits its own band, so BOTH labels must render (column A = Distance, B = Melee).
+            // The builds carry no distance/melee MASTERY (achieved is fire only), so these strings can only
+            // come from the per-column band labels — proving the bands are per-column, not a single default.
+            assertThat(onAllNodesWithText("Distance", substring = true).fetchSemanticsNodes()).isNotEmpty()
+            assertThat(onAllNodesWithText("Melee", substring = true).fetchSemanticsNodes()).isNotEmpty()
         }
 
     @Test

--- a/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/history/HistoryMappingTest.kt
@@ -207,7 +207,7 @@ class HistoryMappingTest {
                 kind = SublimationKind.FLAT,
                 rawText = "+50 fire mastery"
             )
-        val passive = Passive(spellId = 6989, name = "Ligne", clazz = "FECA", gfxId = 6989, flatBuildStats = mapOf("RANGE" to 1.0))
+        val passive = Passive(spellId = 6989, name = I18nText("Ligne", "Ligne", "Ligne", "Ligne"), clazz = "FECA", gfxId = 6989, flatBuildStats = mapOf("RANGE" to 1.0))
         val build =
             BuildCombination(
                 equipments = listOf(amulet),
@@ -239,7 +239,7 @@ class HistoryMappingTest {
         assertThat(rebuilt.sublimations[rebuiltAmulet].orEmpty().map { it.stateId })
             .describedAs("the sublimation reattaches to its carrier item")
             .containsExactly(42)
-        assertThat(rebuilt.passives.map { it.name })
+        assertThat(rebuilt.passives.mapNotNull { it.name?.fr })
             .describedAs("the passive loadout survives the round-trip")
             .containsExactly("Ligne")
         assertThat(rebuilt.passives.single().flatStats).containsEntry(Characteristic.RANGE, 1)

--- a/gui-compose/src/test/kotlin/me/chosante/ui/paperdoll/SocketLayoutTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/paperdoll/SocketLayoutTest.kt
@@ -1,0 +1,71 @@
+package me.chosante.ui.paperdoll
+
+import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.I18nText
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.RuneColor
+import me.chosante.common.RuneType
+import me.chosante.common.Sublimation
+import me.chosante.common.SublimationKind
+import me.chosante.common.SublimationRarity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * [socketLayout] must surface EVERY socket the item has — the bug was it stopped at max(pattern, runes), so a
+ * 4-socket item with a 3-colour sublimation pattern + 1 rune only drew 3 sockets (the 4th free one vanished
+ * from both the card and the tooltip).
+ */
+class SocketLayoutTest {
+    private fun amulet(slots: Int) =
+        Equipment(
+            equipmentId = 1,
+            guiId = 1,
+            level = 215,
+            name = I18nText("Amu", "Amu", "Amu", "Amu"),
+            rarity = Rarity.EPIC,
+            itemType = ItemType.AMULET,
+            characteristics = emptyMap(),
+            maxShardSlots = slots
+        )
+
+    private val critRune =
+        RuneType(1, I18nText("crit", "crit", "crit", "crit"), RuneColor.GREEN, Characteristic.MASTERY_CRITICAL, listOf(4), 0)
+
+    // A NORMAL sublimation with a green/blue/green 3-socket pattern (codes 2,3,2).
+    private val influence =
+        Sublimation(
+            stateId = 10,
+            name = I18nText("Influence II", "Influence II", "Influence II", "Influence II"),
+            rarity = SublimationRarity.NORMAL,
+            slotColorPattern = listOf(2, 3, 2),
+            kind = SublimationKind.FLAT
+        )
+
+    @Test
+    fun `draws all four sockets including the free one beyond the pattern and runes`() {
+        val layout = socketLayout(amulet(slots = 4), runes = listOf(critRune), subs = listOf(influence))
+        assertThat(layout).describedAs("one cell per socket — the 4th (free) socket used to be dropped").hasSize(4)
+        // Pattern paints the first three sockets green/blue/green.
+        assertThat(layout.take(3).map { it.first }).containsExactly(RuneColor.GREEN, RuneColor.BLUE, RuneColor.GREEN)
+        // The 4th socket is free: empty (null colour, no rune).
+        assertThat(layout[3].first).describedAs("free socket has no colour").isNull()
+        assertThat(layout[3].second).describedAs("free socket has no rune").isNull()
+        // Exactly the one rune is placed (in the first socket).
+        assertThat(layout.count { it.second != null }).isEqualTo(1)
+    }
+
+    @Test
+    fun `an item with sockets but no runes or subs still shows all its sockets as empty`() {
+        val layout = socketLayout(amulet(slots = 3), runes = emptyList(), subs = emptyList())
+        assertThat(layout).hasSize(3)
+        assertThat(layout.all { it.first == null && it.second == null }).isTrue()
+    }
+
+    @Test
+    fun `a socketless item shows no sockets`() {
+        assertThat(socketLayout(amulet(slots = 0), runes = emptyList(), subs = emptyList())).isEmpty()
+    }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/spells/ClassSpellsPanelUiTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/spells/ClassSpellsPanelUiTest.kt
@@ -6,9 +6,18 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.v2.runComposeUiTest
 import me.chosante.autobuilder.domain.BuildCombination
+import me.chosante.autobuilder.domain.BuildSpellDamage
+import me.chosante.autobuilder.domain.DamageScenario
+import me.chosante.autobuilder.domain.RangeBand
+import me.chosante.autobuilder.domain.SpellCatalog
 import me.chosante.common.Character
 import me.chosante.common.CharacterClass
 import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.I18nText
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.SpellDamage
 import me.chosante.ui.i18n.Lang
 import me.chosante.ui.i18n.LocalLang
 import me.chosante.ui.state.UiState
@@ -57,4 +66,88 @@ class ClassSpellsPanelUiTest {
             }
             assertThat(onAllNodesWithText("base hit").fetchSemanticsNodes()).isNotEmpty()
         }
+
+    @Test
+    fun `surfaces the range band the damage credits`() =
+        runComposeUiTest {
+            val character = Character(CharacterClass.CRA, level = 110, minLevel = 0)
+            val build = BuildCombination(equipments = emptyList(), characterSkills = character.characterSkills)
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    ClassSpellsPanel(
+                        ui =
+                            UiState(
+                                clazz = CharacterClass.CRA,
+                                level = 110,
+                                build = build,
+                                scenario = DamageScenario(rangeBand = RangeBand.MELEE)
+                            )
+                    )
+                }
+            }
+            // The panel must say which secondary mastery it folds in, so the numbers are transparent.
+            assertThat(onAllNodesWithText("melee mastery", substring = true).fetchSemanticsNodes()).isNotEmpty()
+        }
+
+    @Test
+    fun `shows back-hit scenario variants under each spell`() =
+        runComposeUiTest {
+            val character = Character(CharacterClass.CRA, level = 110, minLevel = 0)
+            val build = BuildCombination(equipments = emptyList(), characterSkills = character.characterSkills)
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    ClassSpellsPanel(ui = UiState(clazz = CharacterClass.CRA, level = 110, build = build))
+                }
+            }
+            // Every damage-spell card adds a "back" variant line (×1.25 + rear), so many nodes carry "back" —
+            // far more than the lone CRA spell whose description happens to mention it.
+            assertThat(onAllNodesWithText("back", substring = true).fetchSemanticsNodes().size).isGreaterThanOrEqualTo(5)
+        }
+
+    @Test
+    fun `warns when the build carries both distance and melee mastery`() =
+        runComposeUiTest {
+            val character = Character(CharacterClass.CRA, level = 110, minLevel = 0)
+            val build = BuildCombination(equipments = emptyList(), characterSkills = character.characterSkills)
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    ClassSpellsPanel(
+                        ui =
+                            UiState(
+                                clazz = CharacterClass.CRA,
+                                level = 110,
+                                build = build,
+                                achieved = mapOf(Characteristic.MASTERY_DISTANCE to 300, Characteristic.MASTERY_MELEE to 300)
+                            )
+                    )
+                }
+            }
+            assertThat(onAllNodesWithText("a hit uses only one", substring = true).fetchSemanticsNodes()).isNotEmpty()
+        }
+
+    @Test
+    fun `crediting the range band raises a distance build's spell damage`() {
+        // Pure-function guard backing the UI fix: passing the build's range band must add its distance mastery,
+        // so a distance build's expected hit rises versus the old rangeBand=null call that silently dropped it.
+        val character = Character(CharacterClass.CRA, level = 110, minLevel = 0)
+        val distanceItem =
+            Equipment(
+                equipmentId = 1,
+                guiId = 1,
+                level = 1,
+                name = I18nText("Dist", "Dist", "Dist", "Dist"),
+                rarity = Rarity.COMMON,
+                itemType = ItemType.AMULET,
+                characteristics = mapOf(Characteristic.MASTERY_DISTANCE to 400)
+            )
+        val build = BuildCombination(equipments = listOf(distanceItem), characterSkills = character.characterSkills)
+        val spell = SpellCatalog.damageSpells(CharacterClass.CRA).first { it.hasDamage }
+
+        val withBand = BuildSpellDamage.expectedDamage(spell, build, character, rangeBand = SpellDamage.RangeBand.DISTANCE)
+        val withoutBand = BuildSpellDamage.expectedDamage(spell, build, character, rangeBand = null)
+
+        assertThat(withBand).isNotNull
+        assertThat(withoutBand).isNotNull
+        assertThat(withBand!!.expected).isGreaterThan(withoutBand!!.expected)
+    }
 }

--- a/gui-compose/src/test/kotlin/me/chosante/ui/spells/ClassSpellsPanelUiTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/spells/ClassSpellsPanelUiTest.kt
@@ -1,0 +1,60 @@
+package me.chosante.ui.spells
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import me.chosante.autobuilder.domain.BuildCombination
+import me.chosante.common.Character
+import me.chosante.common.CharacterClass
+import me.chosante.common.Characteristic
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import me.chosante.ui.state.UiState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Headless widget tests for the "Class spells" tab: renders the real [ClassSpellsPanel] composable (the
+ * same code the result-region tab shows) and asserts each class damage spell surfaces a hit number — the
+ * interactive path the PNG screenshot smoke-test can't exercise.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ClassSpellsPanelUiTest {
+    @Test
+    fun `shows a per-spell expected hit for the discovered build`() =
+        runComposeUiTest {
+            val character = Character(CharacterClass.CRA, level = 110, minLevel = 0)
+            val build = BuildCombination(equipments = emptyList(), characterSkills = character.characterSkills)
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    ClassSpellsPanel(
+                        ui =
+                            UiState(
+                                clazz = CharacterClass.CRA,
+                                level = 110,
+                                build = build,
+                                achieved = mapOf(Characteristic.CRITICAL_HIT to 20)
+                            )
+                    )
+                }
+            }
+            onNodeWithText("Class spells").assertExists()
+            // Every damage-spell card carries the "expected hit" label, so at least one must render.
+            assertThat(onAllNodesWithText("expected hit").fetchSemanticsNodes()).isNotEmpty()
+            // The "& passives" tab promises passives: the class's passive pool renders too.
+            onNodeWithText("Passives").assertExists()
+        }
+
+    @Test
+    fun `falls back to base hits when no build is loaded yet`() =
+        runComposeUiTest {
+            setContent {
+                CompositionLocalProvider(LocalLang provides Lang.EN) {
+                    ClassSpellsPanel(ui = UiState(clazz = CharacterClass.CRA, level = 110))
+                }
+            }
+            assertThat(onAllNodesWithText("base hit").fetchSemanticsNodes()).isNotEmpty()
+        }
+}

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelCompareSlotsTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelCompareSlotsTest.kt
@@ -1,0 +1,68 @@
+package me.chosante.ui.state
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import me.chosante.ui.history.HistoryRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Locks the compare-slot logic behind the N-build compare view: [BuildSearchModel.addCompareSlot] caps at
+ * four, [BuildSearchModel.setCompareSlot] is index-addressed, and [BuildSearchModel.clearCompareSlot]
+ * removes an extra column but only empties (never drops below) the two base columns. Unconfined dispatchers
+ * make the model's init run synchronously; the build finder is stubbed so OR-Tools never starts.
+ */
+class BuildSearchModelCompareSlotsTest {
+    @Test
+    fun `slots add up to four then cap, and clearing removes extras but keeps two`(
+        @TempDir tempDir: Path,
+    ) = runBlocking<Unit> {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val model =
+            BuildSearchModel(
+                scope = scope,
+                buildFinder = { emptyFlow() },
+                zenithBuilder = { "" },
+                mainDispatcher = Dispatchers.Unconfined,
+                ioDispatcher = Dispatchers.Unconfined,
+                libraryPreferences = LibraryPreferences(null),
+                historyRepository = HistoryRepository(baseDir = tempDir, ioDispatcher = Dispatchers.Unconfined)
+            )
+        try {
+            // startCompare seeds the first column + one empty slot.
+            model.startCompare("a")
+            assertThat(model.ui.compareSlots).containsExactly("a", null)
+
+            model.addCompareSlot()
+            model.addCompareSlot()
+            assertThat(model.ui.compareSlots).hasSize(4)
+            model.addCompareSlot() // capped at four
+            assertThat(model.ui.compareSlots).hasSize(4)
+
+            model.setCompareSlot(1, "b")
+            assertThat(model.ui.compareSlots[1]).isEqualTo("b")
+            model.setCompareSlot(9, "z") // out of range → ignored, no growth
+            assertThat(model.ui.compareSlots).hasSize(4)
+
+            // Above the floor of two, clearing removes the whole column…
+            model.clearCompareSlot(3)
+            assertThat(model.ui.compareSlots).hasSize(3)
+            model.clearCompareSlot(2)
+            assertThat(model.ui.compareSlots).hasSize(2)
+
+            // …at the floor, clearing empties the slot instead of dropping below two columns.
+            model.clearCompareSlot(0)
+            assertThat(model.ui.compareSlots).hasSize(2)
+            assertThat(model.ui.compareSlots[0]).isNull()
+            assertThat(model.ui.compareSlots[1]).isEqualTo("b")
+        } finally {
+            scope.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A batch of GUI + engine work, in two commits:

1. **`feat`** — per-spell damage view, up-to-4-build comparison, translated spell/passive/sublimation text (+ full socket display, default duration 120s).
2. **`fix`** — boss-mode max-damage streams instantly instead of hanging, and the max-damage optimum now *proves* with runes **and** sublimations enabled.

## Spell damage & comparison
- New **Class spells & passives** result tab: each damage spell with its element, AP/WP/range/cost, description, and **expected hit** — with an info "i" tooltip explaining the figure and a non-crit/crit split when crit < 100%. Follows the selected class.
- **Build comparison extended to 4 builds**, with a per-spell damage table (one row per spell, one column per build) plus the stat grid.

## Translations (EN/FR)
- Spell + passive **names and descriptions** now localized from the local client i18n bundles (`bdata-extractor` → new `spell-i18n.json`; `Passive.name/description` widened to `I18nText` via a tolerant serializer so previously-saved builds still deserialize).
- **Sublimation effect text** re-synthesized from the structured condition/effects/conversion data.

## Max-damage: boss fix + provability
- **Boss / multi-element search no longer hangs.** Each per-element probe now streams its best-so-far build (~5s to first result) instead of awaiting the whole batch behind the "Preparing OR-Tools model" overlay.
- **Proves the optimum with runes + sublimations on** (~80–110s; was intractable, no proof in 7 min at level 110). Mechanism: a sound **single-type-per-item rune fold** (a rune's value is uniform across an item's sockets, so one best type per item ≥ any mix → per-(item,stat) integer counts collapse to one boolean pick), plus `Σ runeCount = slots` full-fill and a socket-aware tightening of the scenario-mastery declared domain. Gated to max-damage; forced runes / secondary-mastery-cap sublimations keep the exact count model. See `docs/MAX_DAMAGE_PROVABLE_OPTIMUM.md` §8b.

## Also
- **Item cards/tooltips show every enchantment socket** (incl. empty free ones) — the layout used to stop at the sublimation pattern / rune count and hide free sockets.
- **Default search duration → 120s**, so max-damage reaches a proven optimum out of the box.

## Verification
- `ktlintCheck` + `:common-lib:test` + `:autobuilder:test` + `:gui-compose:test` all green.
- Provability locked by: a **fold == count optimum** equality test, a rune-aware **reachable-bounds soundness** panel, and a slow det-time **"proves with runes+sublimations"** test. The rune fold was also reviewed across 5 soundness dimensions (single-type optimality, gating, domain arithmetic, output consistency, regressions) with no confirmed issues.
- New GUI/unit tests: `SocketLayoutTest`, `CompareScreenUiTest`, `ClassSpellsPanelUiTest`, `BuildSearchModelCompareSlotsTest`, `SublimationTextTest`.

## Known follow-ups (tracked separately)
- Most-masteries mode is blind to global damage multipliers (it can pick a `−DAMAGE_INFLICTED` sublimation to inflate the raw mastery count while lowering real damage) — to be fixed.
- The comparison spell-damage uses a neutral yardstick that drops distance/melee mastery; should credit each build's range band and surface more damage-relevant stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)