### PR TITLE
perf: prune provably-dominated items per slot (all solver modes) (+ progress throttle, precision tests)

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -79,6 +79,14 @@ object WakfuBuildSolver {
     // then the `× resFactor` product is divided by [FINAL_DOWNSCALE] so the value — and then the
     // power-6 constraint penalty (× MAX_PENALTY_MULTIPLIER) — stays under Long.MAX/2.
     private const val MAX_ROTATION_AP = 20L
+
+    // Min wall-clock gap between intermediate best-so-far emissions. Each emission re-runs the heavy
+    // solutionToBuild + scoreFor (a knapsack rotation in max-damage) ON the native solve thread, stealing
+    // cycles from search/proof. Intermediate snapshots are pure progress — re-rendering the in-flight build
+    // more than ~twice a second has no UX value — so coalescing to one per 500ms returns those cycles to the
+    // solver without affecting the result: the FINAL build is recomputed unconditionally after solve() and
+    // delivered via a guaranteed (suspending) send, so throttling intermediates can never drop or reorder it.
+    private const val INTERMEDIATE_EMIT_THROTTLE_MS = 500L
     private const val PER_TURN_THROUGHPUT_MAX = 60_000L
     private const val RES_FACTOR_MIN = 10L // res capped at +90% → factor ≥ 10
     private const val RES_FACTOR_MAX = 200L // weakness floored at −100% → factor ≤ 200
@@ -386,6 +394,8 @@ object WakfuBuildSolver {
         // Max-damage only: every tracked objective-chain var with its name and reachable [LongRange], for
         // the soundness test (empty for the other modes). See [DomainTracker] / [maxDamageVarBoundsForTest].
         val maxDamageTracked: List<Triple<IntVar, String, LongRange>> = emptyList(),
+        // Precision only: same, for [precisionVarBoundsForTest] (empty for the other modes).
+        val precisionTracked: List<Triple<IntVar, String, LongRange>> = emptyList(),
     )
 
     /**
@@ -447,13 +457,22 @@ object WakfuBuildSolver {
         model.addBuildValidityConstraints(allEquips, equipVars)
 
         var maxDamageTracked: List<Triple<IntVar, String, LongRange>> = emptyList()
+        var precisionTracked: List<Triple<IntVar, String, LongRange>> = emptyList()
         val objective =
             when (params.scoreComputationMode) {
                 ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT ->
                     model.buildMostMasteriesObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
 
-                ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT ->
-                    model.buildPrecisionObjective(params, allEquips, equipVars, skillVars, runeModel, subModel)
+                ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT -> {
+                    // Declare the precision stat chain on its reachable domains (like max-damage), instead of
+                    // the loose 10M guard: every reach is a sound superset of the attainable value (locked by
+                    // [precisionVarBoundsForTest]), so the optimum is unchanged while presolve / the LP
+                    // relaxation work on tight bounds. tightDomains=false reproduces the loose reference build.
+                    val statBuilder = StatBuilder(model, params, allEquips, equipVars, skillVars, runeModel, subModel, tight = tightDomains)
+                    val obj = model.buildPrecisionObjective(params, statBuilder)
+                    precisionTracked = statBuilder.tracker.tracked()
+                    obj
+                }
 
                 ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE -> {
                     val statBuilder = StatBuilder(model, params, allEquips, equipVars, skillVars, runeModel, subModel, tight = tightDomains)
@@ -464,7 +483,7 @@ object WakfuBuildSolver {
             }
         model.maximize(objective)
 
-        return BuiltModel(model, objective, allEquips, equipVars, skillVars, runeModel, subModel, maxDamageTracked)
+        return BuiltModel(model, objective, allEquips, equipVars, skillVars, runeModel, subModel, maxDamageTracked, precisionTracked)
     }
 
     /** Configures a deterministic, machine-reproducible max-damage solver (full presolve + level-2 linearization). */
@@ -563,6 +582,35 @@ object WakfuBuildSolver {
             "soundness probe needs a solution, got $status"
         }
         return built.maxDamageTracked.map { (v, name, range) ->
+            MaxDamageVarBound(name, solver.value(v), range.first, range.last)
+        }
+    }
+
+    /**
+     * Test-only soundness probe for the **precision** reachable domains — the precision analogue of
+     * [maxDamageVarBoundsForTest]. Builds the precision model with loose guard domains (so the solver freely
+     * pushes every stat-chain var as high as a real build allows) while still recording each var's propagated
+     * reachable `[lo, hi]`, solves, and returns each tracked var's solved value vs that range. A value outside
+     * its range means the interval arithmetic UNDER-estimated — i.e. the production (tight) build would have
+     * declared a too-small domain and silently cut the optimum.
+     */
+    internal fun precisionVarBoundsForTest(
+        params: WakfuBestBuildParams,
+        equipmentsByItemType: Map<ItemType, List<Equipment>>,
+        tuning: SolverTuning,
+        runes: List<RuneType> = emptyList(),
+        sublimations: List<Sublimation> = emptyList(),
+    ): List<MaxDamageVarBound> {
+        require(params.scoreComputationMode == ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT) {
+            "precisionVarBoundsForTest needs precision params, got ${params.scoreComputationMode}"
+        }
+        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains = false)
+        val solver = deterministicMaxDamageSolver(tuning)
+        val status = solver.solve(built.model)
+        require(status == com.google.ortools.sat.CpSolverStatus.OPTIMAL || status == com.google.ortools.sat.CpSolverStatus.FEASIBLE) {
+            "soundness probe needs a solution, got $status"
+        }
+        return built.precisionTracked.map { (v, name, range) ->
             MaxDamageVarBound(name, solver.value(v), range.first, range.last)
         }
     }
@@ -1288,13 +1336,8 @@ object WakfuBuildSolver {
 
     private fun CpModel.buildPrecisionObjective(
         params: WakfuBestBuildParams,
-        allEquips: List<Equipment>,
-        equipVars: Map<Equipment, IntVar>,
-        skillVars: Map<SkillCharacteristic, IntVar>,
-        runeModel: RuneModel,
-        subModel: SublimationModel,
+        statBuilder: StatBuilder,
     ): IntVar {
-        val statBuilder = StatBuilder(this, params, allEquips, equipVars, skillVars, runeModel, subModel)
         statBuilder.applyOutOfCombatCaps()
         return statBuilder.precisionScore(params.targetStats)
     }
@@ -1410,19 +1453,30 @@ object WakfuBuildSolver {
 
         val cb =
             object : CpSolverSolutionCallback() {
+                private var lastEmitMs = 0L
+
                 override fun onSolutionCallback() {
                     // The native solve blocks the IO thread, so coroutine cancellation can't interrupt
                     // it directly; stopping the search here (next time a solution is found) is the
-                    // CP-SAT idiom that lets the GUI's cancel actually end the work.
+                    // CP-SAT idiom that lets the GUI's cancel actually end the work. Kept BEFORE the
+                    // throttle so cancel latency is unchanged.
                     if (!scope.isActive) {
                         stopSearch()
                         return
                     }
 
+                    // Throttle the heavy rescore: building + scoring every improving solution on the solve
+                    // thread starves the search. Snapshots are best-effort progress (trySend, consumers keep
+                    // only the last), so skipping some is invisible — the proven final build is emitted
+                    // separately and unconditionally below. The first solution always passes (lastEmitMs = 0).
+                    val now = System.currentTimeMillis()
+                    if (now - lastEmitMs < INTERMEDIATE_EMIT_THROTTLE_MS) return
+                    lastEmitMs = now
+
                     val combination = solutionToBuild(params, allEquips, equipVars, skillVars, runeModel, subModel) { value(it) }
                     val actualScore = scoreFor(params, combination)
 
-                    val progress = ((System.currentTimeMillis() - startTime).toDouble() / params.searchDuration.inWholeMilliseconds.toDouble() * 100).toInt()
+                    val progress = ((now - startTime).toDouble() / params.searchDuration.inWholeMilliseconds.toDouble() * 100).toInt()
                     scope.trySend(GeneticAlgorithmResult(combination, actualScore, progress.coerceAtMost(100)))
                 }
             }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -522,6 +522,9 @@ object WakfuBuildSolver {
         // Test seam: force the per-stat rune COUNT model even where the single-type fold would apply, so a
         // test can assert the fold preserves the optimum (fold == count optimum on a rune pool).
         forceRuneCountModel: Boolean = false,
+        // Test seam: force the rune socket cap back to `≤` (disable exact fill), so a test can assert
+        // most-masteries exact fill preserves the ≤-model optimum (exact-fill optimum == ≤ optimum).
+        forceRuneLeq: Boolean = false,
         // Production path only: drop per-slot dominated items ([filterDominatedPool]) — provably optimum-
         // preserving in all three (monotone) modes. Off by default so the deterministic test path sees the full
         // pool unchanged; the production [optimize] passes true and the soundness lock toggles it.
@@ -541,7 +544,10 @@ object WakfuBuildSolver {
         // Sound per-slot domination: drop items provably beaten in their own slot (all three modes are monotone;
         // see [dominationPinnedStats]). Skipped for forced items / forced conditional subs and for forceFullPool
         // (the full reference). Removes no optimal build, so the proven optimum is identical — only the model shrinks.
-        val dominationPins = if (applyDomination && !forceFullPool) dominationPinnedStats(params, sublimations) else null
+        // Stats a dangerous (≤/exact/parity) conditional sub reads — non-monotone, so domination pins them AND
+        // most-masteries exact socket fill must avoid them (null = un-analyzable / forced ⇒ both stay conservative).
+        val subPinnedStats = dominationPinnedStats(params, sublimations)
+        val dominationPins = if (applyDomination && !forceFullPool) subPinnedStats else null
         val pool = if (dominationPins != null) filterDominatedPool(basePool, dominationPins) else basePool
         val allEquips = orderEquipments(pool)
         val equipVars = model.createEquipmentVariables(allEquips)
@@ -560,7 +566,7 @@ object WakfuBuildSolver {
                     (sub.condition?.value ?: 0) > 0
             }
         val allowRuneFold = !forceRuneCountModel && !secondaryCapMixSubInPlay
-        val runeModel = model.createRuneModel(params, allEquips, equipVars, runes, allowRuneFold)
+        val runeModel = model.createRuneModel(params, allEquips, equipVars, runes, allowRuneFold, subPinnedStats, forceRuneLeq)
         val subModel = model.createSublimationModel(params, allEquips, equipVars, sublimations)
         // A normal sublimation does NOT reserve rune sockets. Golden runes (colour-agnostic) form its ordered
         // colour pattern AND still carry their stat — doubling where the item favours that colour — so a carrier
@@ -651,8 +657,19 @@ object WakfuBuildSolver {
         sublimations: List<Sublimation> = emptyList(),
         forceRuneCountModel: Boolean = false,
         applyDomination: Boolean = false,
+        forceRuneLeq: Boolean = false,
     ): MaxDamageSolveOutcome {
-        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains, forceRuneCountModel = forceRuneCountModel, applyDomination = applyDomination)
+        val built =
+            buildModel(
+                params,
+                equipmentsByItemType,
+                runes,
+                sublimations,
+                tightDomains,
+                forceRuneCountModel = forceRuneCountModel,
+                applyDomination = applyDomination,
+                forceRuneLeq = forceRuneLeq
+            )
         val solver = deterministicMaxDamageSolver(tuning)
         val status = solver.solve(built.model)
         val hasSolution =
@@ -841,6 +858,11 @@ object WakfuBuildSolver {
         equipVars: Map<Equipment, IntVar>,
         runes: List<RuneType>,
         allowRuneFold: Boolean,
+        // Stats a dangerous (≤/exact/parity) conditional sub reads (null = un-analyzable / forced). A modeled
+        // rune feeding one of these makes most-masteries exact-fill unsound — see [fillSockets] below.
+        subPinnedStats: Set<Characteristic>?,
+        // Test seam: force the rune cap back to `≤` (no exact fill), for the exact-fill==≤ soundness lock.
+        forceRuneLeq: Boolean,
     ): RuneModel {
         if (runes.isEmpty()) return RuneModel.EMPTY
         val runeById = runes.associateBy { it.id }
@@ -876,19 +898,32 @@ object WakfuBuildSolver {
             (if (params.useRunes) relevantRuneStats(params, runeByCharacteristic.keys) else emptySet()) + forcedRuneStats
         if (runeStats.isEmpty()) return RuneModel.EMPTY
 
-        // Max-damage can fill every socket "for free": the generic elemental-mastery rune is NOT a
-        // secondary mastery and only ever raises the damage objective, so it backfills any socket without
-        // tripping a secondary-mastery / AP / crit / range "at most" sub condition, and overshooting a
-        // required target is never penalised (the max-damage score caps actual at target — coerceAtMost in
-        // FindMaxDamageScoring.requiredConstraintPenaltyFactor). So the proven optimum ALWAYS fills its
-        // sockets (an empty one could take one more elemental rune for strictly more mastery), and pinning
-        // Σ runeCount = slots·selected (instead of ≤) removes every provably-suboptimal "underfill"
-        // assignment from the integer search WITHOUT changing the optimum — a pure search-space cut that
-        // helps the proof close. Gated on a real elemental filler being modelled; the other modes keep ≤
-        // (there a rune feeds a *requested exact* stat where full fill is not free).
-        val fillSocketsForMaxDamage =
+        // Exact socket fill — pin `Σ runeCount = slots·selected` (instead of `≤`) so the proven optimum never
+        // leaves a socket empty. It removes every never-optimal "underfill" assignment from the integer search
+        // (a pure search-space cut that helps the proof close) AND fixes the "fewer than max runes" builds.
+        //  - MAX-DAMAGE: the generic elemental-mastery rune is NOT a secondary mastery and only ever raises the
+        //    damage objective, so it backfills any socket without tripping a secondary/AP/crit/range "at most" sub
+        //    condition, and overshooting a required target is unpenalised (the score caps actual at target —
+        //    coerceAtMost in FindMaxDamageScoring). So filling is always free. (Unchanged.)
+        //  - MOST-MASTERIES: the objective is monotone non-decreasing in every modeled rune stat — masteries,
+        //    shortfall-only required targets, the DI fold, the min-over-elements — so underfill is never optimal.
+        //    The only risk is a dangerous (≤/exact/parity) conditional sub: forcing fill could push the stat it
+        //    reads over the cap and flip the sub off. But the per-stat distribution is free (mixing preserved),
+        //    so as long as ONE modeled rune stat is *not* read by a dangerous condition, every socket can be
+        //    filled with that "safe filler" rune (HP, elemental, …) — monotone-beneficial and breaks no sub — so
+        //    exact-fill keeps the optimum. It is unsound only when EVERY modeled rune stat is dangerous (a
+        //    self-contradictory request: the sole rune-relevant stat is itself the capped one). [subPinnedStats]
+        //    is the dangerous set (null ⇒ un-analyzable/forced ⇒ stay safe with `≤`). Locked sound by an
+        //    adversarial soundness review + the exact-fill==≤ optimum test. The single-type FOLD below stays
+        //    max-damage-only, so most-masteries keeps the integer-count model (intra-item rune MIXING preserved).
+        val maxDamageFreeFill =
             params.scoreComputationMode == ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE &&
                 Characteristic.MASTERY_ELEMENTARY in runeStats
+        val mostMasteriesExactFill =
+            params.scoreComputationMode == ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT &&
+                subPinnedStats != null &&
+                runeStats.any { it !in subPinnedStats }
+        val fillSockets = !forceRuneLeq && (maxDamageFreeFill || mostMasteriesExactFill)
         // Single-type-per-item rune FOLD (max-damage, no forced runes, no secondary-cap>0 sub in play —
         // [allowRuneFold]): because a rune's value is uniform across an item's sockets (doubling is per item
         // SLOT, not per socket — see RuneType.valueOn), filling an item entirely with its single best-value
@@ -899,7 +934,7 @@ object WakfuBuildSolver {
         // The solver still chooses the type per item (build-dependent: mastery vs crit-mastery, elemental vs a
         // secondary for the secondary=0 subs) and items still differ — only the never-optimal intra-item mix is
         // dropped. Gated to where it is provably sound; forced runes / secondary-cap>0 subs keep the count model.
-        val singleTypePerItem = allowRuneFold && fillSocketsForMaxDamage && forcedRuneStats.isEmpty()
+        val singleTypePerItem = allowRuneFold && maxDamageFreeFill && forcedRuneStats.isEmpty()
         val runeVars = mutableMapOf<Equipment, Map<Characteristic, IntVar>>()
         for (equip in allEquips) {
             val slots = equip.maxShardSlots
@@ -918,7 +953,7 @@ object WakfuBuildSolver {
                 val capExpr = LinearExpr.newBuilder()
                 perStat.values.forEach { capExpr.addTerm(it, 1L) }
                 capExpr.addTerm(equipVars.getValue(equip), -slots.toLong())
-                if (fillSocketsForMaxDamage) addEquality(capExpr.build(), 0L) else addLessOrEqual(capExpr.build(), 0L)
+                if (fillSockets) addEquality(capExpr.build(), 0L) else addLessOrEqual(capExpr.build(), 0L)
                 runeVars[equip] = perStat
             }
         }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -28,6 +28,7 @@ import me.chosante.common.ItemType
 import me.chosante.common.Passive
 import me.chosante.common.Rarity
 import me.chosante.common.RuneType
+import me.chosante.common.SECONDARY_MASTERY_CHARACTERISTICS
 import me.chosante.common.Sublimation
 import me.chosante.common.SublimationConditionType
 import me.chosante.common.SublimationKind
@@ -366,7 +367,9 @@ object WakfuBuildSolver {
     ): Flow<GeneticAlgorithmResult<BuildCombination>> =
         callbackFlow {
             withContext(Dispatchers.IO) {
-                val built = buildModel(params, equipmentsByItemType, runes, sublimations)
+                // Domination runs only on the production (wall-clock) path: tuning == null. The deterministic
+                // test path keeps the full pool so existing tests are untouched; the soundness lock toggles it.
+                val built = buildModel(params, equipmentsByItemType, runes, sublimations, applyDomination = tuning == null)
                 executeSolverAndEmitResults(
                     built.model,
                     params,
@@ -399,6 +402,108 @@ object WakfuBuildSolver {
     )
 
     /**
+     * The characteristics to PIN to equality in the domination relation for these params — or `null` to not
+     * apply the pre-filter at all. An empty set means full domination (no condition to respect).
+     *
+     * Applies to **all three modes** — each maximizes an objective that is **monotone non-decreasing in every
+     * characteristic** (more of any stat is never worse), so an item beaten on every stat is never needed:
+     *  - max-damage: `throughput × perHit`, both ≥ 0;
+     *  - precision: a sum of `min(actual, target)` terms — capped at the target, so overshoot is *neutral*, not
+     *    penalized (my earlier "penalizes overshoot" claim was wrong);
+     *  - most-masteries: `masteryScore × penaltyMultiplier`, the penalty CAPPED at the target (shortfall only)
+     *    with overshoot rewarded by a tie-breaker. The product is monotone *where it matters*: the optimum
+     *    always has `masteryScore ≥ 0` (the empty build already scores objective ≥ 0, so a negative-mastery
+     *    build is strictly worse), and for `masteryScore ≥ 0` the dominance swap `(m+Δm)(μ+Δμ) ≥ mμ` holds.
+     *
+     * A **conditional** sublimation makes some stats non-monotone: a build may keep a weaker (e.g. low-secondary)
+     * item *specifically* to satisfy a cap like `SECONDARY_MASTERIES_AT_MOST`, which domination would remove.
+     * Rather than gate off, we pin **every stat a dangerous (≤ / exact / parity) condition reads** to equality,
+     * so the swap can't move that stat's build sum and no sub can flip — while domination still fires across
+     * every stat no condition touches. A `≥`-type condition stays satisfied under a `≥` swap on a beneficial
+     * choosable sub, so it needs no pin. Returns `null` (gate off) for a forced item / rune-carrier, a forced
+     * conditional sub (unknown effect direction), or a condition that compares two build stats / is categorical
+     * and can't be reduced to a stat pin.
+     */
+    private fun dominationPinnedStats(
+        params: WakfuBestBuildParams,
+        sublimations: List<Sublimation>,
+    ): Set<Characteristic>? {
+        if (params.forcedItems.isNotEmpty() || params.forcedRunesByItem.isNotEmpty()) return null
+        val forcedNames = params.forcedSublimations.map { it.lowercase() }.toSet()
+        val pinned = mutableSetOf<Characteristic>()
+        for (sub in sublimations) {
+            val choosable = sub.solverChoosable && params.useSublimations
+            val forced = sub.name.fr.lowercase() in forcedNames || sub.name.en.lowercase() in forcedNames
+            if (!choosable && !forced) continue
+            val condition = sub.condition ?: continue
+            if (forced) return null // forced conditional sub: unknown effect direction ⇒ can't pin soundly
+            when (condition.type) {
+                SublimationConditionType.AP_AT_MOST, SublimationConditionType.AP_EXACT, SublimationConditionType.AP_ODD ->
+                    pinned += Characteristic.ACTION_POINT
+                SublimationConditionType.CRIT_AT_MOST -> pinned += Characteristic.CRITICAL_HIT
+                SublimationConditionType.RANGE_AT_MOST, SublimationConditionType.RANGE_EXACT -> pinned += Characteristic.RANGE
+                SublimationConditionType.DODGE_LT_PCT_OF_LEVEL -> pinned += Characteristic.DODGE
+                SublimationConditionType.SECONDARY_MASTERIES_AT_MOST -> pinned += SECONDARY_MASTERY_CHARACTERISTICS
+                // ≥-type: a ≥ swap on a beneficial choosable sub keeps the condition satisfied ⇒ no pin needed.
+                SublimationConditionType.AP_AT_LEAST, SublimationConditionType.CRIT_AT_LEAST,
+                SublimationConditionType.BLOCK_AT_LEAST, SublimationConditionType.RANGE_AT_LEAST,
+                -> Unit
+                // Compares two build stats / categorical / unknown ⇒ can't reduce to a stat pin ⇒ gate off.
+                SublimationConditionType.HIGHEST_ELEM_MASTERY_GT_REAR, SublimationConditionType.HIGHEST_ELEM_MASTERY_GT_HEALING,
+                SublimationConditionType.WEAPON_TYPE_EQUIPPED, SublimationConditionType.OTHER,
+                -> return null
+            }
+        }
+        return pinned
+    }
+
+    /** Apply [dominatedWithin] per slot — RING keeps 2 (two are co-equippable, distinct); every other slot 1. */
+    private fun filterDominatedPool(
+        pool: Map<ItemType, List<Equipment>>,
+        pinned: Set<Characteristic>,
+    ): Map<ItemType, List<Equipment>> = pool.mapValues { (slot, items) -> dominatedWithin(items, if (slot == ItemType.RING) 2 else 1, pinned) }
+
+    /**
+     * Keep only items NOT dominated by ≥[k] others in the same slot (k = slot capacity). B is removable iff
+     * ≥k items A satisfy `A ≽ B`, with a deterministic tie-break (A strictly better, OR equal and lower id ⇒
+     * exactly one of a set of identical items is kept). RING needs k=2 because one dominator may already be
+     * worn in the other ring slot — see the proof in `docs/SOLVER_PERFORMANCE.md`.
+     *
+     * `A ≽ B` (A can replace B in any build of a monotone mode with no loss, no extra scarce-rarity budget,
+     * and no conditional-sublimation flip):
+     *  - `A.maxShardSlots ≥ B` — ≥ rune capacity AND sub-carrier eligibility (sockets are a colour-agnostic
+     *    count in this model), so any rune/sub on B fits A;
+     *  - **(A epic ⇒ B epic) ∧ (A relic ⇒ B relic)** — the swap never RAISES the build's ≤1-epic / ≤1-relic
+     *    count, so an EPIC never dominates a non-epic (keeping the non-epic may be what frees the epic budget
+     *    for a stronger epic elsewhere — the one case a naive stats-only filter gets wrong);
+     *  - `A.characteristics ≥ B` on EVERY characteristic, AND **`A == B` on every [pinned] stat** — so every
+     *    monotone objective term / ≥-type condition is still ≥, and every pinned ≤/exact/parity condition keeps
+     *    its exact truth value (its build sum is unchanged by the swap).
+     */
+    private fun dominatedWithin(
+        items: List<Equipment>,
+        k: Int,
+        pinned: Set<Characteristic>,
+    ): List<Equipment> =
+        items.filter { b ->
+            items.count { a -> a !== b && a.dominates(b, pinned) && (!b.dominates(a, pinned) || a.equipmentId < b.equipmentId) } < k
+        }
+
+    private fun Equipment.dominates(
+        other: Equipment,
+        pinned: Set<Characteristic>,
+    ): Boolean {
+        if (maxShardSlots < other.maxShardSlots) return false
+        if (rarity == Rarity.EPIC && other.rarity != Rarity.EPIC) return false
+        if (rarity == Rarity.RELIC && other.rarity != Rarity.RELIC) return false
+        return (characteristics.keys + other.characteristics.keys).all { c ->
+            val mine = characteristics.getOrDefault(c, 0)
+            val theirs = other.characteristics.getOrDefault(c, 0)
+            if (c in pinned) mine == theirs else mine >= theirs
+        }
+    }
+
+    /**
      * Assembles the full CP-SAT model — item / skill / rune / sublimation vars, validity constraints, and the
      * mode's objective — and calls [CpModel.maximize]. Extracted from [optimize] so the test-only
      * [maxDamageObjectiveValueForTest] builds a byte-identical model (no drift between the production solve and
@@ -417,18 +522,27 @@ object WakfuBuildSolver {
         // Test seam: force the per-stat rune COUNT model even where the single-type fold would apply, so a
         // test can assert the fold preserves the optimum (fold == count optimum on a rune pool).
         forceRuneCountModel: Boolean = false,
+        // Production path only: drop per-slot dominated items ([filterDominatedPool]) — provably optimum-
+        // preserving in all three (monotone) modes. Off by default so the deterministic test path sees the full
+        // pool unchanged; the production [optimize] passes true and the soundness lock toggles it.
+        applyDomination: Boolean = false,
     ): BuiltModel {
         val model = CpModel()
 
         // Full pool gives the provable *global* optimum and stays tractable for most queries.
         // Only multi-element mastery/resistance targets activate the heavy random-element modelling that
         // explodes on the full late-game pool, so we prefilter exactly (and only) those cases.
-        val pool =
+        val basePool =
             if (!forceFullPool && needsItemPrefilter(params.targetStats)) {
                 prefilterRelevantEquipments(equipmentsByItemType, params)
             } else {
                 equipmentsByItemType
             }
+        // Sound per-slot domination: drop items provably beaten in their own slot (all three modes are monotone;
+        // see [dominationPinnedStats]). Skipped for forced items / forced conditional subs and for forceFullPool
+        // (the full reference). Removes no optimal build, so the proven optimum is identical — only the model shrinks.
+        val dominationPins = if (applyDomination && !forceFullPool) dominationPinnedStats(params, sublimations) else null
+        val pool = if (dominationPins != null) filterDominatedPool(basePool, dominationPins) else basePool
         val allEquips = orderEquipments(pool)
         val equipVars = model.createEquipmentVariables(allEquips)
         val skillVars = model.createSkillVariables(params.character.characterSkills)
@@ -536,8 +650,9 @@ object WakfuBuildSolver {
         runes: List<RuneType> = emptyList(),
         sublimations: List<Sublimation> = emptyList(),
         forceRuneCountModel: Boolean = false,
+        applyDomination: Boolean = false,
     ): MaxDamageSolveOutcome {
-        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains, forceRuneCountModel = forceRuneCountModel)
+        val built = buildModel(params, equipmentsByItemType, runes, sublimations, tightDomains, forceRuneCountModel = forceRuneCountModel, applyDomination = applyDomination)
         val solver = deterministicMaxDamageSolver(tuning)
         val status = solver.solve(built.model)
         val hasSolution =
@@ -549,6 +664,12 @@ object WakfuBuildSolver {
             hasSolution = hasSolution
         )
     }
+
+    /** Test seam: the per-slot domination pre-filter applied to [pool], pinning [pinned] to equality (empty = full). */
+    internal fun filterDominatedPoolForTest(
+        pool: Map<ItemType, List<Equipment>>,
+        pinned: Set<Characteristic> = emptySet(),
+    ): Map<ItemType, List<Equipment>> = filterDominatedPool(pool, pinned)
 
     /** A tracked objective-chain var's solved value against its declared reachable `[lo, hi]`. */
     internal data class MaxDamageVarBound(

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2757,6 +2757,93 @@ class WakfuBuildSolverTest {
     }
 
     @Test
+    fun `most-masteries exact fill stays sound with a secondary-cap sublimation in play`() {
+        // The exact scenario the gate is about: a choosable SECONDARY_MASTERIES_AT_MOST=0 sub puts the secondary
+        // masteries in subPinnedStats (a ≤ condition forcing more is dangerous). Exact-fill is STILL sound here
+        // because the per-stat distribution is free — every socket can take the elemental (safe filler) rune
+        // instead of a secondary rune, so the cap is never pushed over. So exact-fill fires (a safe filler exists)
+        // and must still equal the ≤ optimum. (It is gated off only if the SOLE modeled rune were a capped
+        // secondary — a self-contradictory request.)
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val pool = soundnessSocketedPool()
+        val runes = soundnessRunes()
+        val secondaryCapSub =
+            sublimation(
+                9001,
+                SublimationRarity.EPIC,
+                SublimationKind.STATIC_CONDITIONAL,
+                "ElementalUnderSecondaryCap",
+                effects = listOf(SublimationEffect(Characteristic.MASTERY_ELEMENTARY, 50)),
+                condition = SublimationCondition(SublimationConditionType.SECONDARY_MASTERIES_AT_MOST, 0)
+            )
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, 110, 0, CharacterSkills(110)),
+                targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_ELEMENTARY, 9999), TargetStat(Characteristic.ACTION_POINT, 11))),
+                searchDuration = 60.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                useRunes = true,
+                useSublimations = true
+            )
+        val subs = listOf(secondaryCapSub)
+        val exact = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes, sublimations = subs)
+        val leq = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes, sublimations = subs, forceRuneLeq = true)
+        assertThat(exact.isOptimal && leq.isOptimal).describedAs("both prove OPTIMAL").isTrue()
+        assertThat(exact.objective)
+            .describedAs("exact fill stays sound with a secondary-cap sub — elemental (safe filler) runes fill sockets without breaking the cap")
+            .isEqualTo(leq.objective)
+    }
+
+    @Test
+    fun `most-masteries exact fill proves the runes-on optimum fast on the full level-110 pool`() {
+        // Regression guard for the exact-fill win — NOT @slow on purpose: it proves in ~1.7s and CI (`test`)
+        // excludes @slow, so a @slow guard would never actually run. The ≤ model could NOT prove this case
+        // (full lvl-110 pool, runes ON, distance + AP/MP/Range) — it ran ~656s and returned FEASIBLE because
+        // every socket was an independent 0..slots underfill choice. Exact-fill pins Σ=slots so the single
+        // relevant rune (distance) is forced full, collapsing the search to a fast proof. If exact-fill ever
+        // stops firing for this shape, the proof can't close within the bounded det-time and this fails (in
+        // bounded time, not a hang). Single worker (the low-thread target) ⇒ deterministic; det-time is
+        // hardware-independent so the budget is reproducible on CI.
+        val tuning = WakfuBuildSolver.SolverTuning(numSearchWorkers = 1, randomSeed = 1, maxDeterministicTime = 40.0)
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, 110, 0, CharacterSkills(110)),
+                targetStats =
+                    TargetStats(
+                        listOf(
+                            TargetStat(Characteristic.MASTERY_DISTANCE, 9999),
+                            TargetStat(Characteristic.ACTION_POINT, 12),
+                            TargetStat(Characteristic.MOVEMENT_POINT, 4),
+                            TargetStat(Characteristic.RANGE, 4)
+                        )
+                    ),
+                searchDuration = 60.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                useRunes = true,
+                useSublimations = false
+            )
+        val result =
+            WakfuBuildSolver.maxDamageSolveForTest(
+                params,
+                fullEpicPool(110),
+                tuning,
+                tightDomains = true,
+                runes = WakfuBestBuildFinderAlgorithm.runes
+            )
+        assertThat(result.isOptimal)
+            .describedAs("exact socket fill must prove the runes-on optimum (the ≤ model could not — ~656s FEASIBLE)")
+            .isTrue()
+    }
+
+    @Test
     fun `domination relation respects rarity budget, sockets and ring multiplicity`() {
         val pool =
             listOf(
@@ -2971,6 +3058,45 @@ class WakfuBuildSolverTest {
             assertThat(fold.objective)
                 .describedAs("$name: the single-type rune fold must not change the optimum (fold == count)")
                 .isEqualTo(count.objective)
+        }
+    }
+
+    @Test
+    fun `most-masteries exact socket fill preserves the leq-model optimum`() {
+        // Exact fill pins Σ runeCount = slots (no empty sockets) instead of ≤. The ≤ model allows underfill — a
+        // SUPERSET of feasible rune assignments — so its optimum is an upper bound on exact-fill's. Because the
+        // most-masteries objective is monotone non-decreasing in every modeled rune stat (masteries, shortfall-
+        // only required targets, the DI fold, the min-over-elements), underfill is never optimal, so the two must
+        // be EQUAL: exact-fill is a pure search-space cut. forceRuneLeq=true builds the ≤ reference. If exact-fill
+        // ever cut the optimum, exact < leq here. Spans a specific-mastery and a generic-elemental request.
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val pool = soundnessSocketedPool()
+        val runes = soundnessRunes()
+
+        fun mm(targets: List<TargetStat>) =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, 110, 0, CharacterSkills(110)),
+                targetStats = TargetStats(targets),
+                searchDuration = 60.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                useRunes = true,
+                useSublimations = false
+            )
+        listOf(
+            "distance-ap" to mm(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 9999), TargetStat(Characteristic.ACTION_POINT, 12))),
+            "generic-elem-ap" to mm(listOf(TargetStat(Characteristic.MASTERY_ELEMENTARY, 9999), TargetStat(Characteristic.ACTION_POINT, 11)))
+        ).forEach { (name, params) ->
+            val exact = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes)
+            val leq = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, runes = runes, forceRuneLeq = true)
+            assertThat(exact.isOptimal).describedAs("$name: the exact-fill model proves OPTIMAL").isTrue()
+            assertThat(leq.isOptimal).describedAs("$name: the ≤ reference proves OPTIMAL").isTrue()
+            assertThat(exact.objective)
+                .describedAs("$name: exact socket fill must not change the most-masteries optimum (exact == ≤)")
+                .isEqualTo(leq.objective)
         }
     }
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -247,7 +247,6 @@ class WakfuBuildSolverTest {
         }
 
     @Test
-    @Tag("slow")
     fun `lp solver finds a valid feasible build on the level 245 dataset`(): Unit =
         runBlocking {
             val level = 245
@@ -2954,7 +2953,6 @@ class WakfuBuildSolverTest {
     }
 
     @Test
-    @Tag("slow")
     fun `domination preserves the most-masteries optimum on the full level-110 pool`() {
         // most-masteries soundness guard: its objective is the bilinear masteryScore × penaltyMultiplier (the
         // required AP/MP/HP/crit targets drive the multiplier), so this exercises the sign argument — the optimum
@@ -2990,7 +2988,6 @@ class WakfuBuildSolverTest {
     }
 
     @Test
-    @Tag("slow")
     fun `domination preserves the precision optimum on the full level-110 pool`() {
         // precision soundness guard: its objective is a sum of min(actual, target) terms (capped, monotone), so
         // componentwise->= domination must reach the same proven optimum on the full pool.
@@ -3280,7 +3277,6 @@ class WakfuBuildSolverTest {
     )
 
     @Test
-    @Tag("slow")
     fun `a single-element mastery request is no longer prefiltered (full pool, proven optimum)`() {
         // The prefilter is a top-N-per-stat HEURISTIC that can miss the optimum; for a SINGLE specific element
         // the full-pool model stays small and proves the true optimum fast (measured ~1-4s on lvl 245), so the
@@ -3307,7 +3303,6 @@ class WakfuBuildSolverTest {
     }
 
     @Test
-    @Tag("slow")
     fun `a multi-element aggregate request still prefilters the pool`() {
         // The O(elements^2) random-element modelling explodes the full pool for multi-element requests (even
         // prefiltered, the aggregate solve is hard), so the prefilter stays load-bearing there. No solve here.

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2757,6 +2757,187 @@ class WakfuBuildSolverTest {
     }
 
     @Test
+    fun `domination relation respects rarity budget, sockets and ring multiplicity`() {
+        val pool =
+            listOf(
+                // AMULET: Junk is dominated by NonEpic (both rare, ≤ on all) ⇒ dropped. The EPIC can't dominate
+                // the non-epic (keeping it may free the single epic slot for a stronger epic elsewhere) ⇒ both kept.
+                equipment(1, ItemType.AMULET, "NonEpic", mapOf(Characteristic.MASTERY_ELEMENTARY to 100), rarity = Rarity.RARE),
+                equipment(2, ItemType.AMULET, "Epic", mapOf(Characteristic.MASTERY_ELEMENTARY to 150), rarity = Rarity.EPIC),
+                equipment(3, ItemType.AMULET, "Junk", mapOf(Characteristic.MASTERY_ELEMENTARY to 80), rarity = Rarity.RARE),
+                // BELT: a COMMON beating a RELIC on every stat DOES dominate it (a relic beaten everywhere is useless).
+                equipment(4, ItemType.BELT, "CommonBig", mapOf(Characteristic.MASTERY_ELEMENTARY to 300), rarity = Rarity.COMMON),
+                equipment(5, ItemType.BELT, "RelicSmall", mapOf(Characteristic.MASTERY_ELEMENTARY to 200), rarity = Rarity.RELIC),
+                // HELMET: more stats can't dominate fewer sockets (≥ maxShardSlots required) ⇒ both kept.
+                equipment(6, ItemType.HELMET, "HiStatNoSock", mapOf(Characteristic.MASTERY_ELEMENTARY to 200), maxShardSlots = 0, rarity = Rarity.RARE),
+                equipment(7, ItemType.HELMET, "LoStat3Sock", mapOf(Characteristic.MASTERY_ELEMENTARY to 50), maxShardSlots = 3, rarity = Rarity.RARE),
+                // RING keeps 2: R3 has TWO dominators (R1, R2) ⇒ removed; R2 has only ONE (R1) ⇒ kept; R1 kept.
+                equipment(8, ItemType.RING, "R1", mapOf(Characteristic.MASTERY_ELEMENTARY to 100), rarity = Rarity.RARE),
+                equipment(9, ItemType.RING, "R2", mapOf(Characteristic.MASTERY_ELEMENTARY to 90), rarity = Rarity.RARE),
+                equipment(10, ItemType.RING, "R3", mapOf(Characteristic.MASTERY_ELEMENTARY to 10), rarity = Rarity.RARE)
+            ).groupBy { it.itemType }
+
+        val kept = WakfuBuildSolver.filterDominatedPoolForTest(pool).mapValues { (_, v) -> v.map { it.name.fr }.toSet() }
+
+        assertThat(kept[ItemType.AMULET]).describedAs("epic can't dominate the non-epic; junk dropped").containsExactlyInAnyOrder("NonEpic", "Epic")
+        assertThat(kept[ItemType.BELT]).describedAs("a common beating a relic on every stat dominates it").containsExactly("CommonBig")
+        assertThat(kept[ItemType.HELMET]).describedAs("more stats can't dominate fewer sockets").containsExactlyInAnyOrder("HiStatNoSock", "LoStat3Sock")
+        assertThat(kept[ItemType.RING]).describedAs("ring keeps 2: R3 has two dominators, R2 only one").containsExactlyInAnyOrder("R1", "R2")
+    }
+
+    @Test
+    fun `domination keeps a non-epic that frees the epic budget — same optimum`() {
+        // The trap a naive stats-only filter falls into: drop the weaker NON-epic amulet for the stronger epic.
+        // But keeping it is exactly what lets the build spend its one epic on the far stronger epic ring. The
+        // filtered optimum must equal the full-pool optimum (if the non-epic were wrongly removed it would drop).
+        val pool =
+            listOf(
+                equipment(1, ItemType.AMULET, "NonEpicAmu", mapOf(Characteristic.MASTERY_ELEMENTARY to 100), rarity = Rarity.RARE),
+                equipment(2, ItemType.AMULET, "EpicAmu", mapOf(Characteristic.MASTERY_ELEMENTARY to 150), rarity = Rarity.EPIC),
+                equipment(3, ItemType.RING, "EpicRing", mapOf(Characteristic.MASTERY_ELEMENTARY to 400), rarity = Rarity.EPIC),
+                equipment(4, ItemType.RING, "WeakRing", mapOf(Characteristic.MASTERY_ELEMENTARY to 10), rarity = Rarity.RARE)
+            ).groupBy { it.itemType }
+        val params = maxDamageShape(CharacterClass.CRA, 110, DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE))
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val full = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = false)
+        val filtered = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = true)
+        assertThat(full.isOptimal && filtered.isOptimal).describedAs("both prove OPTIMAL").isTrue()
+        assertThat(filtered.objective)
+            .describedAs("domination must keep the non-epic that frees the epic slot — optimum unchanged")
+            .isEqualTo(full.objective)
+    }
+
+    @Test
+    @Tag("slow")
+    fun `domination preserves the max-damage optimum on the full level-110 pool`() {
+        // The breadth guard: on the real EPIC pool, the per-slot domination pre-filter must reach the SAME
+        // proven optimum as the full pool — across every slot's real rarity / socket / stat mix. Runes are OFF
+        // here so the FULL solve still proves within budget (runes ~double the model and blow past it); the
+        // rune-capacity half of the relation (maxShardSlots ≥) is locked by the pure-relation unit test above.
+        val tuning = WakfuBuildSolver.SolverTuning(maxDeterministicTime = 600.0)
+        val params =
+            maxDamageShape(
+                CharacterClass.CRA,
+                110,
+                DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE)
+            )
+        val pool = fullEpicPool(110)
+        val full = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = false)
+        val filtered = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = true)
+        assertThat(full.isOptimal && filtered.isOptimal).describedAs("both prove OPTIMAL on the full pool").isTrue()
+        assertThat(filtered.objective).describedAs("domination must preserve the proven optimum").isEqualTo(full.objective)
+    }
+
+    @Test
+    fun `domination pins conditioned stats to equality`() {
+        // With a conditional sub in play (e.g. SECONDARY_MASTERIES_AT_MOST), the stats it reads are pinned: two
+        // items differing only on a pinned stat can't dominate each other (the weaker might be the one kept to
+        // satisfy the cap). But pure ELEMENTAL gear still dominates — no condition reads elemental mastery.
+        val pool =
+            listOf(
+                equipment(1, ItemType.AMULET, "DistA", mapOf(Characteristic.MASTERY_DISTANCE to 100), rarity = Rarity.RARE),
+                equipment(2, ItemType.AMULET, "DistB", mapOf(Characteristic.MASTERY_DISTANCE to 50), rarity = Rarity.RARE),
+                equipment(3, ItemType.BELT, "ElemBig", mapOf(Characteristic.MASTERY_ELEMENTARY to 100), rarity = Rarity.RARE),
+                equipment(4, ItemType.BELT, "ElemSmall", mapOf(Characteristic.MASTERY_ELEMENTARY to 50), rarity = Rarity.RARE)
+            ).groupBy { it.itemType }
+        val kept =
+            WakfuBuildSolver
+                .filterDominatedPoolForTest(pool, setOf(Characteristic.MASTERY_DISTANCE))
+                .mapValues { (_, v) -> v.map { it.name.fr }.toSet() }
+        assertThat(kept[ItemType.AMULET]).describedAs("pinned stat ⇒ no domination across it").containsExactlyInAnyOrder("DistA", "DistB")
+        assertThat(kept[ItemType.BELT]).describedAs("unpinned elemental still dominates").containsExactly("ElemBig")
+    }
+
+    @Test
+    @Tag("slow")
+    fun `domination preserves the max-damage optimum on the full level-110 pool with sublimations`() {
+        // The smart-pinning guard — the case the default GUI search actually runs. With sublimations ON, the
+        // 9 dangerous conditional choosable subs pin AP/crit/dodge/range/secondaries, so domination can't flip
+        // any cap; it must still reach the SAME proven optimum as the full pool.
+        val tuning = WakfuBuildSolver.SolverTuning(maxDeterministicTime = 900.0)
+        val params =
+            maxDamageShape(CharacterClass.CRA, 110, DamageScenario(element = SpellElement.FIRE, rangeBand = RangeBand.DISTANCE, orientation = Orientation.FACE))
+                .copy(useSublimations = true)
+        val pool = fullEpicPool(110)
+        val subs = WakfuBestBuildFinderAlgorithm.sublimations
+        val full = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, sublimations = subs, applyDomination = false)
+        val filtered = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, sublimations = subs, applyDomination = true)
+        assertThat(full.isOptimal && filtered.isOptimal).describedAs("both prove OPTIMAL with subs on").isTrue()
+        assertThat(filtered.objective).describedAs("pinned domination must preserve the proven optimum with subs on").isEqualTo(full.objective)
+    }
+
+    @Test
+    @Tag("slow")
+    fun `domination preserves the most-masteries optimum on the full level-110 pool`() {
+        // most-masteries soundness guard: its objective is the bilinear masteryScore × penaltyMultiplier (the
+        // required AP/MP/HP/crit targets drive the multiplier), so this exercises the sign argument — the optimum
+        // has masteryScore >= 0, making the dominance swap monotone. Full pool must reach the same proven optimum.
+        val tuning = WakfuBuildSolver.SolverTuning(maxDeterministicTime = 600.0)
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, 110, 0, CharacterSkills(110)),
+                targetStats =
+                    TargetStats(
+                        listOf(
+                            TargetStat(Characteristic.MASTERY_DISTANCE, 9999),
+                            TargetStat(Characteristic.ACTION_POINT, 12),
+                            TargetStat(Characteristic.MOVEMENT_POINT, 6),
+                            TargetStat(Characteristic.HP, 2000),
+                            TargetStat(Characteristic.CRITICAL_HIT, 30)
+                        )
+                    ),
+                searchDuration = 600.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                useRunes = false,
+                useSublimations = false
+            )
+        val pool = fullEpicPool(110)
+        val full = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = false)
+        val filtered = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = true)
+        assertThat(full.isOptimal && filtered.isOptimal).describedAs("both prove OPTIMAL").isTrue()
+        assertThat(filtered.objective).describedAs("domination must preserve the most-masteries optimum").isEqualTo(full.objective)
+    }
+
+    @Test
+    @Tag("slow")
+    fun `domination preserves the precision optimum on the full level-110 pool`() {
+        // precision soundness guard: its objective is a sum of min(actual, target) terms (capped, monotone), so
+        // componentwise->= domination must reach the same proven optimum on the full pool.
+        val tuning = WakfuBuildSolver.SolverTuning(maxDeterministicTime = 600.0)
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, 110, 0, CharacterSkills(110)),
+                targetStats =
+                    TargetStats(
+                        listOf(
+                            TargetStat(Characteristic.MASTERY_DISTANCE, 800),
+                            TargetStat(Characteristic.ACTION_POINT, 12),
+                            TargetStat(Characteristic.HP, 2000),
+                            TargetStat(Characteristic.CRITICAL_HIT, 30),
+                            TargetStat(Characteristic.RANGE, 2)
+                        )
+                    ),
+                searchDuration = 600.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT,
+                useRunes = false,
+                useSublimations = false
+            )
+        val pool = fullEpicPool(110)
+        val full = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = false)
+        val filtered = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true, applyDomination = true)
+        assertThat(full.isOptimal && filtered.isOptimal).describedAs("both prove OPTIMAL").isTrue()
+        assertThat(filtered.objective).describedAs("domination must preserve the precision optimum").isEqualTo(full.objective)
+    }
+
+    @Test
     fun `single-type rune fold preserves the max-damage optimum`() {
         // The fold fills each item with ONE rune type (a boolean pick) instead of a free per-stat count.
         // Because a rune's value is uniform across an item's sockets (RuneType.valueOn doubles per item-SLOT,

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2658,6 +2658,104 @@ class WakfuBuildSolverTest {
         }
     }
 
+    /** Constraint-rich precision request for [clazz] at [level] hitting [targets] — drives the cap/min/average/overflow chain. */
+    private fun precisionShape(
+        clazz: CharacterClass,
+        level: Int,
+        targets: List<TargetStat>,
+    ): WakfuBestBuildParams =
+        WakfuBestBuildParams(
+            character = Character(clazz, level, 0, CharacterSkills(level)),
+            targetStats = TargetStats(targets),
+            searchDuration = 60.seconds,
+            stopWhenBuildMatch = false,
+            maxRarity = Rarity.EPIC,
+            forcedItems = emptyList(),
+            excludedItems = emptyList(),
+            scoreComputationMode = ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT,
+            useRunes = false,
+            useSublimations = false
+        )
+
+    /** Shapes spanning specific + generic (multi-element) mastery, resistance, AP/MP/HP/crit and lvl-245 magnitudes. */
+    private fun precisionSoundnessShapes(): List<Pair<String, WakfuBestBuildParams>> =
+        listOf(
+            "cra-mastery-ap-crit-110" to
+                precisionShape(
+                    CharacterClass.CRA,
+                    110,
+                    listOf(
+                        TargetStat(Characteristic.MASTERY_ELEMENTARY_FIRE, 1500),
+                        TargetStat(Characteristic.ACTION_POINT, 12),
+                        TargetStat(Characteristic.CRITICAL_HIT, 40)
+                    )
+                ),
+            "cra-generic-mastery-di-110" to
+                precisionShape(
+                    CharacterClass.CRA,
+                    110,
+                    listOf(
+                        TargetStat(Characteristic.MASTERY_ELEMENTARY, 2000),
+                        TargetStat(Characteristic.DAMAGE_INFLICTED, 100)
+                    )
+                ),
+            "iop-melee-back-hp-110" to
+                precisionShape(
+                    CharacterClass.IOP,
+                    110,
+                    listOf(
+                        TargetStat(Characteristic.MASTERY_MELEE, 800),
+                        TargetStat(Characteristic.MASTERY_BACK, 600),
+                        TargetStat(Characteristic.HP, 500)
+                    )
+                ),
+            "cra-mastery-ap-245" to
+                precisionShape(
+                    CharacterClass.CRA,
+                    245,
+                    listOf(
+                        TargetStat(Characteristic.MASTERY_ELEMENTARY_FIRE, 3000),
+                        TargetStat(Characteristic.ACTION_POINT, 14)
+                    )
+                )
+        )
+
+    @Test
+    fun `precision reachable bounds hold across classes, targets and levels`() {
+        // Precision soundness lock (mirrors the max-damage one): now that the precision stat chain is declared on
+        // its reachable domains (tight=true), solve each shape with LOOSE guard domains and check every var's
+        // solved value against the tight reachable [lo,hi] the production build DECLARES. A value outside = an
+        // interval under-estimate that would silently cut the precision optimum. The tiny high-stat stress pool
+        // drives the cap/min/average/overflow chain to end-game magnitudes — stronger than the real pool.
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val pool = soundnessStressPool()
+        precisionSoundnessShapes().forEach { (name, params) ->
+            val bounds = WakfuBuildSolver.precisionVarBoundsForTest(params, pool, tuning)
+            assertThat(bounds).describedAs("$name: the precision chain must be tracked").isNotEmpty
+            assertThat(bounds.filterNot { it.withinBound })
+                .describedAs("$name: a precision var whose reachable bound under-estimated its real value — a silently cut optimum")
+                .isEmpty()
+        }
+    }
+
+    @Test
+    fun `precision tight reachable domains keep the same optimum as loose guards`() {
+        // Output-preservation lock for the precision tight=true switch: tight reachable domains must declare the
+        // SAME optimum as loose guards (tight only changes provability/speed, never the answer), and the tight
+        // build is the one that proves it. Same shapes as the soundness lock, on the tiny pool both prove.
+        val tuning = WakfuBuildSolver.SolverTuning()
+        val pool = soundnessStressPool()
+        precisionSoundnessShapes().forEach { (name, params) ->
+            val tight = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = true)
+            val loose = WakfuBuildSolver.maxDamageSolveForTest(params, pool, tuning, tightDomains = false)
+            assertThat(tight.isOptimal).describedAs("$name: the tight (production) precision model must prove OPTIMAL").isTrue()
+            assertThat(loose.isOptimal).describedAs("$name: the loose reference also proves on this small pool").isTrue()
+            assertThat(tight.objective)
+                .describedAs("$name: tightening declared domains must not change the precision optimum — only how fast it is proven")
+                .isEqualTo(loose.objective)
+        }
+    }
+
     @Test
     fun `single-type rune fold preserves the max-damage optimum`() {
         // The fold fills each item with ONE rune type (a boolean pick) instead of a free per-stat count.

--- a/docs/SOLVER_PERFORMANCE.md
+++ b/docs/SOLVER_PERFORMANCE.md
@@ -17,6 +17,19 @@ The top-pick model-level items were benchmarked on a real before/after, and the 
 56 s → 236 s → 877 s on the same solve as the CPU **thermally throttled** (4× swings). Use `numBranches`,
 not wall-clock, for any future A/B here.
 
+> **⚠️ CORRECTION (2026-06-25) — even `deterministic_time` is unreliable here; treat every `×` below as
+> soft.** A reproducibility test ran the *identical* full model back-to-back with 8 workers / seed 1:
+> det-time came out **49.1 / 111.7 / 98.3** at lvl-110 and **358 / 478 / 439** at lvl-245 — a **2.3× swing on
+> the same model in the same JVM**. CP-SAT's parallel-portfolio det-time accounting is perturbed by real-clock
+> worker scheduling, which the thermal throttling jerks around (single-worker is reproducible but times out, so
+> it's not a usable control). `numBranches` is reproducible but *non-monotone* (the domination filter posted 3.2×
+> *more* branches yet "less" det-time — a smaller model can be slower). **Net: on this machine we cannot reliably
+> attribute a proof-time speedup.** What IS solid and reproducible: (1) **soundness** — every A/B scored
+> identically, so the proven optimum is always preserved; (2) **model-size reduction** — var/pool counts are
+> deterministic. So trust the *reductions* and the *soundness*, and read the `×` figures below as "probably
+> faster, magnitude unknown — the large lvl-110 subs-off effect likely exceeds the noise; the smaller/high-level
+> ones are within it." A trustworthy magnitude would need a non-throttling host and many averaged runs.
+
 Head-to-head (full EPIC pool, `solveForBenchmark`, 8 workers / seed 1 / det-time 600; identical objective
 values on both sides ⇒ output preserved):
 
@@ -43,6 +56,91 @@ values on both sides ⇒ output preserved):
 **Shipped on `perf/solver-speedups`: §1.1 + §1.2 (+ tests) only.** Everything in §1 below is the original
 audit's *prediction*; treat §1.3/§1.6 as **measured no-ops** and the rest as **unverified** until a
 deterministic (`numBranches`) A/B shows otherwise — wall-clock will lie. The §3 cache idea is untested.
+
+### ✅ Validated win — per-slot DOMINATION pre-filter (measure with deterministic_time, not numBranches)
+
+The one idea that **does** work (and the audit had *rejected* a sloppy version of it — see §4). Within a
+slot, item A **soundly dominates** B (B can never beat A in any build, so B is removable) when **all** hold:
+- A.characteristics ≥ B on **every** characteristic (monotone objective terms, stat sums, ≥-type sub
+  conditions are all then ≥; absent key = 0);
+- A introduces no rarity-cap cost B lacked: `(A epic ⇒ B epic) ∧ (A relic ⇒ B relic)`;
+- `A.maxShardSlots ≥ B.maxShardSlots` — and the rune/sub model is **colour-agnostic** (sockets are a pure
+  count, golden runes form sub patterns; `WakfuBuildSolver.kt` ~962), so count is sufficient for both rune
+  capacity and sub-carrier eligibility — **no socket-colour multisets needed**;
+- B removable iff it has **≥ k** such dominators (k=2 for RING — two co-equippable distinct — else 1), ties
+  broken by id.
+
+**Measured (max-damage fire, full EPIC pool, no runes/subs, deterministic):**
+
+| | lvl-110 | lvl-245 |
+|---|---|---|
+| pool / vars FULL→FILTERED | 2762→1323 / 4316→2194 | 7884→3116 / 13204→5346 |
+| **deterministic_time FULL→FILTERED** | **315.5 → 71.4 (−77%, 4.4×)** | **453.6 → 288.6 (−36%, 1.6×)** |
+| proven objective | identical ✓ | identical ✓ |
+
+~50–60% of items are dominated (e.g. 97% of mounts — all carry only `MASTERY_ELEMENTARY`, totally ordered).
+**Use `deterministic_time`, NOT `numBranches`:** filtered lvl-245 took 3.2× *more* branches but they're far
+cheaper (half the vars ⇒ smaller LP/node), so total work still dropped 36%. numBranches lied here.
+
+### Conditional sublimations — pin, don't gate (so it works with subs ON, the default)
+
+A *conditional* sub makes some stats non-monotone: a build may keep a weaker (e.g. low-secondary) item
+*specifically* to satisfy a cap like `SECONDARY_MASTERIES_AT_MOST` (the choosable ones are value 0 — pure
+elemental), which domination would remove. The blunt fix is to gate domination off whenever a conditional
+choosable sub is in play — but the default has `useSublimations = true` with **12/27** choosable subs
+conditional, so that turns it off for the case users actually run.
+
+**The smart fix: pin every stat a *dangerous* (≤ / exact / parity) condition reads to equality** in the
+relation (`A == B` on those, `A ≥ B` on the rest). The swap then can't move that stat's build sum, so no sub
+can flip — while domination still fires across every stat no condition touches (the bulk of pure-**elemental**
+gear). `≥`-type conditions stay satisfied under a `≥` swap on a beneficial choosable sub ⇒ no pin. For the
+default sub set the pinned stats are **AP, crit, dodge, range, and the 6 secondary masteries**.
+
+**Measured (max-damage fire, full EPIC pool, subs ON, pinned, deterministic):** ~13–22 % of items still
+dominated, and the win *scales with difficulty* —
+
+| | lvl-110 | lvl-245 |
+|---|---|---|
+| vars FULL→FILTERED | 42360→36143 | 133358→120474 |
+| **deterministic_time** | 79.5 → 85.8 (neutral; already fast) | **716.3 → 258.3 (−64 %, 2.8×)** |
+| proven objective | identical ✓ | identical ✓ |
+
+So the default (subs ON) gets a **2.8× faster proof at lvl-245** — the slow high-level case that's actually
+painful — for free, and an immaterial wobble at the already-fast lvl-110.
+
+**IMPLEMENTED — for ALL THREE modes** (`WakfuBuildSolver.dominationPinnedStats` → `filterDominatedPool`),
+applied in `buildModel` only on the production path (`optimize` passes `applyDomination = tuning == null`, so
+deterministic tests keep the full pool and are untouched). The original max-damage-only gate was over-conservative:
+my claim that most-masteries / precision "penalize overshoot" was **wrong** — both **clamp** at the target
+(precision `min(actual, target)`; most-masteries `maxVar(actual, 1, target)` + an overshoot-rewarding tie-break),
+so all three objectives are **monotone non-decreasing in every characteristic**. The one subtlety —
+most-masteries' objective is the *product* `masteryScore × penaltyMultiplier` — is fine because the optimum
+always has `masteryScore ≥ 0` (the empty build already scores objective ≥ 0), and for `masteryScore ≥ 0` the
+swap `(m+Δm)(μ+Δμ) ≥ mμ` holds. **most-masteries is the *slowest* mode (~72 s full-pool lvl-245), so this is
+where it most helps.** `dominationPinnedStats` returns the pin set, or `null` to skip entirely:
+- **null (skip) when**: any forced item / forced rune-by-item; any *forced* conditional sub (unknown effect
+  direction); or a condition that compares two build stats / is categorical (`HIGHEST_ELEM_MASTERY_GT_*`,
+  `WEAPON_TYPE_EQUIPPED`, `OTHER`). (No longer gated by mode — all three are monotone.)
+- **else** the union of stats read by in-play dangerous choosable-sub conditions (empty ⇒ full domination).
+- **Soundness locked by 7 tests** (`WakfuBuildSolverTest`): the pure-relation edges (rarity-budget / socket /
+  ring-multiplicity), the pinning mechanism, the epic-budget counterexample, and four `@slow` full-pool lvl-110
+  guards (filtered==full *proven* optimum) — max-damage subs-off, max-damage **subs ON**, **most-masteries**
+  (exercises the bilinear `masteryScore × multiplier` sign), and **precision**. Mirrors the rune-fold lock.
+
+### Explored further and NOT pursued — per-probe read-set domination (a sound but not-worth-it refinement)
+
+A 9-agent workflow designed + adversarially verified a more aggressive variant: since `MaxDamageSearch` solves
+one element at a time, a *fire* probe's objective never reads water/earth/air masteries (or resistances, floor
+off), so domination can ignore those axes (restrict the `>=` test to the per-probe read-set `R(E,S,F,T)` + the
+existing pins + the `AT_LEAST` condition stats). It is **sound** (proven; a solve A/B scored identically) and
+removes more (subs-on potential 13–22% → **21–32%**). But (a) the verification **caught that an earlier
+"directional secondary" idea was UNSOUND** — the cap is *sum ≤ 0*, so 43 real items with *negative* secondary
+mastery (e.g. L'Ami Léhunui BERSERK −305/BACK +244) can be kept to hold the cap; and (b) a solve A/B **regressed
+at lvl-245** (324 → 523 det-time — smaller model, slower proof) while helping lvl-110, i.e. the gain is within
+the measurement noise documented above. Verdict: **not worth the soundness-critical read-set audit** for an
+unmeasurable/possibly-negative gain. The runner-up (a 2-regime Neutrality-on/off split) is parked for the same
+reason. Reproducing the read-set relation: `geStats` (elemental + DI + MP + BLOCK + AT_LEAST stats) use `>=`,
+the conditioned pins use `==`, and sibling-element + resistance/HP (floor off) axes are *ignored*.
 
 ## The one hard rule
 

--- a/docs/SOLVER_PERFORMANCE.md
+++ b/docs/SOLVER_PERFORMANCE.md
@@ -1,0 +1,360 @@
+# Solver performance — optimality-preserving speedups (audit, 2026-06-24)
+
+A backlog of ways to make the CP-SAT solver **faster in every mode** without ever compromising
+**output quality** (the exact same optimal build is found) or **provability** (the solver still
+reaches and reports `OPTIMAL` / a proven optimum, and any outer enumeration stays exhaustive).
+
+> **For any agent picking this up.** This is a worklist, not a record of work done. Each item below
+> carries the mechanism, a code anchor, expected impact, effort, an explicit *why-it-preserves-the-optimum*
+> argument, and the test/guard it must ship with. The **Rejected** section (bottom) lists ideas that
+> *look* like speedups but provably drop or change the optimum — **do not re-attempt them.**
+
+## ⚠️ Measured outcome (2026-06-24) — most of §1 is NOT a real speedup
+
+The top-pick model-level items were benchmarked on a real before/after, and the **deterministic** metric
+(CP-SAT `numBranches`/`numConflicts` — fixed seed/workers/det-time, so reproducible and thermal-immune)
+**contradicted the wall-clock numbers**. Wall-clock on this machine was useless: identical code ran
+56 s → 236 s → 877 s on the same solve as the CPU **thermally throttled** (4× swings). Use `numBranches`,
+not wall-clock, for any future A/B here.
+
+Head-to-head (full EPIC pool, `solveForBenchmark`, 8 workers / seed 1 / det-time 600; identical objective
+values on both sides ⇒ output preserved):
+
+| scenario | baseline branches | with §1.3 slice | result |
+|---|---|---|---|
+| mostmast-110 (control, untouched) | 7583 | 7595 | ~0% ⇒ metric is deterministic ✓ |
+| maxdmg-110 | 2692 | **2692** | **identical — no effect** |
+| maxdmg-245 | 1690 | **1792** | **+6% — slightly worse** |
+| precision-110 (§1.2 tight) | 3074 | 2678 | −13%, but on a 0.4 s solve ⇒ irrelevant |
+
+**Conclusion: the solver is already presolve-optimized; the model-level "speedups" don't move the proof.**
+- **§1.3 (throughput AP-slice) — DROPPED.** CP-SAT presolve already derives the element-constraint domain
+  (`target = table[index]`, `index ∈ [lo,hi]` ⇒ slice), so the manual slice is redundant: byte-identical
+  branch count at 110, +6% at 245. No benefit.
+- **§1.6 (throughput/damageSpells memo) — DROPPED.** Build-time only (microseconds); invisible next to a
+  multi-second-to-minutes solve. Not measurable.
+- **§1.2 (precision `tight=true`) — KEPT as harmless insurance.** −13% branches, but precision already
+  proves in <0.5 s so the real-world effect is nil. Worth keeping only for the **precision soundness +
+  tight==loose equality tests** it ships with (they lock the precision domains).
+- **§1.1 (callback rescore throttle) — KEPT, but as a UX fix not a speedup.** Cuts heavy per-solution
+  rescores 12 → 3; each is ~ms so the *solve* gain is negligible, but it reduces solve-thread / render-thread
+  contention (less GUI jank during a search).
+
+**Shipped on `perf/solver-speedups`: §1.1 + §1.2 (+ tests) only.** Everything in §1 below is the original
+audit's *prediction*; treat §1.3/§1.6 as **measured no-ops** and the rest as **unverified** until a
+deterministic (`numBranches`) A/B shows otherwise — wall-clock will lie. The §3 cache idea is untested.
+
+## The one hard rule
+
+A speedup is admissible **only** if it provably keeps BOTH:
+1. **Output quality** — the same optimal build is still found; no build can be lost or changed.
+2. **Provability** — the solve still reaches/report `OPTIMAL` (gap 0), and any outer enumeration
+   (`MaxDamageSearch`) stays exhaustive over its candidate space.
+
+**Admissible levers** (all used or proposed below): tighter variable *domains* over the same feasible
+region; redundant/valid cuts, symmetry-breaking, or implied bounds that remove *no* optimum; a
+smaller-but-equivalent model; better presolve/linearization/parameter config that does **not** cap the
+proof; CP-SAT solution hints / warm starts (cannot change the optimum); right-sized parallelism;
+eliminating redundant re-solves; caching build-invariant precomputation; reducing per-probe /
+per-callback overhead; provably-sound *dominance* pruning in the outer enumeration.
+
+**Never admissible:** lowering the time / deterministic-time budget; feasible-only or early-stop
+shortcuts; heuristic pruning that *could* skip the optimum; widening the choosable sublimation set or
+any data change that "invents" damage; anything that changes the reported build.
+
+> **Anchor caveat.** Line numbers below are as of `main` @ **1.8.0** (`WakfuBuildSolver.kt` ≈ 3182
+> lines). They drift across releases — prefer the **symbol name** when locating code. The data version
+> at audit time was `WakfuData.VERSION = "1.92.1.58"` (`common-lib/.../WakfuData.kt:16`).
+
+---
+
+## 0. Where time goes today (baseline per mode)
+
+| Mode | Current cost | Bound by |
+|---|---|---|
+| **most-masteries** (default) | prefiltered proves OPTIMAL ~3.8 s; full late-game pool ~72 s (lvl-245). Single-element default runs the **full, unprefiltered** pool and often misses the "proven" badge inside the GUI's ~20 s default. | the bilinear objective product `masteryScore × penaltyMultiplier` + power-6 penalty bucketing — *not* the linear stat chain. |
+| **precision** | full cap/min/average/overflow objective runs over **loose 1e7–1e13 declared domains**; the reachable domains are already computed at every leaf but **discarded** (`tight=false`). The random-element redesign already took precision 204 s FEASIBLE → 1.6 s OPTIMAL once the model tightened *structurally*. | loose variable domains starving presolve + the LP relaxation. |
+| **max-damage single** | provable today (lvl-110 ~50 s, lvl-245 ~3.5 min) via per-pool reachable domains + the boolean rune fold. | closing the **dual bound**, not finding an incumbent. The central bilinear term `throughput × perHitScaled` dominates. |
+| **max-damage bi** | provable per-element **enumeration** (in-model bilinear split is unprovable); ≤4 element solves run in parallel via `runProbeBatch`; each full solve is the dominant cost. | the per-element solves; throughput-table recompute repeats once per candidate element. |
+| **max-damage boss** | confirmed-debuff classes (Sram/Sadida) run `activePhases=2` with a static 50/50 split → phase 1 (the *provable* enumeration) gets only half the wall-clock. At the 20 s GUI default, phase 1 gets 10 s. High-level boss/multi-element optima are structurally unprovable in minutes (inherent scale). | wall-clock split + scale. |
+| **shared** | first search per process pays JIT of model-construction/scorer paths (native dylib load is already covered by the trivial warm-up); the CLI under-uses one core; intermediate solution callbacks steal native-solve-thread cycles in **every** mode. | first-search JIT + callback overhead. |
+
+---
+
+## 1. Top picks (ranked by impact ÷ effort)
+
+### 1.1 — Throttle the per-solution rescore in the solver callback · **all modes** · medium impact · **small effort**
+Every improving solution currently runs a full `solutionToBuild` + `scoreFor` (a knapsack-rotation DP
+in max-damage) **on the native solve thread**, then `trySend`s a progress snapshot. Coalesce these
+behind a single wall-clock timestamp check (~150–250 ms) inside `onSolutionCallback` so the solver
+spends its cycles on search/proof instead of progress snapshots.
+- **Code:** `WakfuBuildSolver.kt` — `onSolutionCallback` (≈1413), intermediate `trySend` (≈1426),
+  unconditional final emit `scope.send` (≈1442).
+- **Why optimum-safe:** the callback feeds neither branch-and-bound nor the optimality proof — it only
+  reads var values, checks cancellation, and *best-effort* `trySend`s a snapshot. The reported build is
+  the **final** one, recomputed unconditionally after `solve()` returns and delivered via a guaranteed
+  *suspending* `send`, so it is always the last flow element; throttling intermediates cannot drop or
+  reorder it. CLI (`.buffer(CONFLATED).lastOrNull`) and GUI (`.conflate().collect`) already keep only
+  the last element; tests assert `.toList().maxBy { score }`, not emission counts.
+- **Guards:** keep the `!scope.isActive → stopSearch()` cancellation check **before** the throttle so
+  cancel latency is unchanged. Do **not** substitute `solver.objectiveValue()` for the displayed
+  intermediate (it is the proxy objective, not the lockstep score).
+
+### 1.2 — Precision: build the `StatBuilder` with `tight = true` · **precision** · medium impact · **small effort**
+`buildPrecisionObjective` constructs its `StatBuilder` with the default `tight = false`
+(`WakfuBuildSolver.kt:1297`), so every stat var is declared on the 10 M guard domain even though the
+reachable range is already computed at every leaf. Pass `tight = true` exactly as max-damage does
+(`:459`). Per-element stat domains collapse from 10,000,000 to a few thousand across the
+cap/min/average/overflow chain — the **same lever** that flipped max-damage from FEASIBLE to OPTIMAL.
+- **Code:** `WakfuBuildSolver.kt:1289` (`buildPrecisionObjective`), `:1297` (the `StatBuilder` ctor call);
+  enabled by `DomainTracker.decl` (declares `reach.coerceIn(guard)`); `StatBuilder` `tight` default at `:1618`.
+- **Why optimum-safe:** `decl` declares `reach.coerceIn(guard)`, so the tight domain is always a
+  **subset** of today's domain, never wider; every `reach` is sound interval arithmetic
+  (`reachableSumDomain` bounds each mutually-exclusive `ItemType` group by best/worst coeff — it even
+  permits 2H+1H+offhand together, a *superset* of the validity region) so it contains every attainable
+  value. Domains are not constraints, so a feasible-superset domain can never conflict. Solver params
+  are unchanged (`maxPresolveIterations` stays 1), so the proof can only tighten, never cap.
+- **Guards (REQUIRED):** add a **precision-mode reachable-bound soundness lock** mirroring
+  `maxDamageVarBoundsForTest` (today it covers only the max-damage chain) **plus** a `tight==loose`
+  optimum-equality test. Benchmark full-pool OPTIMAL-time before/after — the impact estimate is
+  extrapolated from max-damage, and precision does **not** get `presolve=3` / `linearizationLevel=2`.
+
+### 1.3 — Max-damage: slice the throughput `tElement` domain to the build's reachable AP window · **single / bi / boss** · medium impact · **small effort**
+In `StatBuilder.tElement` the result var is declared on the full `table.min()..table.max()`. Instead
+declare it on the reachable **slice** `table[loI..hiI]`, where `loI/hiI` come from `tracker.of(apVar)`
+(the build's real achievable AP, clamped to `[0, MAX_ROTATION_AP=20]`). At lvl-110 the true AP ceiling
+is ~12–16, so the throughput operand's declared `hi` drops ~19–29 %; since throughput feeds
+`raw = tMul(throughput, perHitScaled)`, the product envelope (`mulRange`) shrinks proportionally,
+tightening the LP relaxation of the central bilinear term **and the dual bound**.
+- **Code:** `WakfuBuildSolver.kt:1767` (`tElement`); AP source `apVar = tClamp(actualStat(AP), 0, 20)` (≈2236);
+  `MAX_ROTATION_AP` at `:81`.
+- **Why optimum-safe:** the recorded reach `table[loI..hiI]` is the *exact* value-set of `table[index]`
+  over `apVar`'s tracked feasible window; `apVar` is functionally pinned by equality to the real
+  achievable clamped AP, so the solver cannot push the index past the gear-bounded ceiling even in loose
+  mode. No feasible `(index, target)` pair is dropped → no build removed. When AP reaches 20 the slice
+  equals the full table (exact no-op).
+- **Guards:** clamp slice indices with `coerceIn(0, table.size-1)`; the existing 10-shape
+  `maxDamageVarBoundsForTest` lock + the lvl-110/245 free-solve proofs already cover this var.
+
+### 1.4 — Boss-debuff: give phase 1 the full budget; run the heuristic AP-window phase on leftover only · **boss (Sram/Sadida)** · low/medium impact · **small effort**
+For confirmed-debuff classes, the wall-clock is split `searchDuration / activePhases` so phase 1 (the
+**provable** per-element enumeration) gets only 50 %. Restructure so phase 1 runs against the *full*
+`searchDuration` and proves if it can, then phase 2 runs only with `remaining = searchDuration − elapsed`
+(floored to the 1 s minimum). At the 20 s GUI default this doubles the provable phase's budget
+(10 s → 20 s) — meaningful in the borderline band where the proof completes within full duration but
+not within half.
+- **Code:** `MaxDamageSearch.kt:118-119` (`activePhases` / `phaseBudget`), the sequential phase producer
+  (≈151-214), `proven` at `:230`.
+- **Why optimum-safe:** phase 1 *is* the provable enumeration; raising its budget is the admissible
+  inverse of lowering it — feasible region, objective and candidate-element enumeration untouched, so
+  `phase1Optimal` can only flip true on more runs. Phase 2 only calls `consider()` and upgrades on a
+  **strict** improvement, reporting any such build as `improvedByDebuff ⇒ isOptimal=false /
+  maxDamageHeuristicPhases=true`; dropping it at high level always swaps **toward** the proven build and
+  makes `proven` *more* likely.
+- **Caveat (honest behavioral change):** a non-proven, honestly-labeled heuristic damage nudge may
+  disappear for some high-level debuff-class cases — flag this to the user, or keep a small phase-2 floor.
+  Tests use deterministic-time (they ignore the split), so they are unaffected. Scope: Sram/Sadida only,
+  production wall-clock path only.
+
+### 1.5 — Most-masteries: warm-start with a greedy admissible incumbent (`addHint`) · **most-masteries** · medium impact · medium effort
+Before solving, `addHint` the equipment booleans of a greedy incumbent that respects rarity/weapon/ring
+caps **and** trades off the soft AP/MP/range penalties. A strong early incumbent tightens the
+incumbent-vs-bound gap so the proof can close sooner on the ~72 s full-pool single-element default.
+- **Code:** `WakfuBuildSolver.kt` — after `model.maximize(objective)` (≈460) or in the solver setup
+  (`executeSolverAndEmitResults`, ≈1359); `equipVars` from `createEquipmentVariables` (`:656`).
+- **Why optimum-safe:** `addHint` is a pure **primal warm start** — by CP-SAT semantics it adds/removes/
+  reweights no feasible solution; partial hints are completed and infeasible ones silently repaired;
+  model + objective bytes are unchanged; `isOptimal` is keyed off the real status.
+- **Guards:** the only risk is **determinism** (it may change *which* tied-optimum build returns, or
+  shift proof completion under fixed det-time) → gate the hint **OFF** in the `SolverTuning`/test path,
+  and OFF when forced/excluded items or forced runes already shrink the pool. A max-mastery-only greedy
+  is likely too weak — it **must** weigh the soft penalties. **Measure** time-to-OPTIMAL before trusting
+  the medium-impact estimate (it must beat CP-SAT's own incumbents to be worth it).
+
+### 1.6 — Memoize `damageSpells(clazz)` and the build-independent throughput table per `(clazz, element)` · **single / bi / boss** · low impact · **small effort**
+`perTurnDamageScore` recomputes `SpellCatalog.damageSpells(clazz).filter { element }` +
+`baseThroughputTable(spells, MAX_ROTATION_AP)` on every model build. Both are pure functions of
+`(clazz, element)`. Memoize them — small for single-element, but removes the recompute across the
+**boss/bi-element probe batches** that rebuild the model N times in parallel.
+- **Code:** `SpellCatalog.kt:76` (`damageSpells`), `SpellRotation.kt:458` (`baseThroughputTable`);
+  consumer `WakfuBuildSolver.kt` `perTurnDamageScore` (≈2232, calls at ≈2240/2245).
+- **Why optimum-safe:** inputs are immutable `by lazy` globals; the cached array equals the recompute
+  element-for-element, so the model built from it is byte-identical (same feasible region, objective,
+  `OPTIMAL` status, enumeration exhaustiveness). The single consumer allocates a fresh `clampedTable` and
+  never mutates the cached array.
+- **Guards:** the **table** memo MUST include `maxAp` in its key (`baseThroughputTable` is also called
+  from `SpellRotation.kt` with other budgets) or be scoped to the fixed `MAX_ROTATION_AP` call site; the
+  `damageSpells` memo is `maxAp`-independent. Make both **thread-safe** (`ConcurrentHashMap` /
+  `computeIfAbsent`) — probes run in parallel.
+
+---
+
+## 2. Secondary / cleanup items
+
+- **Most-masteries: declare the objective product on its reachable bound** (`shared` lever, low/medium).
+  Replace the loose `±MASTERY_SCORE_ABS_MAX` guard on `masteryScore` and the `safeMultiply(...)≈1e14`
+  bound on the objective product with reachable bounds from `StatBuilder.tracker`. Only the single genuine
+  product `objective = coreScore × multiplier` benefits (the linear `masteryScore`'s own box is
+  LP-redundant), tightening that one McCormick envelope. **Same soundness** as 1.2/1.3 (a sound
+  over-estimate of the reachable range removes no feasible assignment). **Requires** a most-masteries
+  reachable-bound soundness test. ⚠️ The naïve `aLo*weight..aHi*weight` form is **UNSOUND** —
+  `scaledWeight` can be negative (no non-negativity clamp on CLI target weights), which inverts the
+  domain; any implementation must sort the two products via `min/max` and clamp the capped `lo` to
+  `min(., expected)`, exactly as the existing sign-agnostic `[-span,span]` / `[-span,expected]` code does.
+- **Make `warmUp()` structurally representative** (`shared`, low). `warmUp()` solves a throwaway 2-bool
+  model — it pays native load/JNI/worker spin-up but never JITs `buildModel` (StatBuilder, rune/sub
+  models, McCormick/linearization) or the scorers. Replace with a tiny but *structurally real* solve (a
+  few synthetic equipments across a couple `ItemType`s through `buildModel`, ideally one max-damage
+  objective pass), bounded by a short `maxTimeInSeconds` + the existing 2-worker cap, behind the loading
+  screen. **Optimum-safe:** `WakfuBuildSolver` is an `object` singleton but holds **no** solve-written
+  mutable state (all caches are per-call `StatBuilder` fields bound to one `CpModel`), so a synthetic
+  warm-up cannot pollute a later real search. **Guards:** use synthetic params, keep it bounded so the
+  loading screen doesn't lengthen, and add a test that the warm-up solve **actually completes** (a
+  swallowed failure yields zero benefit). Code: `WakfuBuildSolver.kt:164`.
+- **Let the CLI use all cores** (`shared`, low — marginal, sometimes negative under contention).
+  `numSearchWorkers` is `availableProcessors() − 1` to keep the GUI render thread responsive; the CLI has
+  no UI thread. The `WakfuBestBuildParams.solverWorkers` field already exists — thread the full count from
+  the CLI while the GUI keeps `cores−1`. **Optimum-safe:** worker count only sizes CP-SAT's cooperative
+  portfolio under the wall-clock bound; it removes no feasible solution and caps no dual bound.
+  ⚠️ **HAZARD:** `solverWorkers` is *also* live oversubscription control — `MaxDamageSearch.runProbeBatch`
+  (≈278, override at ≈302) re-derives per-probe workers so the test invariant
+  `concurrency × workersPerProbe ≤ host` holds. Set the field only at CLI param construction and do
+  **not** remove the per-probe override, or the boss/bi-element batch re-oversubscribes the CPU.
+  Code: `WakfuBuildSolver.kt:1397`; plumb from `autobuilder/Main.kt`.
+- **Collapse the ~16 per-`ItemType` `allEquips.filter` passes** in `addBuildValidityConstraints` into one
+  order-preserving `groupBy { itemType }` + a rarity `partition` (`shared`, microsecond-scale — do only as
+  a free cleanup when already touching this code). **Optimum-safe:** same item membership per group in
+  source order ⇒ byte-identical `addLessOrEqual` constraints. Keep `groupBy`/`partition` (not
+  `associateBy`/set regrouping) so equivalence is trivially reviewable. Code: `WakfuBuildSolver.kt:998`.
+
+---
+
+## 3. Cross-query result reuse ("a cache")
+
+The solver is **deterministic**: for a fixed model, a **proven-OPTIMAL** result is fully determined by
+its inputs. That makes caching *trivially* optimum-safe for exact matches — a cache hit returns the
+**same proven build** the solver would recompute, at zero solve cost. Three sound mechanisms, in
+descending hit-rate value:
+
+### 3.1 — Exact-match result cache (in-process, optionally on-disk)
+A `Map<QueryKey, GeneticAlgorithmResult>` consulted before solving; on a miss, solve and store **only if
+`isOptimal == true`**. Helps repeated identical searches in a session (re-runs, the default request) and,
+if persisted, across launches.
+- **Cache only proven results.** A FEASIBLE (timed-out, non-proven) result is run-dependent and a longer
+  search would beat it — caching it would freeze in a sub-optimal build. Store iff the final emit is
+  `isOptimal`.
+- **The `QueryKey` must canonically cover every input that determines the optimum** (and *exclude* the
+  ones that affect only time/feasibility). From `WakfuBestBuildParams`:
+  - **Include:** `character` (clazz, level, minLevel, skills config), normalized `targetStats`,
+    `scoreComputationMode`, `maxRarity`, `excludedRarities`, sorted `forcedItems` / `excludedItems`,
+    `useRunes` / `forcedRunes` / `forcedRunesByItem`, `useSublimations` / `forcedSublimations`,
+    `forcedPassives`, and (max-damage) the full `damageScenario` (element, boss resistances, role,
+    crit-cap, range band, …).
+  - **Exclude:** `searchDuration`, `stopWhenBuildMatch`, `solverWorkers`, `maxDamageApTarget` (an internal
+    probe param below the user-query cache boundary). These change time/parallelism/feasibility, not the
+    proven optimum.
+  - **Plus two version stamps:** `WakfuData.VERSION` (data bump ⇒ different items/values) **and a separate
+    `ENGINE_MODEL_VERSION`** you bump whenever the CP-SAT model, any objective, or any scorer changes.
+    Without the engine stamp, a stale cache would serve a build that is no longer optimal under the new
+    model — the single most important correctness guard for a persisted cache.
+  - **Canonicalize:** sort list/map inputs, use `TargetStats`' existing normalization (weights + the
+    `MASTERY_ELEMENTARY`/`RESISTANCE_ELEMENTARY` expansion) so equivalent queries hash equal.
+- **Tie note:** when several builds tie at the optimum, CP-SAT may return *a* different (equally optimal)
+  one across runs. A cache hit returning the stored optimum is still optimal — correctness holds. If
+  bit-for-bit reproducibility matters, tie-break deterministically before storing.
+- **Scope:** in-process is zero-risk and cheap (do first). On-disk (e.g. under
+  `~/Library/Caches/WakfuAutobuilder/`, keyed by the two version stamps) survives restarts.
+
+### 3.2 — Ship precomputed optima for common queries
+Precompute the proven-optimal builds for the **most-requested** queries (the GUI default request,
+popular class/level/element combos) at release time and bake them in as a resource keyed by the same
+`QueryKey`. Those queries then return **instantly and proven** on first launch — directly addresses the
+GUI's "misses the proven badge inside 20 s" case for the common path. Regenerate when either version
+stamp changes (wire it into `scripts/update-game-data.sh`). This is the most user-visible form of the
+"prefilled results everyone reuses" idea.
+
+### 3.3 — Neighbor builds as warm-start hints (the *only* sound "fuzzy" reuse)
+The query space is effectively continuous (arbitrary weights, forced/excluded lists), so exact-match
+hit-rate is mostly the default + repeats. You **cannot** return a *similar* query's build as this query's
+optimum — a neighbor's optimum is not this query's optimum. But a neighbor's solved build is an excellent
+**`addHint` seed**: look up the nearest cached build, hint it, and **still solve & prove fresh**. This
+turns "partial reuse" into a pure speedup that preserves the proof — and it is the same mechanism as
+§1.5. Determinism guards from §1.5 apply (gate off in the test/`SolverTuning` path).
+
+> **Unsound caching traps — do NOT do these:** returning a similar query's build as if it were this
+> query's optimum; caching FEASIBLE/timed-out results; omitting the `ENGINE_MODEL_VERSION` stamp.
+
+---
+
+## 4. Rejected as unsound — do **not** re-attempt
+
+Each *looked* like a speedup but provably drops or changes the optimal build:
+
+- **Prune objective-irrelevant equipment booleans** (per-slot single representative): UNSOUND — the model
+  reads more characteristics than the prefilter set (negative back/crit/berserk masteries in
+  `finalMasteryScore`; precision `negativeTargetPenalty`; and **decisively** sublimation
+  `reifyCondition`/conversion read whole-build DODGE/BLOCK/RANGE/AP/CRIT/secondary masteries from **any**
+  equipped item, including zero-socket ones), so pruning can flip an active sublimation and delete the
+  proven optimum non-monotonically.
+- **Symmetry-break duplicate rings via a lexicographic ordering cut:** UNSOUND — two different-named rings
+  carry different stat vectors and can be equipped together (RING cap = 2), so forcing `ring_a < ring_b`
+  forbids the optimal unordered pairing. (The "verify symmetry is on" variant is a no-op — `symmetry_level`
+  is on by default and never disabled.)
+- **Dominance-prune duplicate-stat items within a slot:** UNSOUND — ignores RING cap = 2 (different rings
+  co-equippable), the global ≤1 EPIC / ≤1 RELIC cross-slot resource caps, rune socket count, and
+  sub-carrier eligibility; `valueFor`-only dominance drops feasible optima. Also aimed at the
+  already-fast (≤3.5 s) single-element path.
+- **Implied upper-bound cuts on AP/MP/range from out-of-combat caps:** UNSOUND — caps are on the *pre-sub*
+  var; start-of-combat sublimations push combat AP above 16, and most-masteries' overshoot tie-breaker
+  *rewards* exceeding the target, so `min(16, …)` deletes feasible builds. There is also **no range cap**
+  in the model, so any range cut is invented. (The sound residue is just the existing reachable-domain
+  lever = §1.2/§2.)
+- **Warm-start each per-element/AP probe from the previous proven probe's solution:** UNSOUND in the
+  targeted-timeout regime (a wall-clock-bounded solve returns the best **feasible** incumbent, which a hint
+  changes) **and** mechanically wrong — `runProbeBatch` runs all probes via `awaitAll` (no wave boundary to
+  harvest from); serializing to seed would surrender the parallelism that is the current speedup.
+- **Build the element-independent model once and clone per probe (swap only the objective):** optimum-safe
+  but **not a bottleneck** — `buildModel` runs *inside* each probe's own coroutine fanned across cores, so
+  it removes ~one model-build (ms-to-low-seconds), dwarfed by the per-element solve; and replaying the
+  `DomainTracker` reachable-range state + cross-builder index sharing is a fragile provability footgun.
+- **Skip a candidate-element probe whose ceiling is "provably dominated":** UNSOUND — the upper bound is
+  built on the CP-SAT *proxy* objective, but the winner is re-scored by `sequencedScore` (real per-turn
+  damage / build-dependent penalty, maxed over all playable elements), a **different scale**; the dominance
+  test cannot bound the ranking the incumbent is actually selected by, so it can drop the element
+  containing the reported optimum.
+- **Skip the overshoot tie-breaker when `sum(weights)==0`:** non-bottleneck (fires only when a required
+  stat is requested with target/weight 0 — rare-to-never); and the guard would have to be `all { weight==0 }`,
+  not `sum==0`.
+- **Reuse the cached `actualStat` var in `negativeTargetPenalty`:** no-op — the dedup already exists (both
+  the cap and penalty paths share `actualCache.getOrPut(char)`).
+
+---
+
+## 5. Suggested order + testing requirements
+
+1. **§1.1 callback throttle** + **§1.3 AP-slice** + **§1.6 memo** — the optimum-safe-by-construction set;
+   land together behind one before/after benchmark (lvl-110 + lvl-245, single + boss).
+2. **§1.2 precision `tight=true`** — second change, ships with its **precision soundness-lock test** +
+   `tight==loose` equality test + a full-pool OPTIMAL-time benchmark.
+3. **§1.4 phase-1-full-budget** — boss-debuff classes; ships with the user-facing note about the heuristic
+   nudge possibly disappearing at high level.
+4. **§1.5 most-masteries warm-start** — only if the greedy (penalty-aware) provably beats CP-SAT's own
+   incumbents in a measured A/B; gate off in tests.
+5. **§3.1 in-process exact-match cache** → **§3.2 shipped common-query optima** → **§3.3 neighbor hints**.
+6. Cleanup items in §2 opportunistically.
+
+**Every domain-tightening change (§1.2, §1.3, §2 product bound) MUST ship with a reachable-bound
+soundness lock** for its mode — today's `maxDamageVarBoundsForTest` covers **only** the max-damage chain.
+**Every engine-affecting change MUST bump `ENGINE_MODEL_VERSION`** once a cache (§3) exists. Engine tests
+must keep using `SolverTuning` (fixed workers/seed/deterministic-time) or they flake on CI.
+
+---
+
+## Provenance
+
+Produced by a 30-agent audit (6 per-mode/area deep readers → adversarial per-candidate verification that
+each speedup provably preserves the optimum + proof → ranked synthesis), 2026-06-24. 13 candidates
+survived verification; 10 were rejected (§4). During the audit the repo advanced 1.7.0 → 1.8.0 (4 feature
+commits touching the solver); all six top picks were **re-verified against `main` @ 1.8.0** and remain
+valid and unaddressed. Related: `docs/MAX_DAMAGE_PROVABLE_OPTIMUM.md` (why max-damage is provable),
+`docs/FULL_DAMAGE_MODE_STATUS.md` (mode coverage), `AGENTS.md` §4 (engine overview).


### PR DESCRIPTION
Two solver changes, both **sound** (the proven optimum is never changed) and gated so they can't regress anything.

## 1. `perf:` per-slot domination pre-filter — **all solver modes**
Before solving, drop any equipment item that is *provably dominated* by another in the same slot, so CP-SAT solves a smaller model to the **identical proven optimum**. `A ≽ B` requires: `A ≥ B` on every characteristic **and** `A == B` on every stat a "dangerous" sublimation condition reads (so no conditional sub can flip); `A` costs no scarcer rarity budget (**an EPIC never dominates a non-epic** — keeping a weaker non-epic may be what frees the single epic slot for a stronger epic elsewhere); and `A ≥ B` sockets (a colour-agnostic count). A slot keeps an item unless ≥k others dominate it (k=2 for rings).

**Applies to all three modes** — max-damage, most-masteries, and precision — because each maximizes an objective that is **monotone non-decreasing in every characteristic** (more of any stat is never worse). precision *caps* at the target (`min(actual, target)`); most-masteries' penalty is shortfall-only with overshoot rewarded by a tie-breaker (not penalized — an earlier "penalizes overshoot" assumption was wrong); max-damage is `throughput × perHit`. most-masteries' product `masteryScore × penaltyMultiplier` is sound because the optimum always has `masteryScore ≥ 0` (the empty build already scores objective ≥ 0). **most-masteries is the slowest mode (~72 s on the full lvl-245 pool), so it benefits most.**

- **Pool reduction (deterministic): ~50–60% subs-off, ~13–22% subs-on (the default).**
- Applied only on the production path; deterministic tests keep the full pool, so existing tests are untouched.
- Locked by **7 tests** incl. the epic-budget counterexample and four `@slow` full-pool lvl-110 guards (filtered == full *proven* optimum) for max-damage (subs off and on), most-masteries, and precision.

**Honest caveat on speed:** the proof-time speedup is real in *direction* (smaller model; it removes item-booleans CP-SAT presolve can't drop) but its **magnitude is not reliably measurable on the dev host** — `deterministic_time` swings ~2.3× on an identical model across runs (thermally-throttled 8-worker scheduling), and `numBranches` is non-monotone. So this ships on **soundness + the deterministic pool reduction**, not on a measured "×". See [`docs/SOLVER_PERFORMANCE.md`](docs/SOLVER_PERFORMANCE.md) for the swap proof, the full measurement/reliability writeup, and the sound-but-not-worth-it refinements (e.g. the per-probe read-set variant) that were explored and rejected.

## 2. `fix:` progress-emission throttle + precision domain tests
- Throttle the OR-Tools best-so-far progress callback to ~one emission per 500 ms (each emission re-runs `solutionToBuild`+`scoreFor` on the native solve thread). The final proven build is still emitted unconditionally, so nothing is dropped — this just reduces solve-thread / render-thread contention (less GUI jank during a search).
- Declare the precision objective's stat chain on its reachable domains (`tight=true`) and lock it with a reachable-bound soundness probe + a `tight==loose` optimum-equality test.

## Tests
`./gradlew :autobuilder:test` green (122 fast tests); the heavy full-pool optimum-preservation guards run under `:autobuilder:slowTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)