### PR TITLE
fix: Zenith export — whitened runes, tier-correct sublimation levels, epic/relic slots

### DIFF
--- a/zenith-builder/src/main/kotlin/me/chosante/ZenithBuilder.kt
+++ b/zenith-builder/src/main/kotlin/me/chosante/ZenithBuilder.kt
@@ -9,6 +9,7 @@ import me.chosante.common.Equipment
 import me.chosante.common.ItemType
 import me.chosante.common.RuneType
 import me.chosante.common.Sublimation
+import me.chosante.common.SublimationRarity
 import kotlin.time.Duration.Companion.seconds
 
 internal const val BASE_API_URL = "https://api.zenithwakfu.com/builder/api"
@@ -29,12 +30,17 @@ data class ZenithInputParameters(
     val sublimations: Map<Equipment, List<Sublimation>> = emptyMap(),
 )
 
-/** One planned `/shard/add` call: a rune (with a [level]) or a sublimation ([level] = null). */
+/**
+ * One planned `/shard/add` call: a rune (with a [level], [whiten] = true) or a sublimation
+ * ([level] = null — Zenith ignores the parameter for subs; the shard id's intrinsic level is the
+ * socketed level, so the id must already be the tier-resolved family member).
+ */
 internal data class PlannedShard(
     val shardId: Int,
     val position: Int,
     val side: Int,
     val level: Int?,
+    val whiten: Boolean = false,
 )
 
 /**
@@ -62,36 +68,61 @@ internal fun sideAssignments(equipments: List<Equipment>): List<Pair<Equipment, 
 
 /**
  * The shards to socket on [equipment]: its [runes] first (positions `0..n-1`, each at the level its
- * carrier's item level allows), then its [subs] (positions `n..`, `level = null` — sublimations socket
- * like runes on Zenith but carry no level). Positions never collide because the subs start after the runes.
+ * carrier's item level allows and flagged for whitening — see [whitenShard]), then its [subs]
+ * (positions `n..`, `level = null`). Positions never collide because the subs start after the runes.
  *
  * A CUMULABLE sublimation stacked across several carriers appears once in EACH carrier's [subs] list, so it
  * yields one call per carrier — same `id_shard`, different `side`. That is exactly how the game sockets it
  * (one copy per ≥3-socket item), and nothing here dedupes by shard id.
  *
- * (Epic/relic subs have no socket colour pattern — their position is best-effort; verify on the live builder.)
+ * [subShardId] maps a sublimation to the Zenith shard id actually socketed — the tier-resolved family
+ * member (see [fetchSublimationLevelIds]); the default keeps the raw `zenithId` (family root, level 1).
+ *
+ * EPIC/RELIC subs live in the build's dedicated character slots on Zenith, not on an item: the UI posts
+ * them with `side = 0, position = 0`, so the export does too (the server routes them by the shard's
+ * own epic/relic flag).
  */
 internal fun plannedShards(
     equipment: Equipment,
     side: Int,
     runes: List<RuneType>,
     subs: List<Sublimation>,
+    subShardId: (Sublimation) -> Int = { it.zenithId },
 ): List<PlannedShard> =
-    runes.mapIndexed { index, rune -> PlannedShard(rune.id, index, side, rune.maxLevel(equipment.level)) } +
-        subs.mapIndexed { index, sub -> PlannedShard(sub.zenithId, runes.size + index, side, null) }
+    runes.mapIndexed { index, rune -> PlannedShard(rune.id, index, side, rune.maxLevel(equipment.level), whiten = true) } +
+        subs.mapIndexed { index, sub ->
+            if (sub.rarity == SublimationRarity.NORMAL) {
+                PlannedShard(subShardId(sub), runes.size + index, side, null)
+            } else {
+                PlannedShard(subShardId(sub), 0, 0, null)
+            }
+        }
+
+/**
+ * The tier-resolver for [plannedShards]: the family member of [Sublimation.zenithId] whose Zenith shard
+ * level equals the sub's credited [Sublimation.maxTier]. Falls back to the raw id when the catalog is
+ * unreachable or the family has no such member (then Zenith shows the tier-I shard, level 1).
+ */
+private fun subShardIdResolver(levelIdsByRoot: Map<Int, Map<Int, Int>>): (Sublimation) -> Int = { sub -> levelIdsByRoot[sub.zenithId]?.get(sub.maxTier) ?: sub.zenithId }
 
 suspend fun ZenithInputParameters.createZenithBuild() =
     supervisorScope {
         withTimeout(10.seconds) {
             with(this@createZenithBuild) {
                 val zenithBuild = createBuild(character)
+                val subShardId =
+                    if (sublimations.values.any { it.isNotEmpty() }) {
+                        subShardIdResolver(runCatching { fetchSublimationLevelIds() }.getOrDefault(emptyMap()))
+                    } else {
+                        { sub: Sublimation -> sub.zenithId }
+                    }
                 val everyEquipmentCalls =
                     sideAssignments(equipments).map { (equipment, sideValue) ->
                         async {
                             addEquipment(equipment, zenithBuild.id, sideValue)
                             // Socket this item's runes then its sublimations, once the item exists on the
                             // build; the shard's `side` must match the item's.
-                            plannedShards(equipment, sideValue, runes[equipment].orEmpty(), sublimations[equipment].orEmpty())
+                            plannedShards(equipment, sideValue, runes[equipment].orEmpty(), sublimations[equipment].orEmpty(), subShardId)
                                 .forEach { shard ->
                                     addShard(
                                         buildId = zenithBuild.id,
@@ -100,6 +131,15 @@ suspend fun ZenithInputParameters.createZenithBuild() =
                                         side = shard.side,
                                         level = shard.level
                                     )
+                                    // Whitening is a separate transform on the already-socketed shard.
+                                    if (shard.whiten) {
+                                        whitenShard(
+                                            buildId = zenithBuild.id,
+                                            shardId = shard.shardId,
+                                            position = shard.position,
+                                            side = shard.side
+                                        )
+                                    }
                                 }
                         }
                     }

--- a/zenith-builder/src/main/kotlin/me/chosante/ZenithShard.kt
+++ b/zenith-builder/src/main/kotlin/me/chosante/ZenithShard.kt
@@ -2,13 +2,22 @@ package me.chosante
 
 import com.github.kittinunf.fuel.core.awaitUnit
 import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.fuel.coroutines.awaitObjectResponse
+import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.fuel.httpPost
+import com.github.kittinunf.fuel.serialization.kotlinxDeserializerOf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 private const val ADD_SHARD_URL = "$BASE_API_URL/shard/add"
+private const val TRANSFORM_SHARD_URL = "$BASE_API_URL/shard/transform"
+private const val SHARDS_CATALOG_URL = "$BASE_API_URL/shards"
 
 /**
  * Sockets one shard into an item already added to the Zenith build — a rune (with a [level]) or a
@@ -38,4 +47,69 @@ internal suspend fun addShard(
         .header(apiZenithWakfuHeaders)
         .jsonBody(Json.encodeToString<JsonObject>(payload))
         .awaitUnit()
+}
+
+/**
+ * Whitens an already-socketed rune (`/shard/transform`, `isWhited = 1`) — Zenith's equivalent of the
+ * in-game socket-colour re-roll. A whited shard's socket counts as a wildcard for every sublimation
+ * colour pattern, and Zenith's double-bonus computation ignores `is_whited` (it only checks the item
+ * type), so whitening every exported rune makes any sublimation activable at zero stat cost.
+ */
+internal suspend fun whitenShard(
+    buildId: Long,
+    shardId: Int,
+    position: Int,
+    side: Int,
+) {
+    val payload =
+        buildJsonObject {
+            put("id_build", buildId)
+            put("id_shard", shardId)
+            put("position", position)
+            put("side", side)
+            put("isWhited", 1)
+        }
+
+    TRANSFORM_SHARD_URL
+        .httpPost()
+        .header(apiZenithWakfuHeaders)
+        .jsonBody(Json.encodeToString<JsonObject>(payload))
+        .awaitUnit()
+}
+
+/**
+ * Zenith's sublimation catalog, resolved to `family root id -> (shard level -> shard id)`.
+ *
+ * On Zenith every sublimation generation (I/II/III) is its OWN shard id whose intrinsic `level` (1/2/3)
+ * is what the build accumulates — the `/shard/add` `level` parameter is ignored for sublimations
+ * (verified against the live API). Our [me.chosante.common.Sublimation] is a per-FAMILY record whose
+ * `zenithId` is the family root (tier I) and whose effects are valued at `maxTier`, so the export must
+ * socket the family member whose level equals `maxTier` — e.g. Ambition (root 29591) at maxTier 3
+ * sockets 29593 ("Ambition III", level 3), not the root (which Zenith shows as level 1).
+ */
+internal suspend fun fetchSublimationLevelIds(): Map<Int, Map<Int, Int>> {
+    val (_, _, catalog) =
+        SHARDS_CATALOG_URL
+            .httpGet()
+            .header(apiZenithWakfuHeaders)
+            .awaitObjectResponse(kotlinxDeserializerOf<JsonObject>())
+
+    val byRoot = mutableMapOf<Int, MutableMap<Int, Int>>()
+    for (key in listOf("sublimations", "special_sublimations")) {
+        val records = catalog[key]?.jsonArray ?: continue
+        for (record in records) {
+            val root = record.jsonObject
+            val rootId = root["id_shard"]?.jsonPrimitive?.int ?: continue
+            val family = byRoot.getOrPut(rootId) { mutableMapOf() }
+            (root["level"]?.jsonPrimitive?.int)?.let { family[it] = rootId }
+            val children = root["children"]?.jsonArray ?: continue
+            for (child in children) {
+                val childObject = child.jsonObject
+                val childId = childObject["id_shard"]?.jsonPrimitive?.int ?: continue
+                val childLevel = childObject["level"]?.jsonPrimitive?.int ?: continue
+                family[childLevel] = childId
+            }
+        }
+    }
+    return byRoot
 }

--- a/zenith-builder/src/test/kotlin/me/chosante/ZenithShardPlanTest.kt
+++ b/zenith-builder/src/test/kotlin/me/chosante/ZenithShardPlanTest.kt
@@ -108,6 +108,68 @@ class ZenithShardPlanTest {
         assertThat(shards.last().level).describedAs("the sublimation has no level").isNull()
     }
 
+    /** Every exported rune is whitened (wildcard socket) so any sublimation colour pattern activates. */
+    @Test
+    fun `runes are flagged for whitening and sublimations are not`() {
+        val belt = equipment(9, ItemType.BELT, "Belt")
+        val shards =
+            plannedShards(
+                belt,
+                side = ItemType.BELT.id,
+                runes = listOf(rune(10), rune(11)),
+                subs = listOf(sublimation(1, 7001, "SubA"))
+            )
+
+        assertThat(shards.map { it.whiten })
+            .describedAs("each rune gets a follow-up /shard/transform; the sublimation never does")
+            .containsExactly(true, true, false)
+    }
+
+    /**
+     * The sub's socketed id is the TIER-RESOLVED family member: Zenith ignores `/shard/add`'s level for
+     * sublimations — the shard id's intrinsic level (I=1, II=2, III=3) is what the build accumulates —
+     * so a maxTier-3 family must socket the tier-III child id, not the family root (level 1).
+     */
+    @Test
+    fun `sublimations socket the tier-resolved shard id with a root fallback`() {
+        val belt = equipment(10, ItemType.BELT, "Belt")
+        val ambition = sublimation(stateId = 7115, zenithId = 29591, label = "Ambition I")
+        val catalog = mapOf(29591 to mapOf(1 to 29591, 2 to 29592, 3 to 29593))
+
+        val resolved =
+            plannedShards(belt, ItemType.BELT.id, runes = emptyList(), subs = listOf(ambition)) { sub ->
+                catalog[sub.zenithId]?.get(sub.maxTier) ?: sub.zenithId
+            }
+        assertThat(resolved.single().shardId)
+            .describedAs("maxTier 3 sockets the tier-III family member")
+            .isEqualTo(29593)
+
+        val fallback = plannedShards(belt, ItemType.BELT.id, runes = emptyList(), subs = listOf(ambition))
+        assertThat(fallback.single().shardId)
+            .describedAs("without a catalog the export keeps the family root")
+            .isEqualTo(29591)
+    }
+
+    /** Epic/relic subs live in the build's dedicated slots: the UI posts them at side 0, position 0. */
+    @Test
+    fun `epic and relic sublimations target the dedicated build slots`() {
+        val belt = equipment(11, ItemType.BELT, "Belt")
+        val epic = sublimation(2, 8001, "EpicSub").copy(rarity = SublimationRarity.EPIC, maxTier = 1)
+        val relic = sublimation(3, 8002, "RelicSub").copy(rarity = SublimationRarity.RELIC, maxTier = 1)
+
+        val shards =
+            plannedShards(
+                belt,
+                side = ItemType.BELT.id,
+                runes = listOf(rune(10)),
+                subs = listOf(epic, relic)
+            )
+        val specials = shards.filter { it.shardId in listOf(8001, 8002) }
+        assertThat(specials.map { it.side to it.position })
+            .describedAs("epic/relic subs are posted at side 0, position 0, never on the carrier")
+            .containsExactly(0 to 0, 0 to 0)
+    }
+
     /**
      * The two rings must claim the two dedicated ring sides. The ring-side iterator used to be advanced from
      * inside the per-item `async`, so the rings raced for it; [sideAssignments] now resolves every side up


### PR DESCRIPTION
## Summary
Beta-tester report on the Zenith export, fixed and verified against the live builder API:

- **Every exported rune is whitened** (`/shard/transform isWhited=1` after each socket). A whited socket is a wildcard for every sublimation colour pattern, and Zenith's double-bonus computation ignores `is_whited` — so all subs activate with zero stat cost.
- **Sublimation levels now match the algorithm.** Zenith ignores `/shard/add`'s `level` for subs: each generation (I/II/III) is its own shard id whose intrinsic level is what the build accumulates. The export now resolves the family member matching the sub's credited `maxTier` via one `/shards` catalog fetch (root fallback if unreachable). Previously the tier-I root was always socketed → level 1 displayed.
- **Epic/relic subs target the dedicated build slots** (`side=0, position=0`) like the Zenith UI, instead of being socketed on the carrier item.

## Verification
- Live: 3 whitened lvl-11 runes + « Ambition III niveau 3 » read back from `/enchants` (scratch build).
- `ZenithShardPlanTest`: whiten flags, tier resolution + fallback, epic/relic slot routing, stacking contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)