### PR TITLE
fix: a blank search duration now means 10 minutes, not 20 seconds

### DIFF
--- a/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/i18n/I18n.kt
@@ -116,7 +116,7 @@ enum class Tr(
     RARITIES("Rarities", "Raretés"),
     RARITIES_SUB("tap to allow / exclude", "clic pour autoriser / exclure"),
     SEARCH_DURATION("Search duration", "Durée de recherche"),
-    SEARCH_DURATION_SUB("time budget for the solver", "temps alloué au solveur"),
+    SEARCH_DURATION_SUB("time budget for the solver (empty = 10 min)", "temps alloué au solveur (vide = 10 min)"),
     SECONDS_SHORT("sec", "sec"),
     STOP_AT_MATCH("Stop at 100% match", "Arrêter à 100%"),
     SEARCH_NO_RESULT(

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/BuildSearchModel.kt
@@ -708,7 +708,10 @@ class BuildSearchModel(
             WakfuBestBuildParams(
                 character = character,
                 targetStats = targetStats,
-                searchDuration = (snapshot.duration.toIntOrNull() ?: 20).coerceAtLeast(1).seconds,
+                // Blank duration = the longest sensible run (10 min). Kept finite on purpose: an unbounded
+                // budget would make the time-driven progress bar meaningless and risk a search that never
+                // returns on a hard input. (QOL-2)
+                searchDuration = (snapshot.duration.toIntOrNull() ?: 600).coerceAtLeast(1).seconds,
                 // "Stop at 100% match" only applies to precision mode (the only mode with an exact target);
                 // ignore a stale toggle when searching in most-masteries / max-damage.
                 stopWhenBuildMatch = snapshot.stopAtMatch && snapshot.mode == ScoreComputationMode.FIND_CLOSEST_BUILD_FROM_INPUT,


### PR DESCRIPTION
## What
A blank search-duration field now defaults to **600 s (10 min)** instead of 20 s, and the field sublabel says so ("empty = 10 min" / "vide = 10 min").

## Why
Leaving the duration empty fell back to a hard-coded 20 s — far too short to prove an optimum on most inputs, and surprising (the tester expected "run until done"). Kept finite on purpose: an unbounded budget would make the time-driven progress bar meaningless and risk never returning on a hard input.

Backlog ticket **QOL-2**.

## Test plan
- `./gradlew :gui-compose:compileKotlin` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
