### PR TITLE
feat: surface the "all gold" rune assumption next to the Zenith actions

### DIFF
--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -151,6 +151,10 @@ enum class Tr(
         "Runes are pinned per item — hover a slot in the build and click ◈.",
         "Les runes se définissent par objet — survole un emplacement du build et clique sur ◈."
     ),
+    RUNES_ALLGOLD_HINT(
+        "Runes are shown \"all gold\": best stat, max level, socket colours assumed re-rolled. The Zenith link can differ (real socket colours aren't re-rolled).",
+        "Runes affichées en « tout doré » : meilleure stat, niveau max, couleurs d'emplacements supposées re-roll. Le lien Zenith peut différer (les vraies couleurs ne sont pas re-roll)."
+    ),
 
     // Paperdoll
     PREPARING_OR_TOOLS_MODEL("Preparing OR-Tools model", "Préparation du modèle OR-Tools"),

--- a/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/stats/StatsPanel.kt
@@ -925,6 +925,20 @@ private fun ActionsCard(
                 modifier = Modifier.padding(top = 8.dp)
             )
         }
+        // Runes are an optimistic "all gold" best-in-slot model (best stat, max level, socket colours assumed
+        // re-rolled), so the opened Zenith build can legitimately show different colours/levels. Make it explicit
+        // here, next to the Zenith actions, rather than leaving the difference a surprise. (RUNE-1)
+        if (ui.build
+                ?.runes
+                ?.values
+                ?.any { it.isNotEmpty() } == true
+        ) {
+            Text(
+                text = tr(Tr.RUNES_ALLGOLD_HINT),
+                style = WTypography.labelSmall.copy(color = WColor.muted, lineHeight = 15.sp),
+                modifier = Modifier.padding(top = 10.dp)
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## What
A short localized note (EN/FR) under the Zenith open/copy actions, shown when the build carries runes:

> Runes are shown "all gold": best stat, max level, socket colours assumed re-rolled. The Zenith link can differ (real socket colours aren't re-rolled).

## Why
The builder models runes optimistically — best stat, max level, socket colours assumed re-rolled ("all gold") — so the same build opened on zenithwakfu.com can legitimately show different rune colours/levels (Zenith doesn't re-roll the real socket colours). A beta tester read that mismatch (and "+1000 critical mastery but 1% crit") as a bug. This makes the assumption explicit so the difference is expected. No change to which rune is exported.

Backlog ticket **RUNE-1**.

## Test plan
- `./gradlew :gui-compose:compileKotlin` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
