### PR TITLE
feat: validate the search request up front and show all errors in a pop-up

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBestBuildFinderAlgorithm.kt
@@ -10,11 +10,13 @@ import me.chosante.autobuilder.domain.TargetStats
 import me.chosante.autobuilder.genetic.GeneticAlgorithmResult
 import me.chosante.common.Character
 import me.chosante.common.Equipment
+import me.chosante.common.I18nText
 import me.chosante.common.ItemType
 import me.chosante.common.Monster
 import me.chosante.common.Rarity
 import me.chosante.common.RuneType
 import me.chosante.common.Sublimation
+import me.chosante.common.SublimationRarity
 import kotlin.time.Duration
 
 object WakfuBestBuildFinderAlgorithm {
@@ -84,6 +86,10 @@ object WakfuBestBuildFinderAlgorithm {
     }
 
     fun run(params: WakfuBestBuildParams): Flow<GeneticAlgorithmResult<BuildCombination>> {
+        // Reject an invalid request (contradictory level bounds, a non-equippable forced item, or >1 epic/relic
+        // forced sublimation) BEFORE any work, reporting ALL problems at once. The GUI pre-validates with
+        // [validateRequest] and shows them in a pop-up; this throw is the CLI / safety floor. (ENG-1 / ENG-2)
+        validateRequest(params).let { if (it.isNotEmpty()) throw InvalidRequestException(it) }
         val equipmentsByItemType =
             groupAndFilterEquipments(
                 excludedItems = params.excludedItems,
@@ -152,7 +158,92 @@ object WakfuBestBuildFinderAlgorithm {
         }
         return equipmentsByItemType
     }
+
+    /**
+     * Validates a search request and returns ALL problems found (empty list = valid) so the GUI can show them
+     * together in one pop-up and the CLI can report them at once. Checks: contradictory level bounds; a forced
+     * item the character can't equip (level outside [minLevel, level] — PETS/MOUNTS exempt — or a rarity above
+     * [WakfuBestBuildParams.maxRarity] / in [WakfuBestBuildParams.excludedRarities]); and forcing more than one
+     * epic or relic sublimation (a build hosts at most one of each). A forced item/sub name that matches nothing
+     * is ignored (a typo can't be equipped). [allEquipments] / [allSublimations] are injectable for tests.
+     */
+    fun validateRequest(
+        params: WakfuBestBuildParams,
+        allEquipments: List<Equipment> = equipments,
+        allSublimations: List<Sublimation> = sublimations,
+    ): List<RequestValidationProblem> {
+        val problems = mutableListOf<RequestValidationProblem>()
+        val character = params.character
+
+        if (character.minLevel > character.level) {
+            problems += RequestValidationProblem.LevelRangeInvalid(character.minLevel, character.level)
+        }
+
+        for (forcedName in params.forcedItems.map { it.lowercase() }.toSet()) {
+            val matches = allEquipments.filter { it.name.fr.lowercase() == forcedName }
+            if (matches.isNotEmpty() && matches.none { it.isEquippableFor(params) }) {
+                problems += RequestValidationProblem.ForcedItemNotEquippable(matches.first(), character.minLevel, character.level)
+            }
+        }
+
+        if (params.forcedSublimations.isNotEmpty()) {
+            val forcedSubNames = params.forcedSublimations.map { it.lowercase() }.toSet()
+            val forcedSubs =
+                allSublimations.filter { it.name.fr.lowercase() in forcedSubNames || it.name.en.lowercase() in forcedSubNames }
+            for (rarity in listOf(SublimationRarity.EPIC, SublimationRarity.RELIC)) {
+                val ofRarity = forcedSubs.filter { it.rarity == rarity }
+                if (ofRarity.size > 1) {
+                    problems += RequestValidationProblem.ForcedSublimationRarityExceeded(rarity, ofRarity.map { it.name })
+                }
+            }
+        }
+
+        return problems
+    }
+
+    private fun Equipment.isEquippableFor(params: WakfuBestBuildParams): Boolean {
+        val rarityOk = rarity <= params.maxRarity && rarity !in params.excludedRarities
+        val levelOk =
+            itemType == ItemType.PETS ||
+                itemType == ItemType.MOUNTS ||
+                (level >= params.character.minLevel && level <= params.character.level)
+        return rarityOk && levelOk
+    }
 }
+
+/**
+ * A single problem with a search request, found by [WakfuBestBuildFinderAlgorithm.validateRequest]. Structured
+ * (not a pre-formatted string) so the GUI localizes each one and the CLI formats them in one go.
+ */
+sealed interface RequestValidationProblem {
+    /** The character's minimum level is above its level — no normal item fits the range. */
+    data class LevelRangeInvalid(
+        val minLevel: Int,
+        val characterLevel: Int,
+    ) : RequestValidationProblem
+
+    /** A forced [item] can't be equipped: level outside [minLevel, characterLevel] or a disallowed rarity. */
+    data class ForcedItemNotEquippable(
+        val item: Equipment,
+        val minLevel: Int,
+        val characterLevel: Int,
+    ) : RequestValidationProblem
+
+    /** More than one [rarity] (epic or relic) sublimation was forced; a build hosts at most one of each. */
+    data class ForcedSublimationRarityExceeded(
+        val rarity: SublimationRarity,
+        val sublimations: List<I18nText>,
+    ) : RequestValidationProblem
+}
+
+/**
+ * Thrown by [WakfuBestBuildFinderAlgorithm.run] when a request has one or more [problems]. The GUI pre-validates
+ * with [WakfuBestBuildFinderAlgorithm.validateRequest] and shows the problems in a pop-up, so it normally never
+ * reaches this; the throw is the CLI / safety floor.
+ */
+class InvalidRequestException(
+    val problems: List<RequestValidationProblem>,
+) : IllegalArgumentException("Invalid search request with ${problems.size} problem(s).")
 
 data class WakfuBestBuildParams(
     val character: Character,

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -445,6 +445,7 @@ object WakfuBuildSolver {
         // createRuneModel. The two no longer share a socket budget.
 
         model.addBuildValidityConstraints(allEquips, equipVars)
+        model.addForcedItemsEquippedConstraints(params, allEquips, equipVars)
 
         var maxDamageTracked: List<Triple<IntVar, String, LongRange>> = emptyList()
         val objective =
@@ -1069,6 +1070,31 @@ object WakfuBuildSolver {
                 val sumExpr = LinearExpr.sum(equips.map { equipVars.getValue(it) }.toTypedArray())
                 addLessOrEqual(sumExpr, 1L)
             }
+        }
+    }
+
+    /**
+     * Forces every user-imposed item ([WakfuBestBuildParams.forcedItems], matched on the French name) to be
+     * *equipped* — not merely "the only candidate in its slot". [WakfuBestBuildFinderAlgorithm.groupAndFilterEquipments]
+     * narrows a forced slot's pool down to the forced item, but the slot itself is still optional (`Σ ≤ 1`), so an
+     * imposed item that improves no requested stat would otherwise be left unequipped — reading as "forcing didn't
+     * work". Constraining `Σ(same-named) ≥ 1` makes "forcer un objet" mean the item is actually in the build.
+     *
+     * Matched per French name and gated on existence, so a typo'd / out-of-data forced name is a no-op (you cannot
+     * force a non-existent item). Two distinct items forced into the same single-occupancy slot is a contradictory
+     * request that makes the model infeasible (no build); surfacing a clear pre-search message for that is tracked
+     * separately (backlog ENG-2). Rings are forced per name and have two slots, so two forced rings both equip.
+     */
+    private fun CpModel.addForcedItemsEquippedConstraints(
+        params: WakfuBestBuildParams,
+        allEquips: List<Equipment>,
+        equipVars: Map<Equipment, IntVar>,
+    ) {
+        if (params.forcedItems.isEmpty()) return
+        for (forcedName in params.forcedItems.map { it.lowercase() }.toSet()) {
+            val sameName = allEquips.filter { it.name.fr.lowercase() == forcedName }
+            if (sameName.isEmpty()) continue
+            addGreaterOrEqual(LinearExpr.sum(sameName.map { equipVars.getValue(it) }.toTypedArray()), 1L)
         }
     }
 

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolverTest.kt
@@ -2943,6 +2943,174 @@ class WakfuBuildSolverTest {
         return results
     }
 
+    // ENG-1/ENG-2: a search request is validated up front, and validateRequest returns ALL problems at once so
+    // the GUI shows them together in a pop-up. An imposed item the character can't equip (level/rarity) replaces
+    // the old "Archiemblème" swap; >1 epic/relic forced sublimation replaces the misleading "no result".
+    // PETS/MOUNTS have no level requirement (eligibility-filter parity).
+    @Test
+    fun `validateRequest reports a forced item above the character level`() {
+        val level = 50
+        val character = Character(clazz = CharacterClass.CRA, level = level, minLevel = level, CharacterSkills(level))
+        val pool =
+            listOf(
+                equipment(id = 1, type = ItemType.EMBLEM, name = "Forced Emblem", stats = mapOf(Characteristic.MASTERY_MELEE to 50), level = 110, rarity = Rarity.LEGENDARY)
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = listOf("Forced Emblem")),
+                allEquipments = pool
+            )
+        assertThat(problems).hasSize(1)
+        assertThat(problems.single()).isInstanceOf(RequestValidationProblem.ForcedItemNotEquippable::class.java)
+    }
+
+    @Test
+    fun `validateRequest reports a forced item above the search max rarity`() {
+        val level = 110
+        val character = Character(clazz = CharacterClass.CRA, level = level, minLevel = 1, CharacterSkills(level))
+        val pool =
+            listOf(
+                equipment(id = 1, type = ItemType.AMULET, name = "Too Rare", stats = mapOf(Characteristic.MASTERY_MELEE to 50), level = 100, rarity = Rarity.EPIC)
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = listOf("Too Rare"), maxRarity = Rarity.RARE),
+                allEquipments = pool
+            )
+        assertThat(problems.filterIsInstance<RequestValidationProblem.ForcedItemNotEquippable>()).hasSize(1)
+    }
+
+    @Test
+    fun `validateRequest accepts an in-range forced item and a low-level forced mount`() {
+        val level = 110
+        val character = Character(clazz = CharacterClass.CRA, level = level, minLevel = 50, CharacterSkills(level))
+        val pool =
+            listOf(
+                equipment(id = 1, type = ItemType.AMULET, name = "In Range Amulet", stats = mapOf(Characteristic.MASTERY_MELEE to 50), level = 100, rarity = Rarity.LEGENDARY),
+                // A level-1 mount is equippable at any character level (PETS/MOUNTS are level-exempt).
+                equipment(id = 2, type = ItemType.MOUNTS, name = "Low Mount", stats = mapOf(Characteristic.MASTERY_ELEMENTARY to 40), level = 1, rarity = Rarity.RARE)
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = listOf("In Range Amulet", "Low Mount")),
+                allEquipments = pool
+            )
+        assertThat(problems).isEmpty()
+    }
+
+    @Test
+    fun `validateRequest reports forcing two epic sublimations`() {
+        val character = Character(CharacterClass.CRA, 50, 1, CharacterSkills(50))
+        val subs =
+            listOf(
+                sublimation(1, SublimationRarity.EPIC, SublimationKind.FLAT, "EpicA"),
+                sublimation(2, SublimationRarity.EPIC, SublimationKind.FLAT, "EpicB")
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = emptyList(), forcedSublimations = listOf("EpicA", "EpicB")),
+                allSublimations = subs
+            )
+        assertThat(problems.filterIsInstance<RequestValidationProblem.ForcedSublimationRarityExceeded>()).hasSize(1)
+    }
+
+    @Test
+    fun `validateRequest reports forcing two relic sublimations`() {
+        val character = Character(CharacterClass.CRA, 50, 1, CharacterSkills(50))
+        val subs =
+            listOf(
+                sublimation(1, SublimationRarity.RELIC, SublimationKind.FLAT, "RelicA"),
+                sublimation(2, SublimationRarity.RELIC, SublimationKind.FLAT, "RelicB")
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = emptyList(), forcedSublimations = listOf("RelicA", "RelicB")),
+                allSublimations = subs
+            )
+        assertThat(problems.filterIsInstance<RequestValidationProblem.ForcedSublimationRarityExceeded>()).hasSize(1)
+    }
+
+    @Test
+    fun `validateRequest accumulates several problems at once`() {
+        val character = Character(CharacterClass.CRA, 50, 1, CharacterSkills(50))
+        val pool =
+            listOf(
+                equipment(id = 1, type = ItemType.EMBLEM, name = "Forced Emblem", stats = mapOf(Characteristic.MASTERY_MELEE to 50), level = 110, rarity = Rarity.LEGENDARY)
+            )
+        val subs =
+            listOf(
+                sublimation(1, SublimationRarity.EPIC, SublimationKind.FLAT, "EpicA"),
+                sublimation(2, SublimationRarity.EPIC, SublimationKind.FLAT, "EpicB")
+            )
+        val problems =
+            WakfuBestBuildFinderAlgorithm.validateRequest(
+                forcedItemsParams(character, forced = listOf("Forced Emblem"), forcedSublimations = listOf("EpicA", "EpicB")),
+                allEquipments = pool,
+                allSublimations = subs
+            )
+        // Both problems reported together — the whole point of the errors pop-up.
+        assertThat(problems).hasSize(2)
+        assertThat(problems.any { it is RequestValidationProblem.ForcedItemNotEquippable }).isTrue
+        assertThat(problems.any { it is RequestValidationProblem.ForcedSublimationRarityExceeded }).isTrue
+    }
+
+    private fun forcedItemsParams(
+        character: Character,
+        forced: List<String>,
+        maxRarity: Rarity = Rarity.EPIC,
+        forcedSublimations: List<String> = emptyList(),
+    ): WakfuBestBuildParams =
+        WakfuBestBuildParams(
+            character = character,
+            targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_MELEE, 1))),
+            searchDuration = 2.seconds,
+            stopWhenBuildMatch = false,
+            maxRarity = maxRarity,
+            forcedItems = forced,
+            excludedItems = emptyList(),
+            forcedSublimations = forcedSublimations,
+            scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+        )
+
+    // ENG-1: "forcer un objet" must EQUIP the item, not merely make it the only candidate — even when a strictly
+    // better item exists in the same slot (here the un-narrowed pool keeps both, as the solver sees it).
+    @Test
+    fun `a forced item is equipped even when a better item exists in the same slot`(): Unit =
+        runBlocking {
+            val level = 1
+            val character =
+                Character(clazz = CharacterClass.CRA, level = level, minLevel = level, CharacterSkills(level))
+
+            val equipments =
+                listOf(
+                    equipment(id = 1, type = ItemType.AMULET, name = "Weak Amulet", stats = mapOf(Characteristic.MASTERY_MELEE to 10)),
+                    equipment(id = 2, type = ItemType.AMULET, name = "Strong Amulet", stats = mapOf(Characteristic.MASTERY_MELEE to 100))
+                )
+
+            val params =
+                WakfuBestBuildParams(
+                    character = character,
+                    targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_MELEE, 1))),
+                    searchDuration = 2.seconds,
+                    stopWhenBuildMatch = false,
+                    maxRarity = Rarity.EPIC,
+                    forcedItems = listOf("Weak Amulet"),
+                    excludedItems = emptyList(),
+                    scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT
+                )
+
+            val best =
+                WakfuBuildSolver
+                    .optimize(params, equipments.groupBy { it.itemType }, WakfuBuildSolver.SolverTuning())
+                    .toList()
+                    .maxByOrNull { it.matchPercentage }!!
+
+            val equippedNames = best.individual.equipments.map { it.name.fr }
+            assertThat(equippedNames).contains("Weak Amulet")
+            assertThat(equippedNames).doesNotContain("Strong Amulet")
+            assertThat(best.individual.isValid()).isTrue
+        }
+
     private fun equipment(
         id: Int,
         type: ItemType,

--- a/docs/beta-feedback-backlog.md
+++ b/docs/beta-feedback-backlog.md
@@ -43,10 +43,10 @@ chaque fiche est autonome (symptôme, cause racine, fichiers, plan, critères d'
 
 | ID | Titre | Type | Prio | Effort | Statut | Dépend / Conflits |
 |----|-------|------|------|--------|--------|-------------------|
-| **ENG-1** | Emblème imposé → Archiemblème (force-equip) | 🐞 | P0 | S | 🔲 TODO | — |
-| **ENG-2** | Forcer 2 sublis épique/relique = recherche « sans résultat » | 🐞 | P1 | M | 🔲 TODO | partage fichiers SUB-1 |
+| **ENG-1** | Validation requête + **pop-up listant toutes les erreurs** (item non équipable, force-equip) | 🐞 | P0 | M | ✅ `fix/eng-1-emblem-force-equip` | inclut ENG-2 ; → PICK-1/PICK-2 |
+| **ENG-2** | Forcer 2 sublis épique/relique = recherche « sans résultat » | 🐞 | P1 | M | ✅ **fusionné dans ENG-1** | voir ENG-1 |
 | **ENG-3** | Sublimations conditionnelles (croisées + forcée) | 🐞 | P2 | M | 🔲 TODO | re-baseline tests |
-| **RUNE-1** | Runes builder ≠ Zenith : expliciter « all gold » | 🐞 | P2 | S | 🔲 TODO | — |
+| **RUNE-1** | Runes builder ≠ Zenith : expliciter « all gold » | 🐞 | P2 | S | ✅ mergé (#181) | — |
 | **RUNE-2** | Badge « ×2 » rune doublée dans le picker | 🧹 | P3 | S | 🔲 TODO | REF-1/REF-2 (Modals) |
 | **RUNE-3** | Bouton « verrouiller les runes actuelles » | ✨ | P3 | S | 🔲 TODO | forçage par-item déjà fait |
 | **SUB-1** | Sublis : filtre/tri par rareté + couleur sur chips | ✨ | P2 | M | 🔲 TODO | REF-1/REF-2, ENG-2 |
@@ -54,10 +54,12 @@ chaque fiche est autonome (symptôme, cause racine, fichiers, plan, critères d'
 | **FLOW-1** | Charger un build dans un autre mode (comparer dégâts) | ✨ | P1 | M | 🔲 TODO | — |
 | **FLOW-2** | DI sélectionnable en mode max-maîtrises | ✨ | P2 | S | 🔲 TODO | 💬 décision prise |
 | **FLOW-3** | Avertir des points d'aptitude non distribués | 🧹 | P2 | S | 🔲 TODO | — |
+| **PICK-1** | Picker : checkbox « équipables uniquement » (cochée par défaut) | ✨ | P2 | M | 🔲 TODO | s'appuie sur REF-1 |
+| **PICK-2** | Nettoyer les forced hors-niveau au changement de niveau (garder excluded) | 🧹 | P2 | S | 🔲 TODO | sœur d'ENG-1 |
 | **REF-1** | Abstraction partagée des pickers add/suppr (corrige #3 partout) | 🏗️ | P1 | M | 🔲 TODO | base de RUNE-2/SUB-1 |
 | **REF-2** | Tri alphabétique localisé de TOUTES les modales catalogue | 🏗️ | P2 | M | 🔲 TODO | base de SUB-1, hotspot Modals |
 | **QOL-1** | Tooltip sur libellés de stats cibles tronqués | 🧹 | P3 | S | 🔲 TODO | — |
-| **QOL-2** | Durée vide → 10 minutes | 🧹 | P2 | S | 🔲 TODO | — |
+| **QOL-2** | Durée vide → 10 minutes | 🧹 | P2 | S | ✅ mergé (#182) | — |
 | **I18N-1** | Sublis/passifs en EN sous UI FR | 🔵 | — | — | 🔵 Déjà fait (1.8.0) | résidu effect-text |
 | **CLAR-*** | Clarifications / non-bugs | 💬 | — | — | 💬 | voir section |
 
@@ -79,8 +81,8 @@ chaque fiche est autonome (symptôme, cause racine, fichiers, plan, critères d'
 
 # A. Moteur — correctness (bugs)
 
-## ENG-1 — Emblème imposé renvoie un Archiemblème  🐞 P0 · Effort S
-**Statut : 🔲 TODO**
+## ENG-1 — Validation de requête + pop-up d'erreurs (inclut ENG-2)  🐞 P0 · Effort M
+**Statut : ✅ Implémenté — branche `fix/eng-1-emblem-force-equip`** · **💬 Décisions (24/06) : rejeter (pas équiper) + pop-up listant TOUTES les erreurs.**
 
 **Symptôme (testeur).** « Imposer un emblème n'a pas l'air de fonctionner. J'ai *Emblème de Frigost I* en
 imposé mais il me met *Archiemblème de Craqnoix*, et quand enlevé *Archiemblème des Racines*. Pour les
@@ -108,28 +110,69 @@ filtré** ; le solveur choisit alors n'importe quel Archiemblème dans la fourch
   les imposés ; à re-vérifier après fix).
 - `common-lib/.../Equipment.kt:22` — `EMBLEM(646)` partagé emblèmes + Archiemblèmes.
 
-**Plan.**
-1. **Exempter les imposés des filtres qui les supprimeraient** : OR-er les prédicats des filtres rareté
-   (`:126`) et niveau (`:127-129`) avec `equipment.name.fr.lowercase() in itemsToForce`. (Garder le filtre
-   d'exclusion `:130` — un item à la fois imposé ET exclu est contradictoire ; le laisser exclu ou en faire
-   une erreur explicite.) Garantit que l'emblème imposé atteint le narrowing `:140-146`.
-2. **Belt-and-suspenders (recommandé)** : ajouter une vraie contrainte *force-equip* dans
-   `addBuildValidityConstraints` — pour chaque item imposé présent, `addEquality(equipVar, 1)`
-   (pour RING : `≥ 1` sur les deux vars d'anneaux de même nom, pas `== 1` par var). « Forcer » = « doit être
-   équipé », pas seulement « seul candidat ». Corrige aussi le cas silencieux où un slot est laissé vide
-   parce que l'item imposé n'aide aucune maîtrise demandée.
+**Solution implémentée (consolide ENG-1 + ENG-2).** Un item imposé hors niveau est **impossible à équiper en
+jeu** → on le **refuse** (pas équiper). Et l'ancien affichage (un `ErrorBanner` enfoui dans le panneau de droite,
+une seule erreur) n'était **pas clair** → remplacé par une **pop-up listant TOUTES les erreurs** au moment de la
+recherche.
+1. **Validation agrégée (moteur)** — `WakfuBestBuildFinderAlgorithm.validateRequest(params): List<RequestValidationProblem>`
+   retourne **tous** les problèmes d'un coup : bornes de niveau incohérentes (`minLevel > level`), item imposé non
+   équipable (niveau hors `[minLevel, level]` — **PETS/MOUNTS exemptés** — ou rareté > `maxRarity` / exclue), et
+   **> 1 sublimation épique ou relique imposée** (ex-ENG-2). `run()` lève `InvalidRequestException(problems)` si
+   non vide (plancher CLI). Un nom imposé qui ne matche rien = ignoré.
+2. **Force-equip conservé** — `WakfuBuildSolver.addForcedItemsEquippedConstraints` (`Σ même-nom ≥ 1`) : un item
+   imposé **éligible** est bien **équipé**. RING géré par nom (2 slots → 2 anneaux ok).
+3. **Pop-up GUI** — `BuildSearchModel.search()` appelle `validateRequest` avant de lancer ; si problèmes →
+   `UiState.requestErrors` → **`RequestErrorsDialog`** (modèle `WhatsNewDialog` : `Scrim`+`ModalCard`+`DialogButton`)
+   liste chaque problème **localisé** (item/sublis nommés) ; bloque la recherche. `dismissRequestErrors()` ferme.
 
-**Critères d'acceptation.**
-- Forcer un emblème de niveau hors fenêtre (ex. emblème lvl 110 avec `level` < 110) → ce **même** emblème est
-  équipé, pas un Archiemblème.
-- Forcer 2 emblèmes (même slot) ou un item violant 1-EPIC/1-RELIC → **message clair** (pas un modèle infaisable
-  muet, pas « aucun résultat »).
-- Test de non-régression dans `WakfuBuildSolverTest` : impose un emblème hors fenêtre, assert l'emblème exact.
+**Fichiers touchés.** `WakfuBestBuildFinderAlgorithm.kt` (`validateRequest` + `RequestValidationProblem` +
+`InvalidRequestException`), `WakfuBuildSolver.kt` (force-equip), `UiState.kt` (`requestErrors`),
+`BuildSearchModel.kt` (pré-validation + `dismissRequestErrors`), `components/RequestErrorsDialog.kt` (nouveau),
+`Main.kt` (montage), `I18n.kt` (Tr), `WakfuBuildSolverTest.kt` (tests `validateRequest`).
 
-**Risques.** (1) Exempter du filtre niveau → un emblème très hors-niveau sera désormais équipé : confirmer que
-c'est bien la sémantique « force = force » (sinon avertissement type `LEVEL_RANGE_INVALID`). (2) La contrainte
-force-equip peut rendre le modèle **infaisable** (2 imposés même slot, conflits rareté/arme) → valider en amont
-et afficher une erreur lisible. (3) RING = 2 slots, cap même-nom → forçage `≥ 1`.
+**Tests (verts).** Rejet hors-niveau / hors-rareté ; in-range + monture lvl 1 OK ; 2 épiques / 2 reliques
+rejetées ; **agrégation de plusieurs problèmes à la fois** ; item imposé équipé devant un rival meilleur.
+`:autobuilder:test` = 67 tests, 0 échec ; `:gui-compose:compileKotlin` OK.
+
+**Suite = prévention côté GUI (nouveaux tickets).** **PICK-1** (filtre « équipables » coché par défaut) empêche
+de choisir un item hors niveau ; **PICK-2** nettoie les forced devenus invalides au changement de niveau. Le cas
+« 2 imposés dans un slot à 1 place » : à ajouter à `validateRequest` (même pop-up) — TODO.
+
+---
+
+## PICK-1 — Picker « équipables uniquement » (coché par défaut)  ✨ P2 · Effort M
+**Statut : 🔲 TODO** · *(prévention GUI issue d'ENG-1 ; à implémenter dans REF-1)*
+
+**Origine.** Décision dev (24/06) : « une checkbox cochée par défaut pour n'afficher que les items possibles à
+équiper pour le build, sinon c'est la porte ouverte à n'importe quoi. »
+
+**État actuel.** Le picker d'items liste **tout le catalogue** (`equipmentCatalog` =
+`WakfuBestBuildFinderAlgorithm.equipments`, non filtré) — tous niveaux, toutes raretés. C'est ce qui laisse
+forcer un item injouable (cf. ENG-1).
+
+**Plan.** Checkbox « équipables uniquement » (**cochée par défaut**) filtrant sur le **pool éligible du moteur**
+(décision retenue : niveau dans `[minLevel, level]` — PETS/MOUNTS exemptés — ET rareté ≤ `maxRarity` / non
+exclue). Réutiliser la même éligibilité que `validateForcedItemsEquippable` (ENG-1) pour rester cohérent.
+À faire **dans REF-1** (abstraction partagée des pickers) pour couvrir tous les pickers d'items. `Tr` EN/FR.
+
+**Critères.** Par défaut le picker ne montre que les items équipables pour le build courant ; décocher montre
+tout ; changer niveau/rareté recompute la liste.
+
+---
+
+## PICK-2 — Nettoyer les forced hors-niveau au changement de niveau  🧹 P2 · Effort S
+**Statut : 🔲 TODO** · *(sœur d'ENG-1)*
+
+**Origine.** Décision dev (24/06) : « si jamais il change de level sur un build, il faut virer dans les forced
+les items qui n'ont plus de sens (on peut garder les excluded). »
+
+**Plan.** Quand `level`/`minLevel`/`maxRarity`/raretés exclues changent dans `BuildSearchModel`, retirer de
+`forcedItems` les items devenus **non éligibles** (même test que `validateForcedItemsEquippable`) + toast « N
+objet(s) imposé(s) retiré(s) — hors niveau ». **Garder `excludedItems`** (exclure un item hors niveau est
+inoffensif). Évite d'attendre le rejet d'ENG-1 au moment de la recherche.
+
+**Critères.** Baisser le niveau sous celui d'un item imposé le retire automatiquement des forced (+ toast) ; les
+excluded restent intacts.
 
 ---
 

--- a/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
+import me.chosante.ui.components.RequestErrorsDialog
 import me.chosante.ui.components.WhatsNewDialog
 import me.chosante.ui.components.loadClasspathBitmap
 import me.chosante.ui.i18n.LocalLang
@@ -209,6 +210,14 @@ fun App(model: BuildSearchModel) {
                             WhatsNew.markSeen()
                             showWhatsNew = false
                         }
+                    )
+                }
+                // Pre-search request errors, over the shell: lists every problem so the user fixes them
+                // before searching (set by BuildSearchModel.search -> UiState.requestErrors).
+                if (model.ui.requestErrors.isNotEmpty()) {
+                    RequestErrorsDialog(
+                        problems = model.ui.requestErrors,
+                        onDismiss = { model.dismissRequestErrors() }
                     )
                 }
             }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/RequestErrorsDialog.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/RequestErrorsDialog.kt
@@ -1,0 +1,91 @@
+package me.chosante.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import me.chosante.autobuilder.genetic.wakfu.RequestValidationProblem
+import me.chosante.ui.i18n.Lang
+import me.chosante.ui.i18n.LocalLang
+import me.chosante.ui.i18n.Tr
+import me.chosante.ui.i18n.tr
+import me.chosante.ui.theme.WColor
+import me.chosante.ui.theme.WDimens
+import me.chosante.ui.theme.WTypography
+
+/**
+ * Pre-search validation pop-up: lists EVERY problem with the current request (a non-equippable forced item,
+ * more than one epic/relic forced sublimation, contradictory level bounds) so the user fixes them before
+ * searching — instead of a single error buried in the results-panel banner. Driven by
+ * [me.chosante.ui.state.UiState.requestErrors]; dismissed via [me.chosante.ui.state.BuildSearchModel.dismissRequestErrors].
+ */
+@Composable
+fun RequestErrorsDialog(
+    problems: List<RequestValidationProblem>,
+    onDismiss: () -> Unit,
+) {
+    val lang = LocalLang.current
+    Scrim(onDismiss = onDismiss) {
+        ModalCard(title = tr(Tr.REQUEST_ERRORS_TITLE)) {
+            Text(
+                text = tr(Tr.REQUEST_ERRORS_INTRO),
+                style = WTypography.bodyMedium.copy(color = WColor.muted)
+            )
+            Spacer(modifier = Modifier.height(WDimens.gap))
+            Column(
+                modifier =
+                    Modifier
+                        .heightIn(max = 360.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                problems.forEach { problem ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+                        Text(
+                            text = "•",
+                            style = WTypography.bodyMedium.copy(color = WColor.danger)
+                        )
+                        Text(
+                            text = problem.localizedMessage(lang),
+                            style = WTypography.bodyMedium.copy(color = WColor.text, lineHeight = 19.sp),
+                            modifier = Modifier.padding(top = 1.dp)
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(WDimens.gap))
+            DialogButton(
+                text = tr(Tr.REQUEST_ERRORS_DISMISS),
+                filled = true,
+                color = WColor.accent,
+                onClick = onDismiss,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+/** Localized one-line message for a single request problem; named items/sublimations are interpolated. */
+internal fun RequestValidationProblem.localizedMessage(lang: Lang): String =
+    when (this) {
+        is RequestValidationProblem.LevelRangeInvalid -> Tr.LEVEL_RANGE_INVALID.value(lang)
+        is RequestValidationProblem.ForcedItemNotEquippable -> {
+            val name = if (lang == Lang.FR) item.name.fr else item.name.en
+            "$name ${Tr.FORCED_ITEM_NOT_EQUIPPABLE.value(lang)}"
+        }
+        is RequestValidationProblem.ForcedSublimationRarityExceeded -> {
+            val names = sublimations.joinToString { if (lang == Lang.FR) it.fr else it.en }
+            "${Tr.FORCED_SUBLIMATION_RARITY_INVALID.value(lang)} $names"
+        }
+    }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -35,6 +35,26 @@ enum class Tr(
         "Min level can't be higher than the character level. Lower the min, or raise the level.",
         "Le niveau min ne peut pas dépasser le niveau du personnage. Baisse le min, ou augmente le niveau."
     ),
+    FORCED_ITEM_NOT_EQUIPPABLE(
+        "can't be equipped for this build — its level or rarity is outside the search.",
+        "n'est pas équipable pour ce build — son niveau ou sa rareté est hors de la recherche."
+    ),
+    FORCED_SUBLIMATION_RARITY_INVALID(
+        "Only one epic and one relic sublimation can be forced — remove one of:",
+        "Tu ne peux imposer qu'une sublimation épique et une relique — retire l'une de :"
+    ),
+    REQUEST_ERRORS_TITLE(
+        "Can't search yet",
+        "Recherche impossible"
+    ),
+    REQUEST_ERRORS_INTRO(
+        "Fix these before searching:",
+        "Corrige ces points avant de lancer la recherche :"
+    ),
+    REQUEST_ERRORS_DISMISS(
+        "Got it",
+        "Compris"
+    ),
     PROGRESS("Progress", "Progression"),
     PRELOAD_WARMUP("Starting the engine…", "Démarrage du moteur…"),
     MATCH("Match", "Correspondance"),

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -685,14 +685,6 @@ class BuildSearchModel(
     fun search() {
         job?.cancel()
         val snapshot = ui
-        // Contradictory level bounds (min above the character level) match no normal item — the
-        // engine keeps items with minLevel <= itemLevel <= level — so the solver would fall back to
-        // the only level-agnostic slots (pets/mounts) and surface a near-empty nonsense build. Fail
-        // fast with a clear, visible error instead of silently coercing the bounds and searching.
-        if (snapshot.minLevel > snapshot.level) {
-            ui = snapshot.copy(error = Tr.LEVEL_RANGE_INVALID.value(snapshot.lang))
-            return
-        }
         val character = Character(snapshot.clazz, snapshot.level, snapshot.minLevel)
         val targetStats = snapshot.toTargetStats()
         // A targeted boss overlays its per-element resistances onto the manual scenario (mirrors the CLI):
@@ -727,6 +719,14 @@ class BuildSearchModel(
                 damageScenario = damageScenario
             )
 
+        // Validate the whole request up front and surface ALL problems together in a pop-up
+        // (UiState.requestErrors) instead of throwing on the first and burying it in the results-panel banner.
+        val requestProblems = WakfuBestBuildFinderAlgorithm.validateRequest(params)
+        if (requestProblems.isNotEmpty()) {
+            ui = snapshot.copy(requestErrors = requestProblems)
+            return
+        }
+
         ui =
             snapshot.copy(
                 phase = Phase.Searching,
@@ -741,7 +741,8 @@ class BuildSearchModel(
                 zenith = ZenithState.Idle,
                 zenithUrl = null,
                 toast = null,
-                error = null
+                error = null,
+                requestErrors = emptyList()
             )
         job =
             scope.launch(Dispatchers.Default) {
@@ -884,7 +885,9 @@ class BuildSearchModel(
                 } catch (throwable: Throwable) {
                     // Catch Throwable (not just Exception): the solver can raise fatal Errors
                     // (e.g. native-access / linkage issues) that would otherwise crash the event
-                    // thread with a masked coroutines error instead of surfacing here.
+                    // thread with a masked coroutines error instead of surfacing here. Request-validation
+                    // problems are caught BEFORE the search starts (see validateRequest above), so they
+                    // don't reach here.
                     throwable.printStackTrace()
                     val message = throwable.message ?: throwable::class.qualifiedName ?: "Search failed"
                     withContext(mainDispatcher) {
@@ -900,6 +903,11 @@ class BuildSearchModel(
         job?.cancel()
         job = null
         ui = ui.copy(phase = Phase.Idle, progress = 0)
+    }
+
+    /** Dismisses the pre-search request-errors pop-up ([UiState.requestErrors]). */
+    fun dismissRequestErrors() {
+        ui = ui.copy(requestErrors = emptyList())
     }
 
     fun openZenithBuild() {

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/UiState.kt
@@ -6,6 +6,7 @@ import me.chosante.autobuilder.domain.DamageScenario
 import me.chosante.autobuilder.domain.ScenarioDamage
 import me.chosante.autobuilder.domain.SpellElement
 import me.chosante.autobuilder.domain.SpellRotation
+import me.chosante.autobuilder.genetic.wakfu.RequestValidationProblem
 import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
 import me.chosante.autobuilder.genetic.wakfu.isMaximizableMastery
 import me.chosante.autobuilder.genetic.wakfu.isRandomElementStat
@@ -216,6 +217,8 @@ data class UiState(
     val zenithUrl: String? = null,
     val toast: String? = null,
     val error: String? = null,
+    /** Pre-search request problems shown together in the errors pop-up; non-empty blocks the search. */
+    val requestErrors: List<RequestValidationProblem> = emptyList(),
     val modal: Modal? = null,
     // --- Build history / comparison ---
     val screen: Screen = Screen.Builder,

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/BuildSearchModelE2ETest.kt
@@ -14,6 +14,7 @@ import me.chosante.autobuilder.domain.BuildCombination
 import me.chosante.autobuilder.domain.TargetStat
 import me.chosante.autobuilder.domain.TargetStats
 import me.chosante.autobuilder.genetic.GeneticAlgorithmResult
+import me.chosante.autobuilder.genetic.wakfu.RequestValidationProblem
 import me.chosante.autobuilder.genetic.wakfu.ScoreComputationMode
 import me.chosante.autobuilder.genetic.wakfu.WakfuBestBuildFinderAlgorithm
 import me.chosante.autobuilder.genetic.wakfu.WakfuBestBuildParams
@@ -36,7 +37,6 @@ import me.chosante.common.history.TargetSnapshot
 import me.chosante.common.skills.CharacterSkills
 import me.chosante.ui.history.HistoryRepository
 import me.chosante.ui.i18n.Lang
-import me.chosante.ui.i18n.Tr
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -354,10 +354,12 @@ class BuildSearchModelE2ETest {
 
             model.search()
 
-            // The solver is never invoked, and a clear localized error is surfaced instead of the
-            // engine silently returning a near-empty pets/mounts-only build.
+            // The solver is never invoked; the impossible level range is reported as a request problem in the
+            // errors pop-up (UiState.requestErrors), not the results-panel banner, instead of the engine
+            // silently returning a near-empty pets/mounts-only build.
             assertEquals(0, solverInvocations)
-            assertEquals(Tr.LEVEL_RANGE_INVALID.value(Lang.EN), model.ui.error)
+            assertEquals(1, model.ui.requestErrors.size)
+            assertTrue(model.ui.requestErrors.single() is RequestValidationProblem.LevelRangeInvalid)
             assertEquals(Phase.Idle, model.ui.phase)
             assertNull(model.ui.build)
         } finally {


### PR DESCRIPTION
## What
A search request is now validated **up front** and **all** problems are shown together in a pop-up when the user clicks Search — instead of a single message buried in the right-hand results-panel banner.

`WakfuBestBuildFinderAlgorithm.validateRequest(params)` returns every problem (`RequestValidationProblem`):
- a forced item the character can't equip (level outside `[minLevel, level]` — PETS/MOUNTS stay level-exempt — or a disallowed rarity),
- more than one epic/relic forced sublimation (a build hosts ≤1 of each),
- contradictory level bounds (`minLevel > level`).

`run()` throws `InvalidRequestException(problems)` as the CLI / safety floor. An **eligible** forced item is still guaranteed equipped (force-equip constraint), so "forcer un objet" never silently leaves the slot empty. The GUI pre-validates in `search()` and shows `RequestErrorsDialog` (localized EN/FR), blocking the search until fixed.

## Why
Forcing an item the character can't equip produced an in-game-impossible build, and — because forcing only narrows a slot's pool — a forced item dropped by the level filter let the solver equip a *different* item (the "forced emblem → Archiemblème" bug a beta tester hit). Forcing two epic/relic sublimations made the model infeasible, surfacing as a misleading "no result". Both were shown only in an easy-to-miss banner.

Consolidates backlog tickets **ENG-1 + ENG-2**. Also introduces the beta-feedback backlog doc (`docs/beta-feedback-backlog.md`).

## Test plan
- `./gradlew :autobuilder:test` — 67 tests, 0 failures (forced item above level / above max rarity reported; in-range item + level-1 mount accepted; two epic / two relic subs reported; multiple problems accumulated at once; forced item equipped over a better rival).
- `./gradlew :gui-compose:compileKotlin` — OK.
- Pop-up verified manually in the running app (Min>Niv, out-of-level forced item, 2 epic subs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
