### PR TITLE
perf: MM encoding campaign — measured verdicts, A/B seams, certifier harvest index

### DIFF
--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageCertifier.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageCertifier.kt
@@ -166,6 +166,115 @@ internal object CertifierTuning {
     val tier15SegmentsSkippedForTest =
         java.util.concurrent.atomic
             .AtomicLong()
+
+    /**
+     * A/B seam for the FAST-pass harvest coordinate index. Off by default, so production keeps the
+     * reference `all cells × all crit steps` scan until the experiment is measured and accepted.
+     * The environment switch is intentionally experimental; flipping the production default would be
+     * a certifier change and therefore requires a [WakfuBuildSolver.CERTIFIER_VERSION] bump.
+     */
+    @Volatile
+    var indexedFastHarvestEnabled = System.getenv("WAKFU_MAX_DAMAGE_CERT_INDEXED_HARVEST") == "1"
+
+    /** Number of indexed `(state, AP-cell, crit-step)` coordinates actually handed to the harvest. */
+    val indexedFastHarvestCoordinatesForTest =
+        java.util.concurrent.atomic
+            .AtomicLong()
+}
+
+/**
+ * Direct AP-cell index for one FAST-pass DP state's pre-sub AP coordinate.
+ *
+ * Returned pairs are packed as `[cell0, minimumGapSubs0, cell1, minimumGapSubs1, ...]`, in the same
+ * ascending-cell order as the reference scan. Cells outside the exact arithmetic band, or whose AP
+ * gap cannot be covered by the available pure-AP budget, are omitted. This helper is internal so a
+ * focused exhaustive test can lock the indexed enumeration byte-for-byte against the reference loop.
+ */
+internal fun indexedFastHarvestApCoordinates(
+    stateAp: Int,
+    cellCount: Int,
+    apConst: Long,
+    minSubAp: Int,
+    maxSubAp: Int,
+    apPlusSorted: List<Long>,
+    apMinusSorted: List<Long>,
+): IntArray {
+    if (cellCount <= 0) return IntArray(0)
+    val first = maxOf(0L, apConst + stateAp + minSubAp).coerceAtMost(cellCount.toLong())
+    val last = minOf(cellCount.toLong() - 1L, apConst + stateAp + maxSubAp)
+    if (first > last) return IntArray(0)
+
+    val packed = IntArray(((last - first + 1L) * 2L).toInt())
+    var size = 0
+    for (cellLong in first..last) {
+        val gap = cellLong - apConst - stateAp
+        val cover =
+            if (gap >= 0L) {
+                minimumBudgetUnitsToCover(gap, apPlusSorted)
+            } else {
+                minimumBudgetUnitsToCover(-gap, apMinusSorted)
+            }
+        if (cover == Int.MAX_VALUE) continue
+        packed[size++] = cellLong.toInt()
+        packed[size++] = cover
+    }
+    return if (size == packed.size) packed else packed.copyOf(size)
+}
+
+/**
+ * Direct crit-step index for one FAST-pass DP state's pre-sub crit coordinate within one c segment.
+ * The packed output is `[c0, minimumGapSubs0, ...]` in the reference loop's ascending-c order.
+ * `c == 0` deliberately keeps its special clamp band and zero gap charge.
+ */
+internal fun indexedFastHarvestCritCoordinates(
+    stateCrit: Int,
+    cLow: Int,
+    cHigh: Int,
+    critConst: Long,
+    critOff: Int,
+    maxSubCrit: Long,
+    csWorldCrit: Long,
+    forcedStartCritTotal: Long,
+    critBudgetSortedForCharge: List<Long>,
+): IntArray {
+    if (cLow > cHigh) return IntArray(0)
+    val zeroIncluded =
+        cLow <= 0 &&
+            cHigh >= 0 &&
+            stateCrit >= -critOff &&
+            stateCrit <= -critConst
+    val firstPositive = maxOf(cLow.toLong(), 1L, stateCrit + critConst)
+    val lastPositive = minOf(cHigh.toLong(), stateCrit + critConst + maxSubCrit)
+    val positiveCount = if (firstPositive <= lastPositive) (lastPositive - firstPositive + 1L).toInt() else 0
+    val packed = IntArray(2 * (positiveCount + if (zeroIncluded) 1 else 0))
+    var size = 0
+    if (zeroIncluded) {
+        packed[size++] = 0
+        packed[size++] = 0
+    }
+    if (positiveCount > 0) {
+        for (cLong in firstPositive..lastPositive) {
+            val gap = cLong - critConst - stateCrit - csWorldCrit - forcedStartCritTotal
+            val cover = minimumBudgetUnitsToCover(gap, critBudgetSortedForCharge)
+            if (cover == Int.MAX_VALUE) continue
+            packed[size++] = cLong.toInt()
+            packed[size++] = cover
+        }
+    }
+    return if (size == packed.size) packed else packed.copyOf(size)
+}
+
+private fun minimumBudgetUnitsToCover(
+    gap: Long,
+    sortedDesc: List<Long>,
+): Int {
+    if (gap <= 0L) return 0
+    var covered = 0L
+    for ((index, value) in sortedDesc.withIndex()) {
+        covered += value
+        if (covered >= gap) return index + 1
+    }
+    return Int.MAX_VALUE
 }
 
 /**
@@ -2097,6 +2206,7 @@ internal fun StatBuilder.certifyMaxPerHitAtApPass(
         val fastTimingEnabled = System.getenv("WAKFU_MAX_DAMAGE_CERT_TIMING") == "1"
         var fastDpNanos = 0L
         var fastHarvestNanos = 0L
+        var fastHarvestCoordinates = 0L
         var fastSegmentsRun = 0
         var fastSegmentsSkipped = 0
         // Two-tier speed: allocate the per-crit-step harvest for the top cell (see [fastPerCOutHolder]).
@@ -2265,6 +2375,26 @@ internal fun StatBuilder.certifyMaxPerHitAtApPass(
         val bufBF = DenseDp(denseBoxF)
         var dpF = bufAF
         var ndF = bufBF
+        // A/B seam (off by default): AP feasibility depends only on the state's AP coordinate, so build
+        // its exact ascending `(cell, gap-charge)` list once per pass instead of rechecking every cell
+        // for every live state in every c segment.
+        val indexedHarvestEnabled = CertifierTuning.indexedFastHarvestEnabled
+        val indexedApCoordinates =
+            if (indexedHarvestEnabled) {
+                Array(apDimF) { storedAp ->
+                    indexedFastHarvestApCoordinates(
+                        stateAp = storedAp - apOff,
+                        cellCount = fastCellCount,
+                        apConst = apConst,
+                        minSubAp = minSubAp,
+                        maxSubAp = maxSubAp,
+                        apPlusSorted = apPlusSorted,
+                        apMinusSorted = apMinusSorted
+                    )
+                }
+            } else {
+                null
+            }
         for ((si, cLow) in segmentEdges.withIndex()) {
             val cHigh = if (si + 1 < segmentEdges.size) segmentEdges[si + 1] - 1 else cEnumMax
             // Floor speed (tier-1.5 single-cell runs): if tier-1's step-8 bounds cap every crit step of
@@ -2513,6 +2643,80 @@ internal fun StatBuilder.certifyMaxPerHitAtApPass(
             // Family-budget graw prefixes per crit step of this segment (the budget is priced with the
             // EXACT per-c fold at harvest — tighter than the segment-top point fold, still ≥ any build).
             val gpByC = Array(cHigh - cLow + 1) { grawBudgetPrefix(minOf((cLow + it), critCap).toLong()) }
+            // Crit feasibility is likewise a function only of the state's crit coordinate and this
+            // segment. Preserve the reference order exactly: the special clamped c=0 coordinate first,
+            // then the positive direct interval in ascending order, each carrying its precomputed charge.
+            val indexedCritCoordinates =
+                if (indexedHarvestEnabled) {
+                    Array(critDimF) { storedCrit ->
+                        indexedFastHarvestCritCoordinates(
+                            stateCrit = storedCrit - critOff,
+                            cLow = cLow,
+                            cHigh = cHigh,
+                            critConst = critConst,
+                            critOff = critOff,
+                            maxSubCrit = maxSubCrit,
+                            csWorldCrit = csWorldCrit,
+                            forcedStartCritTotal = forcedStartCritTotal,
+                            critBudgetSortedForCharge = critBudgetSortedForCharge
+                        )
+                    }
+                } else {
+                    null
+                }
+
+            fun harvestCoordinate(
+                fr: Frontier,
+                n0: Int,
+                relic: Int,
+                epic: Int,
+                crit: Int,
+                ap: Int,
+                a: Int,
+                apGapSubsA: Int,
+                c: Int,
+                critGapSubsC: Int,
+            ) {
+                if (n0 + critGapSubsC + apGapSubsA > subCap) return
+                if (convTaken != null) {
+                    if (convTaken.rarity == SublimationRarity.EPIC && epic == 0) return
+                    if (convTaken.rarity == SublimationRarity.RELIC && relic == 0) return
+                    val cond = convTaken.condition
+                    if (cond != null) {
+                        val n = (cond.value ?: 0).toLong()
+                        val preCombatCritMin = maxOf(critConst + crit, c - maxStartCrit)
+                        val preCombatCritMax = minOf(c.toLong(), critConst + crit + maxPermCrit)
+                        val preCombatApMin = maxOf(apConst + ap, a - maxStartAp)
+                        val preCombatApMax = minOf(a.toLong(), apConst + ap + maxPermAp)
+                        val ok =
+                            when (cond.type) {
+                                SublimationConditionType.AP_AT_MOST -> preCombatApMin <= n
+                                SublimationConditionType.AP_AT_LEAST -> preCombatApMax >= n
+                                SublimationConditionType.AP_EXACT -> preCombatApMin <= n && n <= preCombatApMax
+                                SublimationConditionType.CRIT_AT_MOST -> preCombatCritMin <= n
+                                SublimationConditionType.CRIT_AT_LEAST -> preCombatCritMax >= n
+                                else -> true
+                            }
+                        if (!ok) return
+                    }
+                }
+                if (critSecret != null && epic == 0) return
+                val cEff = minOf(c, critCap)
+                // Conditional forced credits are unconditional in the FAST pass (sound
+                // over-count, clamped ≥ 0 — keeps `fast ≥ exact` vs the gated exact harvest).
+                val grawConstC = (400L + cEff) * (mConst + forcedCondMTotal) + 5L * cEff * (critMConst + forcedCondCmTotal)
+                val freeSlots = subCap - n0 - critGapSubsC - apGapSubsA
+                val gpC = gpByC[c - cLow]
+                fr.forEachPoint { pd, pg, _ ->
+                    val perHit = budgetMax(dConst + pd, grawConstC + pg, freeSlots, gpC)
+                    if (perHit > fastAllCellsOut[a]) fastAllCellsOut[a] = perHit
+                    // Per-crit-step harvest for the top cell (exact-pass c-loop pruning bounds).
+                    if (fastPerCOut != null && a == maxCell && c < fastPerCOut.size && perHit > fastPerCOut[c]) fastPerCOut[c] = perHit
+                    // ALL-cells per-(cell, crit-step) harvest (tier-1.5 segment-skip bounds).
+                    if (fastPerCellC != null && c < fastPerCellC[a].size && perHit > fastPerCellC[a][c]) fastPerCellC[a][c] = perHit
+                }
+            }
+
             for (ki in 0 until dpF.liveCount) {
                 val k = dpF.liveKeys[ki]
                 val fr = dpF.slots[k] ?: continue
@@ -2524,57 +2728,49 @@ internal fun StatBuilder.certifyMaxPerHitAtApPass(
                 rest /= 2
                 val crit = rest % critDimF - critOff
                 val ap = rest / critDimF - apOff
-                for (a in 0..maxCell) {
-                    val apHighA = a - apConst
-                    if (ap < apHighA - maxSubAp || ap > apHighA - minSubAp) continue
-                    val apGapA = apHighA - ap
-                    val apGapSubsA = if (apGapA >= 0) minSubsToCover(apGapA, apPlusSorted) else minSubsToCover(-apGapA, apMinusSorted)
-                    if (apGapSubsA == Int.MAX_VALUE) continue
-                    for (c in cLow..cHigh) {
-                        val critItemHighC = (c - critConst).toInt()
-                        val critLowBandC = if (c == 0) -critOff else critItemHighC - maxSubCrit.toInt()
-                        if (crit < critLowBandC || crit > critItemHighC) continue
-                        // Forced start-of-combat crit is credited before counting gap subs (mirrors
-                        // the exact harvest): always present, slot already charged.
-                        val critGapSubsC = if (c == 0) 0 else minSubsToCover(c.toLong() - critConst - crit - csWorldCrit - forcedStartCritTotal, critBudgetSortedForCharge)
-                        if (critGapSubsC == Int.MAX_VALUE) continue
-                        if (n0 + critGapSubsC + apGapSubsA > subCap) continue
-                        if (convTaken != null) {
-                            if (convTaken.rarity == SublimationRarity.EPIC && epic == 0) continue
-                            if (convTaken.rarity == SublimationRarity.RELIC && relic == 0) continue
-                            val cond = convTaken.condition
-                            if (cond != null) {
-                                val n = (cond.value ?: 0).toLong()
-                                val preCombatCritMin = maxOf(critConst + crit, c - maxStartCrit)
-                                val preCombatCritMax = minOf(c.toLong(), critConst + crit + maxPermCrit)
-                                val preCombatApMin = maxOf(apConst + ap, a - maxStartAp)
-                                val preCombatApMax = minOf(a.toLong(), apConst + ap + maxPermAp)
-                                val ok =
-                                    when (cond.type) {
-                                        SublimationConditionType.AP_AT_MOST -> preCombatApMin <= n
-                                        SublimationConditionType.AP_AT_LEAST -> preCombatApMax >= n
-                                        SublimationConditionType.AP_EXACT -> preCombatApMin <= n && n <= preCombatApMax
-                                        SublimationConditionType.CRIT_AT_MOST -> preCombatCritMin <= n
-                                        SublimationConditionType.CRIT_AT_LEAST -> preCombatCritMax >= n
-                                        else -> true
-                                    }
-                                if (!ok) continue
-                            }
+                if (indexedHarvestEnabled) {
+                    val apCoordinates = indexedApCoordinates!![ap + apOff]
+                    val critCoordinates = indexedCritCoordinates!![crit + critOff]
+                    var ai = 0
+                    while (ai < apCoordinates.size) {
+                        val a = apCoordinates[ai]
+                        val apGapSubsA = apCoordinates[ai + 1]
+                        var ci = 0
+                        while (ci < critCoordinates.size) {
+                            val c = critCoordinates[ci]
+                            val critGapSubsC = critCoordinates[ci + 1]
+                            fastHarvestCoordinates++
+                            CertifierTuning.indexedFastHarvestCoordinatesForTest.incrementAndGet()
+                            harvestCoordinate(fr, n0, relic, epic, crit, ap, a, apGapSubsA, c, critGapSubsC)
+                            ci += 2
                         }
-                        if (critSecret != null && epic == 0) continue
-                        val cEff = minOf(c, critCap)
-                        // Conditional forced credits are unconditional in the FAST pass (sound
-                        // over-count, clamped ≥ 0 — keeps `fast ≥ exact` vs the gated exact harvest).
-                        val grawConstC = (400L + cEff) * (mConst + forcedCondMTotal) + 5L * cEff * (critMConst + forcedCondCmTotal)
-                        val freeSlots = subCap - n0 - critGapSubsC - apGapSubsA
-                        val gpC = gpByC[c - cLow]
-                        fr.forEachPoint { pd, pg, _ ->
-                            val perHit = budgetMax(dConst + pd, grawConstC + pg, freeSlots, gpC)
-                            if (perHit > fastAllCellsOut[a]) fastAllCellsOut[a] = perHit
-                            // Per-crit-step harvest for the top cell (exact-pass c-loop pruning bounds).
-                            if (fastPerCOut != null && a == maxCell && c < fastPerCOut.size && perHit > fastPerCOut[c]) fastPerCOut[c] = perHit
-                            // ALL-cells per-(cell, crit-step) harvest (tier-1.5 segment-skip bounds).
-                            if (fastPerCellC != null && c < fastPerCellC[a].size && perHit > fastPerCellC[a][c]) fastPerCellC[a][c] = perHit
+                        ai += 2
+                    }
+                } else {
+                    for (a in 0..maxCell) {
+                        val apHighA = a - apConst
+                        if (ap < apHighA - maxSubAp || ap > apHighA - minSubAp) continue
+                        val apGapA = apHighA - ap
+                        val apGapSubsA = if (apGapA >= 0) minSubsToCover(apGapA, apPlusSorted) else minSubsToCover(-apGapA, apMinusSorted)
+                        if (apGapSubsA == Int.MAX_VALUE) continue
+                        for (c in cLow..cHigh) {
+                            val critItemHighC = (c - critConst).toInt()
+                            val critLowBandC = if (c == 0) -critOff else critItemHighC - maxSubCrit.toInt()
+                            if (crit < critLowBandC || crit > critItemHighC) continue
+                            // Forced start-of-combat crit is credited before counting gap subs (mirrors
+                            // the exact harvest): always present, slot already charged.
+                            val critGapSubsC =
+                                if (c == 0) {
+                                    0
+                                } else {
+                                    minSubsToCover(
+                                        c.toLong() - critConst - crit - csWorldCrit - forcedStartCritTotal,
+                                        critBudgetSortedForCharge
+                                    )
+                                }
+                            if (critGapSubsC == Int.MAX_VALUE) continue
+                            fastHarvestCoordinates++
+                            harvestCoordinate(fr, n0, relic, epic, crit, ap, a, apGapSubsA, c, critGapSubsC)
                         }
                     }
                 }
@@ -2585,6 +2781,7 @@ internal fun StatBuilder.certifyMaxPerHitAtApPass(
             System.err.println(
                 "CERT_FAST_TIMING conv=${convTaken?.name?.en ?: "-"} critSecret=${critSecret?.name?.en ?: "-"} wr=$weaponsRestricted " +
                     "step=$fastCSegmentStep cells=$fastCellCount dpMs=${fastDpNanos / 1_000_000} harvestMs=${fastHarvestNanos / 1_000_000} " +
+                    "harvestIndexed=$indexedHarvestEnabled coordinates=$fastHarvestCoordinates " +
                     "segmentsRun=$fastSegmentsRun segmentsSkipped=$fastSegmentsSkipped"
             )
         }

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesExperiments.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesExperiments.kt
@@ -1,0 +1,31 @@
+package me.chosante.autobuilder.genetic.wakfu
+
+/**
+ * Test-only A/B encodings for the most-masteries objective. Production and ordinary tests keep
+ * [CURRENT]; manual performance harnesses opt into the alternatives through [WakfuBuildSolver.SolverTuning].
+ */
+internal enum class MmOvershootEncoding {
+    /** The shipped `excess -> min -> max` encoding. */
+    CURRENT,
+
+    /** Hard-leg-only exact simplification: `actual >= target` makes the lower `max(., 0)` redundant. */
+    HARD_EXACT_SIMPLIFIED,
+
+    /**
+     * Hard-leg-only objective-induced hypograph. At an optimum, the positive objective coefficient drives
+     * `overflow` to `min(actual - target, target)`; unsupported weights fall back to [CURRENT].
+     */
+    HARD_HYPOGRAPH,
+}
+
+/** Exact alternative encodings for the remaining most-masteries `mastery * (100 + DI)` product. */
+internal enum class MmProductEncoding {
+    /** The shipped generic integer multiplication on guard-sized domains. */
+    CURRENT,
+
+    /** The same native multiplication/division, with tracked reachable domains propagated upstream. */
+    TRACKED,
+
+    /** Binary-expand the reachable DI factor and gate the mastery operand exactly. */
+    BINARY,
+}

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/StatBuilder.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/StatBuilder.kt
@@ -957,6 +957,7 @@ internal class StatBuilder(
         requiredTargets: List<TargetStat>,
         totalExpectedScore: Long,
         targetStats: TargetStats,
+        encoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
     ): IntVar {
         val contributions =
             requiredTargets.map { targetStat ->
@@ -965,19 +966,62 @@ internal class StatBuilder(
                 val target = targetStat.target.toLong().coerceAtLeast(0)
                 val name = targetStat.characteristic.name
 
-                val excess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, STAT_WITH_PERCENT_ABS_MAX, "excess_$name")
-                model.addEquality(
-                    excess,
-                    LinearExpr
-                        .newBuilder()
-                        .addTerm(actual, 1)
-                        .add(-target)
-                        .build()
-                )
-                val cappedExcess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, target, "excessCap_$name")
-                model.addMinEquality(cappedExcess, arrayOf(excess, model.newConstant(target)))
-                val positiveExcess = model.newIntVar(0, target, "excessPos_$name")
-                model.addMaxEquality(positiveExcess, arrayOf(cappedExcess, model.newConstant(0L)))
+                // Zero-target/weight and negative custom-weight requests do not satisfy the objective-induced
+                // assumptions below. Keep the shipped exact encoding for those uncommon shapes.
+                val effectiveEncoding =
+                    if (target > 0L && weight > 0L) encoding else MmOvershootEncoding.CURRENT
+                val positiveExcess =
+                    when (effectiveEncoding) {
+                        MmOvershootEncoding.CURRENT -> {
+                            val excess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, STAT_WITH_PERCENT_ABS_MAX, "excess_$name")
+                            model.addEquality(
+                                excess,
+                                LinearExpr
+                                    .newBuilder()
+                                    .addTerm(actual, 1)
+                                    .add(-target)
+                                    .build()
+                            )
+                            val cappedExcess = model.newIntVar(-STAT_WITH_PERCENT_ABS_MAX, target, "excessCap_$name")
+                            model.addMinEquality(cappedExcess, arrayOf(excess, model.newConstant(target)))
+                            val positive = model.newIntVar(0, target, "excessPos_$name")
+                            model.addMaxEquality(positive, arrayOf(cappedExcess, model.newConstant(0L)))
+                            positive
+                        }
+
+                        MmOvershootEncoding.HARD_EXACT_SIMPLIFIED -> {
+                            // The hard leg already adds actual >= target. Expose that fact in this auxiliary's
+                            // declared lower bound, eliminating the now-redundant max(excess, 0) propagator.
+                            val excess = model.newIntVar(0L, STAT_WITH_PERCENT_ABS_MAX, "excess_$name")
+                            model.addEquality(
+                                excess,
+                                LinearExpr
+                                    .newBuilder()
+                                    .addTerm(actual, 1)
+                                    .add(-target)
+                                    .build()
+                            )
+                            val positive = model.newIntVar(0L, target, "excessPos_$name")
+                            model.addMinEquality(positive, arrayOf(excess, model.newConstant(target)))
+                            positive
+                        }
+
+                        MmOvershootEncoding.HARD_HYPOGRAPH -> {
+                            // Exact at every optimum: this var has a positive objective coefficient and is bounded
+                            // above by both target and actual-target, so maximization drives it to their minimum.
+                            val positive = model.newIntVar(0L, target, "excessPos_$name")
+                            model.addLessOrEqual(
+                                LinearExpr
+                                    .newBuilder()
+                                    .addTerm(positive, 1L)
+                                    .addTerm(actual, -1L)
+                                    .add(target)
+                                    .build(),
+                                0L
+                            )
+                            positive
+                        }
+                    }
 
                 val contribution = model.newIntVar(0, target * weight, "overshoot_$name")
                 model.addEquality(contribution, LinearExpr.term(positiveExcess, weight))
@@ -1162,6 +1206,7 @@ internal class StatBuilder(
     fun diAdjustedPerElementMasteryScore(
         targetStats: TargetStats,
         targetCharacteristics: Set<Characteristic>,
+        productEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
     ): Pair<IntVar, Long> {
         val nonElementaries =
             targetStats
@@ -1200,29 +1245,83 @@ internal class StatBuilder(
                 MASTERY_SCORE_ABS_MAX
             )
 
-        val globalDi = model.clampVar(actualStat(Characteristic.DAMAGE_INFLICTED), -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDI")
+        val globalDiSource = actualStat(Characteristic.DAMAGE_INFLICTED)
+        val globalDi =
+            if (productEncoding == MmProductEncoding.CURRENT) {
+                model.clampVar(globalDiSource, -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDI")
+            } else {
+                tClamp(globalDiSource, -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDI")
+            }
         val productBound = MASTERY_SCORE_ABS_MAX * (100L + DAMAGE_DI_MAX)
 
         // The shared `clamp(mastery,≥0) × factor / 100 → clamp` kernel (one bilinear product).
         fun diProduct(
             masteryTier: IntVar,
             diFactor: IntVar,
+            masteryReachHi: Long,
             tag: String,
         ): IntVar {
-            val nonNeg = model.clampVar(masteryTier, 0L, MASTERY_SCORE_ABS_MAX, "mmNN_$tag")
-            val product = model.newIntVar(0L, productBound, "mmProd_$tag")
-            model.addMultiplicationEquality(product, arrayOf(nonNeg, diFactor))
-            val scaled = model.newIntVar(0L, productBound / 100L, "mmScaled_$tag")
-            model.addDivisionEquality(scaled, product, model.newConstant(100L))
-            return model.clampVar(scaled, 0L, MASTERY_SCORE_ABS_MAX, "mmAdj_$tag")
+            if (productEncoding == MmProductEncoding.CURRENT) {
+                val nonNeg = model.clampVar(masteryTier, 0L, MASTERY_SCORE_ABS_MAX, "mmNN_$tag")
+                val product = model.newIntVar(0L, productBound, "mmProd_$tag")
+                model.addMultiplicationEquality(product, arrayOf(nonNeg, diFactor))
+                val scaled = model.newIntVar(0L, productBound / 100L, "mmScaled_$tag")
+                model.addDivisionEquality(scaled, product, model.newConstant(100L))
+                return model.clampVar(scaled, 0L, MASTERY_SCORE_ABS_MAX, "mmAdj_$tag")
+            }
+
+            // The manual reach deliberately ignores negative mastery penalties and slot competition, so it
+            // over-estimates the attainable tier. Recording it upstream lets every following big-M/domain consume
+            // the bound instead of discovering only the final downstream coreHi clamp.
+            val tierHi = masteryReachHi.coerceIn(0L, MASTERY_SCORE_ABS_MAX)
+            tracker.record(masteryTier, -MASTERY_SCORE_ABS_MAX..tierHi, "mmTierReach_$tag")
+            val nonNeg = tClamp(masteryTier, 0L, MASTERY_SCORE_ABS_MAX, "mmNN_$tag")
+            val factorReach = tracker.of(diFactor)
+            val reachableProductHi = (tierHi * maxOf(0L, factorReach.last)).coerceAtMost(productBound)
+            val product =
+                when (productEncoding) {
+                    MmProductEncoding.TRACKED ->
+                        tMul("mmProd_$tag", nonNeg, diFactor, 0L, productBound)
+
+                    MmProductEncoding.BINARY -> {
+                        val span = factorReach.last - factorReach.first
+                        val offset =
+                            tSum(
+                                "mmDiOffset_$tag",
+                                listOf(Term(diFactor, 1L)),
+                                -factorReach.first,
+                                0L..span,
+                                0L,
+                                100L + DAMAGE_DI_MAX
+                            )
+                        tBinaryOffsetProduct(
+                            "mmProd_$tag",
+                            offset,
+                            factorReach,
+                            nonNeg,
+                            0L..tierHi,
+                            0L..productBound
+                        )
+                    }
+
+                    MmProductEncoding.CURRENT -> error("handled above")
+                }
+            val scaled = tDiv("mmScaled_$tag", product, 100L, 0L, productBound / 100L)
+            val reachableScaledHi = (reachableProductHi / 100L).coerceAtMost(MASTERY_SCORE_ABS_MAX)
+            return tClamp(scaled, 0L, reachableScaledHi, "mmAdj_$tag")
         }
 
         val minElements = targetStats.masteryElementsToMinimize
         if (minElements.isEmpty()) {
             // BRANCH A: no element requested ⇒ one product on (nonElemNeg × globalFactor).
-            val factor = model.sumVar("mmDiFactor", listOf(Term(globalDi, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
+            val factor =
+                if (productEncoding == MmProductEncoding.CURRENT) {
+                    model.sumVar("mmDiFactor", listOf(Term(globalDi, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
+                } else {
+                    tSumNaive("mmDiFactor", listOf(Term(globalDi, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
+                }
             val coreHi = WakfuBuildSolver.clampedProductQuotient(nonElemReachMax, diFactorMax, 100L, MASTERY_SCORE_ABS_MAX).coerceAtLeast(1L)
-            return model.clampVar(diProduct(nonElemNeg, factor, "global"), 0L, coreHi, "mmCoreHi") to coreHi
+            return model.clampVar(diProduct(nonElemNeg, factor, nonElemReachMax, "global"), 0L, coreHi, "mmCoreHi") to coreHi
         }
 
         // BRANCH B: per-element products (each with its own element DI inside its factor), then weakest-min.
@@ -1239,22 +1338,44 @@ internal class StatBuilder(
                         MASTERY_SCORE_ABS_MAX
                     )
                 // combinedDi = clamp(globalDI + elementDI_e, [-FLOOR, MAX]) — ONE clamp of the sum (mirrors mono).
-                val combinedDi =
-                    model.clampVar(
+                val diSum =
+                    if (productEncoding == MmProductEncoding.CURRENT) {
                         model.sumVar(
                             "mmDiSum_${e.name}",
                             listOf(Term(globalDi, 1L), Term(elementDiVar(e), 1L)),
                             0L,
                             -DAMAGE_DI_FLOOR,
                             DAMAGE_DI_MAX + DAMAGE_DI_MAX
-                        ),
-                        -DAMAGE_DI_FLOOR,
-                        DAMAGE_DI_MAX,
-                        "mmDiClamp_${e.name}"
-                    )
+                        )
+                    } else {
+                        tSumNaive(
+                            "mmDiSum_${e.name}",
+                            listOf(Term(globalDi, 1L), Term(elementDiVar(e), 1L)),
+                            0L,
+                            -DAMAGE_DI_FLOOR,
+                            DAMAGE_DI_MAX + DAMAGE_DI_MAX
+                        )
+                    }
+                val combinedDi =
+                    if (productEncoding == MmProductEncoding.CURRENT) {
+                        model.clampVar(diSum, -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDiClamp_${e.name}")
+                    } else {
+                        tClamp(diSum, -DAMAGE_DI_FLOOR, DAMAGE_DI_MAX, "mmDiClamp_${e.name}")
+                    }
                 val factor =
-                    model.sumVar("mmDiFactor_${e.name}", listOf(Term(combinedDi, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
-                diProduct(tier, factor, e.name)
+                    if (productEncoding == MmProductEncoding.CURRENT) {
+                        model.sumVar("mmDiFactor_${e.name}", listOf(Term(combinedDi, 1L)), 100L, 100L - DAMAGE_DI_FLOOR, 100L + DAMAGE_DI_MAX)
+                    } else {
+                        tSumNaive(
+                            "mmDiFactor_${e.name}",
+                            listOf(Term(combinedDi, 1L)),
+                            100L,
+                            100L - DAMAGE_DI_FLOOR,
+                            100L + DAMAGE_DI_MAX
+                        )
+                    }
+                val tierReachMax = nonElemReachMax + maxOf(0L, tracker.of(elementVars.getValue(e)).last)
+                diProduct(tier, factor, tierReachMax, e.name)
             }
         // The score is the MIN over requested elements, so it is bounded by the smallest element's (nonElem +
         // element) reach × the max DI factor — a sound over-estimate (each `tier` clamps ≥ 0 and adds the negative

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -475,6 +475,11 @@ object WakfuBuildSolver {
         // alternatives are exercised only by the dedicated same-JVM A/B harness.
         val mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
         val mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
+        // Measurement-only redundant DUAL cut: a sound upper bound on the most-masteries core
+        // (`masteryScore`, scorer units), added as `masteryScore ≤ U`. The caller is responsible for
+        // soundness — an under-estimating U silently truncates the optimum, so the A/B harness locks
+        // optimum equality against the un-cut baseline. Production always passes null.
+        val mmMasteryScoreUpperBound: Long? = null,
     )
 
     fun optimize(
@@ -583,7 +588,8 @@ object WakfuBuildSolver {
                             hardConstraints = hardConstraints,
                             mmPlainPrimaryObjective = mmTwoStage,
                             mmOvershootEncoding = tuning?.mmOvershootEncoding ?: MmOvershootEncoding.CURRENT,
-                            mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT
+                            mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT,
+                            mmMasteryScoreUpperBound = tuning?.mmMasteryScoreUpperBound
                         )
                     // C2: a hard-constraints model with a required target above its reachable ceiling is PROVABLY
                     // infeasible — skip the doomed CP-SAT solve entirely and emit nothing. The caller
@@ -649,7 +655,8 @@ object WakfuBuildSolver {
                                 hardConstraints = hardConstraints,
                                 mmOvershootPinnedPrimary = outcome.objectiveValue,
                                 mmOvershootEncoding = tuning?.mmOvershootEncoding ?: MmOvershootEncoding.CURRENT,
-                                mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT
+                                mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT,
+                                mmMasteryScoreUpperBound = tuning?.mmMasteryScoreUpperBound
                             )
                         executeSolverAndEmitResults(
                             built2.model,
@@ -828,6 +835,8 @@ object WakfuBuildSolver {
         // Manual most-masteries A/B encodings. Production always passes CURRENT through [optimize].
         mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
         mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
+        // Measurement-only redundant dual cut on the MM core; see [SolverTuning.mmMasteryScoreUpperBound].
+        mmMasteryScoreUpperBound: Long? = null,
         // Test seam: when true, the max-damage build also runs [certifyMaxPerHitAtAp] for every AP cell and
         // stores the resulting objectives in [BuiltModel.certifierObjectivesForTest] (single-element only).
         certifyAllApForTest: Boolean = false,
@@ -959,7 +968,8 @@ object WakfuBuildSolver {
                             mmPlainPrimaryObjective,
                             mmOvershootPinnedPrimary,
                             mmOvershootEncoding,
-                            mmProductEncoding
+                            mmProductEncoding,
+                            mmMasteryScoreUpperBound
                         )
                     maxDamageStaticallyInfeasible = mm.staticallyInfeasible
                     mm.objective
@@ -2215,6 +2225,7 @@ object WakfuBuildSolver {
         mmOvershootPinnedPrimary: Long? = null,
         mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
         mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
+        mmMasteryScoreUpperBound: Long? = null,
     ): MostMasteriesObjectiveVars {
         val statBuilder =
             StatBuilder(
@@ -2242,6 +2253,13 @@ object WakfuBuildSolver {
         // envelope on the required-target path.
         val (masteryScore, masteryScoreReach) =
             statBuilder.diAdjustedPerElementMasteryScore(targetStats, targetCharacteristics, mmProductEncoding)
+
+        // Piste-4 A/B: a redundant `core ≤ U` dual cut from an EXTERNAL sound bound (the M3 DP prototype).
+        // Redundant for any correct U, so the optimum is unchanged; the measurement question is whether
+        // handing CP-SAT the tight external ceiling shortens the by-exhaustion dual proof (P0.5 wall).
+        if (mmMasteryScoreUpperBound != null) {
+            addLessOrEqual(masteryScore, mmMasteryScoreUpperBound)
+        }
 
         val requiredTargets = targetStats.filter { it.characteristic.isRequiredMostMasteriesTarget() }
 

--- a/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
+++ b/autobuilder/src/main/kotlin/me/chosante/autobuilder/genetic/wakfu/WakfuBuildSolver.kt
@@ -471,6 +471,10 @@ object WakfuBuildSolver {
         // The oracle hint: a previously captured assignment, applied by var name onto the fresh model.
         // Use with greedyWarmStart = false — a var must not be hinted twice.
         val assignmentHint: Map<String, Long>? = null,
+        // Manual most-masteries performance campaign. CURRENT keeps the production encoding byte-identical;
+        // alternatives are exercised only by the dedicated same-JVM A/B harness.
+        val mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
+        val mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
     )
 
     fun optimize(
@@ -577,7 +581,9 @@ object WakfuBuildSolver {
                             applyDomination = tuning?.applyDominationOverride ?: (tuning == null),
                             maxDamageExperiment = tuning?.maxDamageExperiment ?: MaxDamageExperimentConfig.DEFAULT,
                             hardConstraints = hardConstraints,
-                            mmPlainPrimaryObjective = mmTwoStage
+                            mmPlainPrimaryObjective = mmTwoStage,
+                            mmOvershootEncoding = tuning?.mmOvershootEncoding ?: MmOvershootEncoding.CURRENT,
+                            mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT
                         )
                     // C2: a hard-constraints model with a required target above its reachable ceiling is PROVABLY
                     // infeasible — skip the doomed CP-SAT solve entirely and emit nothing. The caller
@@ -641,7 +647,9 @@ object WakfuBuildSolver {
                                 applyDomination = tuning?.applyDominationOverride ?: (tuning == null),
                                 maxDamageExperiment = tuning?.maxDamageExperiment ?: MaxDamageExperimentConfig.DEFAULT,
                                 hardConstraints = hardConstraints,
-                                mmOvershootPinnedPrimary = outcome.objectiveValue
+                                mmOvershootPinnedPrimary = outcome.objectiveValue,
+                                mmOvershootEncoding = tuning?.mmOvershootEncoding ?: MmOvershootEncoding.CURRENT,
+                                mmProductEncoding = tuning?.mmProductEncoding ?: MmProductEncoding.CURRENT
                             )
                         executeSolverAndEmitResults(
                             built2.model,
@@ -817,6 +825,9 @@ object WakfuBuildSolver {
         // P2b two-stage lexicographic (most-masteries hard leg) — see [buildMostMasteriesObjective].
         mmPlainPrimaryObjective: Boolean = false,
         mmOvershootPinnedPrimary: Long? = null,
+        // Manual most-masteries A/B encodings. Production always passes CURRENT through [optimize].
+        mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
+        mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
         // Test seam: when true, the max-damage build also runs [certifyMaxPerHitAtAp] for every AP cell and
         // stores the resulting objectives in [BuiltModel.certifierObjectivesForTest] (single-element only).
         certifyAllApForTest: Boolean = false,
@@ -946,7 +957,9 @@ object WakfuBuildSolver {
                             subModel,
                             hardConstraints,
                             mmPlainPrimaryObjective,
-                            mmOvershootPinnedPrimary
+                            mmOvershootPinnedPrimary,
+                            mmOvershootEncoding,
+                            mmProductEncoding
                         )
                     maxDamageStaticallyInfeasible = mm.staticallyInfeasible
                     mm.objective
@@ -2163,6 +2176,12 @@ object WakfuBuildSolver {
         }
     }
 
+    /** The most-masteries objective plus the hard-leg static-infeasibility flag (mirrors [MaxDamageObjectiveVars]). */
+    private class MostMasteriesObjectiveVars(
+        val objective: IntVar,
+        val staticallyInfeasible: Boolean = false,
+    )
+
     /**
      * Objective for "most masteries" mode: maximize the *requested* masteries — scaled by the build's global
      * **% Damage Inflicted** so the proxy is damage-faithful (see [StatBuilder.diAdjustedPerElementMasteryScore]) —
@@ -2174,13 +2193,6 @@ object WakfuBuildSolver {
      * proven optimum leaves the slot empty. (Decision: keep as-is; see the engine discussion in
      * AGENTS.md §4.)
      */
-
-    /** The most-masteries objective plus the hard-leg static-infeasibility flag (mirrors [MaxDamageObjectiveVars]). */
-    private class MostMasteriesObjectiveVars(
-        val objective: IntVar,
-        val staticallyInfeasible: Boolean = false,
-    )
-
     private fun CpModel.buildMostMasteriesObjective(
         params: WakfuBestBuildParams,
         allEquips: List<Equipment>,
@@ -2201,6 +2213,8 @@ object WakfuBuildSolver {
         // the objective — a short, near-forced solve that restores the exact lexicographic build.
         mmPlainPrimaryObjective: Boolean = false,
         mmOvershootPinnedPrimary: Long? = null,
+        mmOvershootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
+        mmProductEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
     ): MostMasteriesObjectiveVars {
         val statBuilder =
             StatBuilder(
@@ -2211,6 +2225,9 @@ object WakfuBuildSolver {
                 skillVars,
                 runeModel,
                 subModel,
+                // The TRACKED/BINARY arms deliberately tighten the whole MM stat chain so the product's
+                // big-Ms and declared domains consume the same reachable ranges. CURRENT is byte-identical.
+                tight = mmProductEncoding != MmProductEncoding.CURRENT,
                 // Decouple from the max-damage experiment default (see [MaxDamageExperimentConfig.NON_MAX_DAMAGE]).
                 maxDamageExperiment = MaxDamageExperimentConfig.NON_MAX_DAMAGE
             )
@@ -2223,7 +2240,8 @@ object WakfuBuildSolver {
         // C8: [diAdjustedPerElementMasteryScore] now also returns a sound reachable ceiling on that score, used as
         // the product-box bound below (was the loose MASTERY_SCORE_ABS_MAX), tightening the objective's McCormick
         // envelope on the required-target path.
-        val (masteryScore, masteryScoreReach) = statBuilder.diAdjustedPerElementMasteryScore(targetStats, targetCharacteristics)
+        val (masteryScore, masteryScoreReach) =
+            statBuilder.diAdjustedPerElementMasteryScore(targetStats, targetCharacteristics, mmProductEncoding)
 
         val requiredTargets = targetStats.filter { it.characteristic.isRequiredMostMasteriesTarget() }
 
@@ -2243,7 +2261,7 @@ object WakfuBuildSolver {
                 requiredTargets
                     .sumOf { it.target.toLong() * targetStats.scaledWeight(it) }
                     .coerceAtLeast(1L)
-            val overshoot = statBuilder.overshootScore(requiredTargets, totalExpectedScore, targetStats)
+            val overshoot = statBuilder.overshootScore(requiredTargets, totalExpectedScore, targetStats, mmOvershootEncoding)
             // P2b stage 2: pin the primary at stage 1's proven value, maximize overshoot alone —
             // provably the same lexicographic optimum as the folded objective, without its domain.
             if (mmOvershootPinnedPrimary != null) {
@@ -2272,7 +2290,9 @@ object WakfuBuildSolver {
         // (and, among ties, pick gear that overshoots) instead of leaving them unused — free in-game
         // value the player would always take. It can never trade a maximized-mastery point for
         // overshoot; see [withOvershootTieBreaker].
-        val overshoot = statBuilder.overshootScore(requiredTargets, totalExpectedScore, targetStats)
+        // The alternative overshoot encodings rely on the hard `actual >= target` constraints above.
+        // The soft fallback therefore always keeps the shipped exact chain.
+        val overshoot = statBuilder.overshootScore(requiredTargets, totalExpectedScore, targetStats, MmOvershootEncoding.CURRENT)
         return MostMasteriesObjectiveVars(withOvershootTieBreaker(penalized.objective, penalized.bound, overshoot, totalExpectedScore))
     }
 
@@ -2694,9 +2714,23 @@ object WakfuBuildSolver {
                         )
                     )
                 }
-                SolveOutcome(status, solver.objectiveValue().toLong())
+                SolveOutcome(
+                    status = status,
+                    objectiveValue = solver.objectiveValue().toLong(),
+                    bestObjectiveBound = solver.bestObjectiveBound().toLong(),
+                    deterministicTime = deterministicTimeFrom(solver.responseStats()),
+                    branches = solver.numBranches(),
+                    conflicts = solver.numConflicts()
+                )
             } else {
-                SolveOutcome(status, null)
+                SolveOutcome(
+                    status = status,
+                    objectiveValue = null,
+                    bestObjectiveBound = solver.bestObjectiveBound().toLong(),
+                    deterministicTime = deterministicTimeFrom(solver.responseStats()),
+                    branches = solver.numBranches(),
+                    conflicts = solver.numConflicts()
+                )
             }
         } catch (e: Exception) {
             logger.error(e) { "Solver failed while searching for the best build." }
@@ -2712,6 +2746,10 @@ object WakfuBuildSolver {
     internal class SolveOutcome(
         val status: com.google.ortools.sat.CpSolverStatus,
         val objectiveValue: Long?,
+        val bestObjectiveBound: Long,
+        val deterministicTime: Double,
+        val branches: Long,
+        val conflicts: Long,
     )
 
     /**

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageCertifierHarvestIndexTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MaxDamageCertifierHarvestIndexTest.kt
@@ -1,0 +1,272 @@
+package me.chosante.autobuilder.genetic.wakfu
+
+import me.chosante.autobuilder.domain.DamageScenario
+import me.chosante.autobuilder.domain.Orientation
+import me.chosante.autobuilder.domain.RangeBand
+import me.chosante.autobuilder.domain.SpellElement
+import me.chosante.autobuilder.domain.TargetStats
+import me.chosante.common.Character
+import me.chosante.common.CharacterClass
+import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.I18nText
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.Sublimation
+import me.chosante.common.SublimationEffect
+import me.chosante.common.SublimationKind
+import me.chosante.common.SublimationRarity
+import me.chosante.common.skills.CharacterSkills
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.test.assertContentEquals
+import kotlin.time.Duration.Companion.seconds
+
+class MaxDamageCertifierHarvestIndexTest {
+    @Test
+    fun `indexed AP and crit coordinates are byte-identical to the reference scans`() {
+        val random = Random(0x48_41_52_56)
+        repeat(5_000) { iteration ->
+            val cellCount = random.nextInt(1, 22)
+            val apConst = random.nextInt(-3, 12).toLong()
+            val stateAp = random.nextInt(-12, 25)
+            val apPlus = randomBudget(random)
+            val apMinus = randomBudget(random)
+            val minSubAp = -apMinus.sum().toInt()
+            val maxSubAp = apPlus.sum().toInt()
+            val expectedAp =
+                referenceApCoordinates(
+                    stateAp,
+                    cellCount,
+                    apConst,
+                    minSubAp,
+                    maxSubAp,
+                    apPlus,
+                    apMinus
+                )
+            val indexedAp =
+                indexedFastHarvestApCoordinates(
+                    stateAp,
+                    cellCount,
+                    apConst,
+                    minSubAp,
+                    maxSubAp,
+                    apPlus,
+                    apMinus
+                )
+            assertContentEquals(expectedAp, indexedAp, "AP coordinate mismatch at iteration $iteration")
+
+            val cLow = random.nextInt(0, 105)
+            val cHigh = random.nextInt(cLow, 121)
+            val critConst = random.nextInt(0, 16).toLong()
+            val critOff = random.nextInt(0, 21)
+            val stateCrit = random.nextInt(-critOff, 131)
+            val critBudget = randomBudget(random, maxValue = 30)
+            val forcedStartCrit = random.nextInt(0, 16).toLong()
+            val maxSubCrit = critBudget.sum() + forcedStartCrit
+            val csWorldCrit = random.nextInt(0, 21).toLong()
+            val expectedCrit =
+                referenceCritCoordinates(
+                    stateCrit,
+                    cLow,
+                    cHigh,
+                    critConst,
+                    critOff,
+                    maxSubCrit,
+                    csWorldCrit,
+                    forcedStartCrit,
+                    critBudget
+                )
+            val indexedCrit =
+                indexedFastHarvestCritCoordinates(
+                    stateCrit,
+                    cLow,
+                    cHigh,
+                    critConst,
+                    critOff,
+                    maxSubCrit,
+                    csWorldCrit,
+                    forcedStartCrit,
+                    critBudget
+                )
+            assertContentEquals(expectedCrit, indexedCrit, "crit coordinate mismatch at iteration $iteration")
+        }
+    }
+
+    @Test
+    fun `indexed FAST harvest produces a byte-identical ledger`() {
+        val level = 50
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, level, 0, CharacterSkills(level)),
+                targetStats = TargetStats(emptyList()),
+                searchDuration = 2.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MAX_DAMAGE,
+                useRunes = false,
+                useSublimations = true,
+                damageScenario =
+                    DamageScenario(
+                        element = SpellElement.FIRE,
+                        rangeBand = RangeBand.DISTANCE,
+                        orientation = Orientation.FACE
+                    )
+            )
+        val pool =
+            listOf(
+                equipment(1, ItemType.HELMET, mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 400, Characteristic.CRITICAL_HIT to -8), 4),
+                equipment(2, ItemType.HELMET, mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 300, Characteristic.CRITICAL_HIT to 12), 4),
+                equipment(3, ItemType.AMULET, mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 250, Characteristic.ACTION_POINT to 2), 4),
+                equipment(4, ItemType.AMULET, mapOf(Characteristic.DAMAGE_INFLICTED to 35, Characteristic.ACTION_POINT to -1), 4),
+                equipment(5, ItemType.BELT, mapOf(Characteristic.MASTERY_DISTANCE to 300, Characteristic.CRITICAL_HIT to 18), 4),
+                equipment(6, ItemType.RING, mapOf(Characteristic.MASTERY_CRITICAL to 220), 4),
+                equipment(7, ItemType.RING, mapOf(Characteristic.MASTERY_ELEMENTARY_FIRE to 180), 4)
+            ).groupBy { it.itemType }
+        val sublimations =
+            listOf(
+                flatSub(10_001, Characteristic.ACTION_POINT, 1),
+                flatSub(10_002, Characteristic.ACTION_POINT, -1),
+                flatSub(10_003, Characteristic.CRITICAL_HIT, 15, permanent = true),
+                flatSub(10_004, Characteristic.CRITICAL_HIT, 9),
+                flatSub(10_005, Characteristic.DAMAGE_INFLICTED, 20)
+            )
+
+        val previous = CertifierTuning.indexedFastHarvestEnabled
+        CertifierTuning.indexedFastHarvestCoordinatesForTest.set(0L)
+        try {
+            CertifierTuning.indexedFastHarvestEnabled = false
+            val reference =
+                WakfuBuildSolver.certifierFastLedgerForTest(
+                    params,
+                    pool,
+                    sublimations = sublimations,
+                    applyDomination = false,
+                    threads = 1
+                )
+            CertifierTuning.indexedFastHarvestEnabled = true
+            val indexed =
+                WakfuBuildSolver.certifierFastLedgerForTest(
+                    params,
+                    pool,
+                    sublimations = sublimations,
+                    applyDomination = false,
+                    threads = 1
+                )
+
+            assertThat(indexed)
+                .describedAs("the indexed harvest must leave every FAST certificate cell byte-identical")
+                .isEqualTo(reference)
+            assertThat(CertifierTuning.indexedFastHarvestCoordinatesForTest.get())
+                .describedAs("the optimized seam must actually visit indexed harvest coordinates")
+                .isGreaterThan(0L)
+        } finally {
+            CertifierTuning.indexedFastHarvestEnabled = previous
+        }
+    }
+
+    private fun referenceApCoordinates(
+        stateAp: Int,
+        cellCount: Int,
+        apConst: Long,
+        minSubAp: Int,
+        maxSubAp: Int,
+        apPlus: List<Long>,
+        apMinus: List<Long>,
+    ): IntArray =
+        buildList {
+            for (cell in 0 until cellCount) {
+                val apHigh = cell - apConst
+                if (stateAp < apHigh - maxSubAp || stateAp > apHigh - minSubAp) continue
+                val gap = apHigh - stateAp
+                val charge = if (gap >= 0L) referenceCover(gap, apPlus) else referenceCover(-gap, apMinus)
+                if (charge == Int.MAX_VALUE) continue
+                add(cell)
+                add(charge)
+            }
+        }.toIntArray()
+
+    private fun referenceCritCoordinates(
+        stateCrit: Int,
+        cLow: Int,
+        cHigh: Int,
+        critConst: Long,
+        critOff: Int,
+        maxSubCrit: Long,
+        csWorldCrit: Long,
+        forcedStartCrit: Long,
+        critBudget: List<Long>,
+    ): IntArray =
+        buildList {
+            for (c in cLow..cHigh) {
+                val critHigh = (c - critConst).toInt()
+                val critLow = if (c == 0) -critOff else critHigh - maxSubCrit.toInt()
+                if (stateCrit < critLow || stateCrit > critHigh) continue
+                val charge =
+                    if (c == 0) {
+                        0
+                    } else {
+                        referenceCover(c - critConst - stateCrit - csWorldCrit - forcedStartCrit, critBudget)
+                    }
+                if (charge == Int.MAX_VALUE) continue
+                add(c)
+                add(charge)
+            }
+        }.toIntArray()
+
+    private fun referenceCover(
+        gap: Long,
+        sortedDesc: List<Long>,
+    ): Int {
+        if (gap <= 0L) return 0
+        var covered = 0L
+        for ((index, value) in sortedDesc.withIndex()) {
+            covered += value
+            if (covered >= gap) return index + 1
+        }
+        return Int.MAX_VALUE
+    }
+
+    private fun randomBudget(
+        random: Random,
+        maxValue: Int = 4,
+    ): List<Long> =
+        List(random.nextInt(0, 6)) { random.nextInt(1, maxValue + 1).toLong() }
+            .sortedDescending()
+
+    private fun equipment(
+        id: Int,
+        type: ItemType,
+        stats: Map<Characteristic, Int>,
+        maxShardSlots: Int,
+    ): Equipment =
+        Equipment(
+            equipmentId = id,
+            guiId = id,
+            level = 50,
+            name = I18nText("item$id", "item$id", "item$id", "item$id"),
+            rarity = Rarity.COMMON,
+            itemType = type,
+            characteristics = stats,
+            maxShardSlots = maxShardSlots
+        )
+
+    private fun flatSub(
+        id: Int,
+        characteristic: Characteristic,
+        value: Int,
+        permanent: Boolean = false,
+    ): Sublimation =
+        Sublimation(
+            stateId = id,
+            name = I18nText("sub$id", "sub$id", "sub$id", "sub$id"),
+            rarity = SublimationRarity.NORMAL,
+            slotColorPattern = listOf(1, 2, 3),
+            kind = SublimationKind.FLAT,
+            solverChoosable = true,
+            effects = listOf(SublimationEffect.Flat(characteristic, value, appliesBeforeCombat = permanent))
+        )
+}

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesConditionalCeilingAnalysisTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesConditionalCeilingAnalysisTest.kt
@@ -1,0 +1,384 @@
+package me.chosante.autobuilder.genetic.wakfu
+
+import me.chosante.autobuilder.domain.TargetStat
+import me.chosante.autobuilder.domain.TargetStats
+import me.chosante.autobuilder.genetic.wakfu.WakfuBuildSolver.valueFor
+import me.chosante.common.Character
+import me.chosante.common.CharacterClass
+import me.chosante.common.Characteristic
+import me.chosante.common.Equipment
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.RuneType
+import me.chosante.common.Sublimation
+import me.chosante.common.SublimationEffect
+import me.chosante.common.SublimationRarity
+import me.chosante.common.skills.Assignable
+import me.chosante.common.skills.CharacterSkills
+import me.chosante.common.skills.SkillCharacteristic
+import me.chosante.common.skills.UnitType
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Measurement-only screen for the proposed per-item hard-target feasibility filter.
+ *
+ * For the four simple near-frontier targets (AP/MP/crit/HP), computes a sound over-estimate of
+ * `actual(stat) | item selected`:
+ *  - equipment choices are exact for slot occupancy, weapon compatibility, distinct-name rings and the
+ *    one-epic/one-relic budgets;
+ *  - every carrier may take the best rune for the probed stat (ignores rune/sub colour competition);
+ *  - fixed and percent skill budgets are maximized independently (they can spend the same branch twice);
+ *  - sublimation conditions, carriers and colours are ignored, while the 10-normal/1-epic/1-relic caps remain;
+ *  - positive stat effects are credited even when their build-static condition could not fire.
+ *
+ * All relaxations only ADD reach. A conversion into a probed stat deliberately bails instead of claiming
+ * soundness; none currently targets these four stats. This is a dry-run only: it never edits the CP-SAT pool.
+ */
+class MostMasteriesConditionalCeilingAnalysisTest {
+    private data class Option(
+        val value: Long,
+        val epic: Int = 0,
+        val relic: Int = 0,
+    )
+
+    private data class SkillUpper(
+        val fixed: Long,
+        val percent: Long,
+    )
+
+    private class Analyzer(
+        private val params: WakfuBestBuildParams,
+        private val pool: Map<ItemType, List<Equipment>>,
+        private val runes: List<RuneType>,
+        private val sublimations: List<Sublimation>,
+    ) {
+        private val all = pool.values.flatten()
+        private val weaponTypes =
+            setOf(
+                ItemType.ONE_HANDED_WEAPONS,
+                ItemType.TWO_HANDED_WEAPONS,
+                ItemType.OFF_HAND_WEAPONS
+            )
+
+        private fun rarityOption(
+            value: Long,
+            vararg items: Equipment,
+        ): Option =
+            Option(
+                value = value,
+                epic = items.count { it.rarity == Rarity.EPIC },
+                relic = items.count { it.rarity == Rarity.RELIC }
+            )
+
+        private fun collapse(options: Iterable<Option>): List<Option> =
+            options
+                .filter { it.epic <= 1 && it.relic <= 1 }
+                .groupBy { it.epic to it.relic }
+                .values
+                .map { group -> group.maxBy { it.value } }
+
+        private fun itemValue(
+            item: Equipment,
+            stat: Characteristic,
+        ): Long {
+            val rune =
+                if (params.useRunes) {
+                    runes
+                        .filter { it.characteristic == stat }
+                        .maxOfOrNull { it.valueOn(item.itemType, item.level) }
+                        ?.toLong()
+                        ?: 0L
+                } else {
+                    0L
+                }
+            return item.valueFor(stat).toLong() + item.maxShardSlots * rune
+        }
+
+        private fun stageKey(type: ItemType): String =
+            when {
+                type == ItemType.RING -> "rings"
+                type in weaponTypes -> "weapons"
+                else -> type.name
+            }
+
+        private fun genericStageOptions(
+            key: String,
+            stat: Characteristic,
+        ): List<Option> =
+            when (key) {
+                "rings" -> {
+                    val rings = pool[ItemType.RING].orEmpty()
+                    val out = mutableListOf(Option(0L))
+                    for (i in rings.indices) {
+                        val a = rings[i]
+                        out += rarityOption(itemValue(a, stat), a)
+                        for (j in i + 1 until rings.size) {
+                            val b = rings[j]
+                            if (a.name.fr.lowercase() == b.name.fr.lowercase()) continue
+                            out += rarityOption(itemValue(a, stat) + itemValue(b, stat), a, b)
+                        }
+                    }
+                    collapse(out)
+                }
+
+                "weapons" -> {
+                    val one = pool[ItemType.ONE_HANDED_WEAPONS].orEmpty()
+                    val two = pool[ItemType.TWO_HANDED_WEAPONS].orEmpty()
+                    val off = pool[ItemType.OFF_HAND_WEAPONS].orEmpty()
+                    val out = mutableListOf(Option(0L))
+                    for (item in one + two + off) out += rarityOption(itemValue(item, stat), item)
+                    for (a in one) {
+                        for (b in off) out += rarityOption(itemValue(a, stat) + itemValue(b, stat), a, b)
+                    }
+                    collapse(out)
+                }
+
+                else -> {
+                    val type = ItemType.valueOf(key)
+                    collapse(listOf(Option(0L)) + pool[type].orEmpty().map { rarityOption(itemValue(it, stat), it) })
+                }
+            }
+
+        private fun selectedStageOptions(
+            selected: Equipment,
+            stat: Characteristic,
+        ): List<Option> =
+            when (selected.itemType) {
+                ItemType.RING -> {
+                    val out = mutableListOf(rarityOption(itemValue(selected, stat), selected))
+                    for (other in pool[ItemType.RING].orEmpty()) {
+                        if (other == selected || other.name.fr.lowercase() == selected.name.fr.lowercase()) continue
+                        out += rarityOption(itemValue(selected, stat) + itemValue(other, stat), selected, other)
+                    }
+                    collapse(out)
+                }
+
+                ItemType.TWO_HANDED_WEAPONS -> listOf(rarityOption(itemValue(selected, stat), selected))
+
+                ItemType.ONE_HANDED_WEAPONS -> {
+                    val out = mutableListOf(rarityOption(itemValue(selected, stat), selected))
+                    for (other in pool[ItemType.OFF_HAND_WEAPONS].orEmpty()) {
+                        out += rarityOption(itemValue(selected, stat) + itemValue(other, stat), selected, other)
+                    }
+                    collapse(out)
+                }
+
+                ItemType.OFF_HAND_WEAPONS -> {
+                    val out = mutableListOf(rarityOption(itemValue(selected, stat), selected))
+                    for (other in pool[ItemType.ONE_HANDED_WEAPONS].orEmpty()) {
+                        out += rarityOption(itemValue(selected, stat) + itemValue(other, stat), selected, other)
+                    }
+                    collapse(out)
+                }
+
+                else -> listOf(rarityOption(itemValue(selected, stat), selected))
+            }
+
+        /** Exact item/rune-layer maximum for [stat], conditional on [selected] being equipped. */
+        private fun itemLayerUpper(
+            selected: Equipment,
+            stat: Characteristic,
+        ): Long {
+            val keys = pool.keys.map(::stageKey).toSet()
+            val selectedKey = stageKey(selected.itemType)
+            var dp = mapOf((0 to 0) to 0L)
+            for (key in keys) {
+                val options =
+                    if (key == selectedKey) {
+                        selectedStageOptions(selected, stat)
+                    } else {
+                        genericStageOptions(key, stat)
+                    }
+                val next = mutableMapOf<Pair<Int, Int>, Long>()
+                for ((state, value) in dp) {
+                    for (option in options) {
+                        val e = state.first + option.epic
+                        val r = state.second + option.relic
+                        if (e > 1 || r > 1) continue
+                        val keyState = e to r
+                        next[keyState] = maxOf(next[keyState] ?: Long.MIN_VALUE, value + option.value)
+                    }
+                }
+                dp = next
+            }
+            return dp.values.max()
+        }
+
+        private fun skillValuePerPoint(
+            skill: SkillCharacteristic,
+            stat: Characteristic,
+            unit: UnitType,
+        ): Int =
+            if (skill is SkillCharacteristic.PairedCharacteristic) {
+                skillValuePerPoint(skill.first, stat, unit) + skillValuePerPoint(skill.second, stat, unit)
+            } else if (skill.characteristic == stat && skill.unitType == unit) {
+                skill.unitValue
+            } else {
+                0
+            }
+
+        private fun branchUpper(
+            branch: Assignable<*>,
+            stat: Characteristic,
+            unit: UnitType,
+        ): Long {
+            var remaining = branch.maxPointsToAssign
+            var result = 0L
+            for (skill in branch.getCharacteristics().sortedByDescending { skillValuePerPoint(it, stat, unit) }) {
+                val perPoint = skillValuePerPoint(skill, stat, unit)
+                if (perPoint <= 0 || remaining == 0) break
+                val points = minOf(remaining, skill.maxPointsAssignable)
+                result += points.toLong() * perPoint
+                remaining -= points
+            }
+            return result
+        }
+
+        private fun skillUpper(stat: Characteristic): SkillUpper {
+            val skills = params.character.characterSkills
+            val branches = listOf(skills.intelligence, skills.strength, skills.agility, skills.luck, skills.major)
+            // Deliberately maximize FIXED and PERCENT in separate fantasy allocations. Their sum is an upper bound.
+            return SkillUpper(
+                fixed = branches.sumOf { branchUpper(it, stat, UnitType.FIXED) },
+                percent = branches.sumOf { branchUpper(it, stat, UnitType.PERCENT) }
+            )
+        }
+
+        private fun sublimationUpper(stat: Characteristic): Long? {
+            val byRarity = mutableMapOf<SublimationRarity, MutableList<Long>>()
+            for (sub in sublimations) {
+                if (!params.useSublimations || !sub.solverChoosable) continue
+                if (params.maxSublimationTier != null && sub.nameTier > params.maxSublimationTier) continue
+                var value = 0L
+                for (effect in sub.effects) {
+                    if (!WakfuBuildSolver.scenarioGateMatches(effect.scenarioGate, params)) continue
+                    when (effect) {
+                        is SublimationEffect.StatEffect ->
+                            if (effect.characteristic == stat) value += maxOf(effect.magnitudeAtLevel(params.character.level), 0)
+
+                        is SublimationEffect.PerStatStep ->
+                            if (effect.target == stat) value += maxOf(effect.cap, 0)
+
+                        is SublimationEffect.Conversion ->
+                            if (effect.to == stat) return null // unsupported: refusing an unsafe ceiling
+
+                        is SublimationEffect.BestElementConcentration -> Unit
+                    }
+                }
+                repeat(sub.maxCopies) { byRarity.getOrPut(sub.rarity) { mutableListOf() } += value }
+            }
+
+            fun top(
+                rarity: SublimationRarity,
+                count: Int,
+            ): Long =
+                byRarity[rarity]
+                    .orEmpty()
+                    .sortedDescending()
+                    .take(count)
+                    .sum()
+
+            return top(SublimationRarity.NORMAL, MAX_NORMAL_SUBLIMATIONS.toInt()) +
+                top(SublimationRarity.EPIC, 1) +
+                top(SublimationRarity.RELIC, 1)
+        }
+
+        fun ceiling(
+            selected: Equipment,
+            stat: Characteristic,
+        ): Long? {
+            val skills = skillUpper(stat)
+            val sub = sublimationUpper(stat) ?: return null
+            var preSub =
+                (params.character.baseCharacteristicValues[stat] ?: 0).toLong() +
+                    itemLayerUpper(selected, stat) + skills.fixed
+
+            // These are hard constraints on preSubStat in the real model. Applying them before the relaxed
+            // sublimation layer only tightens the over-estimate; in-combat subs may still exceed the sheet cap.
+            preSub =
+                when (stat) {
+                    Characteristic.ACTION_POINT -> minOf(preSub, MAX_OUT_OF_COMBAT_AP)
+                    Characteristic.MOVEMENT_POINT -> minOf(preSub, MAX_OUT_OF_COMBAT_MP)
+                    else -> preSub
+                }
+            val prePercent = preSub + sub
+            val percentGain =
+                if (prePercent > 0L && skills.percent > 0L) {
+                    // ceil instead of the model's nearest-integer rounding: still an upper bound.
+                    (prePercent * skills.percent + 99L) / 100L
+                } else {
+                    0L
+                }
+            return prePercent + percentGain
+        }
+
+        fun analyze(targets: List<TargetStat>) {
+            val rejectedBy = targets.associate { it.characteristic to mutableSetOf<Equipment>() }
+            val unsupported = mutableSetOf<Characteristic>()
+            for (item in all) {
+                for (target in targets) {
+                    val ceiling = ceiling(item, target.characteristic)
+                    if (ceiling == null) {
+                        unsupported += target.characteristic
+                    } else if (ceiling < target.target) {
+                        rejectedBy.getValue(target.characteristic) += item
+                    }
+                }
+            }
+            val union = rejectedBy.values.flatten().toSet()
+            println("MM_ITEM_CEILING pool=${all.size} rejected=${union.size} kept=${all.size - union.size} pct=${"%.2f".format(100.0 * union.size / all.size)}")
+            for (target in targets) {
+                val rejected = rejectedBy.getValue(target.characteristic)
+                println(
+                    "MM_ITEM_CEILING stat=${target.characteristic} target=${target.target} rejected=${rejected.size} " +
+                        "pct=${"%.2f".format(100.0 * rejected.size / all.size)}"
+                )
+            }
+            if (unsupported.isNotEmpty()) println("MM_ITEM_CEILING unsupported=$unsupported")
+            val byType =
+                union
+                    .groupingBy { it.itemType }
+                    .eachCount()
+                    .toList()
+                    .sortedByDescending { it.second }
+            println("MM_ITEM_CEILING rejectedByType=${byType.joinToString { "${it.first}:${it.second}" }}")
+        }
+    }
+
+    @Test
+    fun `manual per-item hard-target ceiling screen at 245`() {
+        assumeTrue(System.getenv("WAKFU_MM_ITEM_CEILING") == "1")
+        val level = 245
+        val targets =
+            listOf(
+                TargetStat(Characteristic.ACTION_POINT, 16),
+                TargetStat(Characteristic.MOVEMENT_POINT, 8),
+                TargetStat(Characteristic.CRITICAL_HIT, 100),
+                TargetStat(Characteristic.HP, 12000)
+            )
+        val params =
+            WakfuBestBuildParams(
+                character = Character(CharacterClass.CRA, level, 0, CharacterSkills(level)),
+                targetStats = TargetStats(listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 9999)) + targets),
+                searchDuration = 120.seconds,
+                stopWhenBuildMatch = false,
+                maxRarity = Rarity.EPIC,
+                forcedItems = emptyList(),
+                excludedItems = emptyList(),
+                scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+                useRunes = true,
+                useSublimations = true
+            )
+        val basePool =
+            WakfuBestBuildFinderAlgorithm.equipments
+                .filter { it.rarity <= params.maxRarity && it.rarity !in params.excludedRarities }
+                .filter { it.level in 0..level || it.itemType == ItemType.PETS || it.itemType == ItemType.MOUNTS }
+                .groupBy { it.itemType }
+        val shape = requireNotNull(dominationShape(params, WakfuBestBuildFinderAlgorithm.sublimations))
+        val productionPool = WakfuBuildSolver.filterDominatedPoolMemoizedForTest(basePool, shape)
+        println("MM_ITEM_CEILING basePool=${basePool.values.sumOf { it.size }} dominationPool=${productionPool.values.sumOf { it.size }}")
+        Analyzer(params, productionPool, WakfuBestBuildFinderAlgorithm.runes, WakfuBestBuildFinderAlgorithm.sublimations).analyze(targets)
+    }
+}

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesPerfExperimentTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesPerfExperimentTest.kt
@@ -1,0 +1,247 @@
+package me.chosante.autobuilder.genetic.wakfu
+
+import com.google.ortools.sat.CpSolverStatus
+import kotlinx.coroutines.runBlocking
+import me.chosante.autobuilder.domain.BuildCombination
+import me.chosante.autobuilder.domain.TargetStat
+import me.chosante.autobuilder.domain.TargetStats
+import me.chosante.autobuilder.genetic.SolverResult
+import me.chosante.common.Character
+import me.chosante.common.CharacterClass
+import me.chosante.common.Characteristic
+import me.chosante.common.ItemType
+import me.chosante.common.Rarity
+import me.chosante.common.RuneType
+import me.chosante.common.Sublimation
+import me.chosante.common.skills.CharacterSkills
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Canonical same-JVM A/B harness for most-masteries model encodings.
+ *
+ * Protocol: hard leg, production domination, presolve 1 / linearization 1, one worker with
+ * interleaving, fixed seed, and a deterministic-time budget. The arms run sequentially in this
+ * JVM so their wall times are comparable. This is manual-only because a complete campaign is long:
+ *
+ * ```shell
+ * WAKFU_MM_PERF_AB=1 WAKFU_MM_PERF_AB_DET=600 \
+ *   ./gradlew :autobuilder:test --tests '*MostMasteriesPerfExperimentTest*'
+ * ```
+ *
+ * Select `f5`, `frontier`, or `all` with `WAKFU_MM_PERF_AB_SHAPE` (default: `all`).
+ */
+class MostMasteriesPerfExperimentTest {
+    private data class ExperimentConfig(
+        val label: String,
+        val overshootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
+        val productEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
+    )
+
+    private data class Shape(
+        val label: String,
+        val params: WakfuBestBuildParams,
+    )
+
+    private data class Summary(
+        val config: ExperimentConfig,
+        val wallMs: Long,
+        val status: CpSolverStatus?,
+        val rawObjective: Long?,
+        val bestBound: Long,
+        val scoredObjective: java.math.BigDecimal?,
+        val isOptimal: Boolean,
+        val emissions: Int,
+        val firstEmissionMs: Long?,
+        val deterministicTime: Double,
+        val branches: Long,
+        val conflicts: Long,
+    )
+
+    private val configs =
+        listOf(
+            ExperimentConfig("baseline"),
+            ExperimentConfig("overshootExact", overshootEncoding = MmOvershootEncoding.HARD_EXACT_SIMPLIFIED),
+            ExperimentConfig("overshootHypograph", overshootEncoding = MmOvershootEncoding.HARD_HYPOGRAPH),
+            ExperimentConfig("productTracked", productEncoding = MmProductEncoding.TRACKED),
+            ExperimentConfig("productBinary", productEncoding = MmProductEncoding.BINARY)
+        )
+
+    @Test
+    fun `manual canonical most-masteries encoding A-B`(): Unit =
+        runBlocking {
+            assumeTrue(System.getenv("WAKFU_MM_PERF_AB") == "1")
+            val det = System.getenv("WAKFU_MM_PERF_AB_DET")?.toDoubleOrNull() ?: 600.0
+            require(det > 0.0) { "WAKFU_MM_PERF_AB_DET must be positive" }
+            val level = 245
+            val pool =
+                WakfuBestBuildFinderAlgorithm.equipments
+                    .filter { it.rarity <= Rarity.EPIC }
+                    .filter { it.level in 0..level || it.itemType == ItemType.PETS || it.itemType == ItemType.MOUNTS }
+                    .groupBy { it.itemType }
+            val runes = WakfuBestBuildFinderAlgorithm.runes
+            val sublimations = WakfuBestBuildFinderAlgorithm.sublimations
+            val shapes = selectedShapes(level)
+
+            WakfuBuildSolver.warmUp()
+            println(
+                "MM_PERF_AB START det=$det shapes=${shapes.joinToString { it.label }} " +
+                    "arms=${configs.joinToString { it.label }} pool=${pool.values.sumOf { it.size }}"
+            )
+
+            for (shape in shapes) {
+                val summaries = configs.map { config -> solve(shape, config, det, pool, runes, sublimations) }
+                val baseline = summaries.first()
+                for (summary in summaries.drop(1)) {
+                    if (baseline.isOptimal && summary.isOptimal) {
+                        assertThat(summary.rawObjective)
+                            .describedAs("${shape.label}/${summary.config.label}: exact raw optimum")
+                            .isEqualTo(baseline.rawObjective)
+                        assertThat(summary.scoredObjective)
+                            .describedAs("${shape.label}/${summary.config.label}: exact scored optimum")
+                            .isEqualByComparingTo(baseline.scoredObjective)
+                    }
+                    val ratio = baseline.wallMs.toDouble() / summary.wallMs.coerceAtLeast(1)
+                    println(
+                        "MM_PERF_AB COMPARE shape=${shape.label} arm=${summary.config.label} " +
+                            "baselineMs=${baseline.wallMs} armMs=${summary.wallMs} " +
+                            "baselineOverArm=${"%.3f".format(java.util.Locale.ROOT, ratio)} " +
+                            "baselineStatus=${baseline.status ?: "NA"} armStatus=${summary.status ?: "NA"}"
+                    )
+                }
+            }
+        }
+
+    private suspend fun solve(
+        shape: Shape,
+        config: ExperimentConfig,
+        det: Double,
+        pool: Map<ItemType, List<me.chosante.common.Equipment>>,
+        runes: List<RuneType>,
+        sublimations: List<Sublimation>,
+    ): Summary {
+        val termination = AtomicReference<WakfuBuildSolver.SolveOutcome?>()
+        val tuning =
+            WakfuBuildSolver.SolverTuning(
+                numSearchWorkers = 1,
+                randomSeed = 1,
+                maxDeterministicTime = det,
+                interleaveSearch = true,
+                maxPresolveIterationsOverride = 1,
+                linearizationLevelOverride = 1,
+                applyDominationOverride = true,
+                mmOvershootEncoding = config.overshootEncoding,
+                mmProductEncoding = config.productEncoding
+            )
+        val t0 = System.nanoTime()
+        var last: SolverResult<BuildCombination>? = null
+        var emissions = 0
+        var firstEmissionMs: Long? = null
+
+        WakfuBuildSolver
+            .optimize(
+                shape.params,
+                pool,
+                runes,
+                sublimations,
+                tuning,
+                hardConstraints = true,
+                onTermination = { termination.set(it) }
+            ).collect { result ->
+                val elapsedMs = elapsedMs(t0)
+                emissions++
+                if (firstEmissionMs == null) firstEmissionMs = elapsedMs
+                last = result
+                println(
+                    "MM_PERF_AB EMIT shape=${shape.label} arm=${config.label} tMs=$elapsedMs " +
+                        "scoredObjective=${result.matchPercentage} optimal=${result.isOptimal}"
+                )
+            }
+
+        val outcome = termination.get()
+        val wallMs = elapsedMs(t0)
+        checkNotNull(outcome) { "${shape.label}/${config.label}: solver returned no termination diagnostics" }
+        val summary =
+            Summary(
+                config = config,
+                wallMs = wallMs,
+                status = outcome.status,
+                rawObjective = outcome.objectiveValue,
+                bestBound = outcome.bestObjectiveBound,
+                scoredObjective = last?.matchPercentage,
+                isOptimal = last?.isOptimal == true,
+                emissions = emissions,
+                firstEmissionMs = firstEmissionMs,
+                deterministicTime = outcome.deterministicTime,
+                branches = outcome.branches,
+                conflicts = outcome.conflicts
+            )
+        println(
+            "MM_PERF_AB SUMMARY shape=${shape.label} arm=${config.label} det=$det wallMs=${summary.wallMs} " +
+                "status=${summary.status ?: "NA"} rawObjective=${summary.rawObjective ?: "NA"} " +
+                "bestBound=${summary.bestBound} scoredObjective=${summary.scoredObjective ?: "NA"} " +
+                "optimal=${summary.isOptimal} detUsed=${summary.deterministicTime} branches=${summary.branches} " +
+                "conflicts=${summary.conflicts} emissions=${summary.emissions} firstEmissionMs=${summary.firstEmissionMs ?: "NA"}"
+        )
+        return summary
+    }
+
+    private fun selectedShapes(level: Int): List<Shape> {
+        val f5 =
+            Shape(
+                "f5",
+                params(
+                    level,
+                    listOf(
+                        TargetStat(Characteristic.ACTION_POINT, 12),
+                        TargetStat(Characteristic.MOVEMENT_POINT, 6),
+                        TargetStat(Characteristic.HP, 2000),
+                        TargetStat(Characteristic.CRITICAL_HIT, 30)
+                    )
+                )
+            )
+        val frontier =
+            Shape(
+                "frontier",
+                params(
+                    level,
+                    listOf(
+                        TargetStat(Characteristic.ACTION_POINT, 16),
+                        TargetStat(Characteristic.MOVEMENT_POINT, 8),
+                        TargetStat(Characteristic.CRITICAL_HIT, 100),
+                        TargetStat(Characteristic.HP, 12000)
+                    )
+                )
+            )
+        return when (val selected = System.getenv("WAKFU_MM_PERF_AB_SHAPE")?.lowercase() ?: "all") {
+            "all" -> listOf(f5, frontier)
+            "f5" -> listOf(f5)
+            "frontier" -> listOf(frontier)
+            else -> error("Unknown WAKFU_MM_PERF_AB_SHAPE=$selected; expected f5, frontier, or all")
+        }
+    }
+
+    private fun params(
+        level: Int,
+        requiredTargets: List<TargetStat>,
+    ) = WakfuBestBuildParams(
+        character = Character(CharacterClass.CRA, level, 0, CharacterSkills(level)),
+        targetStats =
+            TargetStats(
+                listOf(TargetStat(Characteristic.MASTERY_DISTANCE, 9999)) + requiredTargets
+            ),
+        searchDuration = 600.seconds,
+        stopWhenBuildMatch = false,
+        maxRarity = Rarity.EPIC,
+        forcedItems = emptyList(),
+        excludedItems = emptyList(),
+        scoreComputationMode = ScoreComputationMode.FIND_BUILD_WITH_MOST_MASTERIES_FROM_INPUT,
+        useRunes = true,
+        useSublimations = true
+    )
+
+    private fun elapsedMs(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
+}

--- a/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesPerfExperimentTest.kt
+++ b/autobuilder/src/test/kotlin/me/chosante/autobuilder/genetic/wakfu/MostMasteriesPerfExperimentTest.kt
@@ -39,6 +39,8 @@ class MostMasteriesPerfExperimentTest {
         val label: String,
         val overshootEncoding: MmOvershootEncoding = MmOvershootEncoding.CURRENT,
         val productEncoding: MmProductEncoding = MmProductEncoding.CURRENT,
+        val hardLeg: Boolean = true,
+        val masteryScoreUpperBound: Long? = null,
     )
 
     private data class Shape(
@@ -115,6 +117,64 @@ class MostMasteriesPerfExperimentTest {
             }
         }
 
+    /**
+     * Piste 4: the M3 prototype bound injected as a redundant `masteryScore ≤ U` dual cut on the SOFT
+     * (penalized) model — the remaining slow workload after the frontier INFEASIBLE reclassification
+     * (plan §7.4). The cut is redundant for any sound U, so both arms must prove the same optimum;
+     * the measured question is proof time against the P0.5 by-exhaustion dual wall.
+     *
+     * ```shell
+     * WAKFU_MM_SOFT_CUT_AB=1 [WAKFU_MM_PERF_AB_DET=600] [WAKFU_MM_SOFT_CUT_U=<override>] \
+     *   ./gradlew :autobuilder:test --tests '*MostMasteriesPerfExperimentTest*'
+     * ```
+     */
+    @Test
+    fun `manual soft-leg M3-cut A-B`(): Unit =
+        runBlocking {
+            assumeTrue(System.getenv("WAKFU_MM_SOFT_CUT_AB") == "1")
+            val det = System.getenv("WAKFU_MM_PERF_AB_DET")?.toDoubleOrNull() ?: 600.0
+            val level = 245
+            val pool =
+                WakfuBestBuildFinderAlgorithm.equipments
+                    .filter { it.rarity <= Rarity.EPIC }
+                    .filter { it.level in 0..level || it.itemType == ItemType.PETS || it.itemType == ItemType.MOUNTS }
+                    .groupBy { it.itemType }
+            val runes = WakfuBestBuildFinderAlgorithm.runes
+            val sublimations = WakfuBestBuildFinderAlgorithm.sublimations
+            val shape = selectedShapes(level).first { it.label == "f5" }
+
+            val bound =
+                System.getenv("WAKFU_MM_SOFT_CUT_U")?.toLongOrNull()
+                    ?: requireNotNull(MostMasteriesBoundPrototype.bound(shape.params, pool, runes, sublimations)) {
+                        "M3 prototype bailed on the f5 shape; pass WAKFU_MM_SOFT_CUT_U explicitly"
+                    }
+            WakfuBuildSolver.warmUp()
+            println("MM_SOFT_CUT START det=$det bound=$bound pool=${pool.values.sumOf { it.size }}")
+
+            val arms =
+                listOf(
+                    ExperimentConfig("softBaseline", hardLeg = false),
+                    ExperimentConfig("softM3Cut", hardLeg = false, masteryScoreUpperBound = bound)
+                )
+            val summaries = arms.map { config -> solve(shape, config, det, pool, runes, sublimations) }
+            val (baseline, cut) = summaries
+            if (baseline.isOptimal && cut.isOptimal) {
+                assertThat(cut.rawObjective)
+                    .describedAs("softM3Cut: the redundant cut must not change the raw optimum")
+                    .isEqualTo(baseline.rawObjective)
+                assertThat(cut.scoredObjective)
+                    .describedAs("softM3Cut: the redundant cut must not change the scored optimum")
+                    .isEqualByComparingTo(baseline.scoredObjective)
+            }
+            val ratio = baseline.wallMs.toDouble() / cut.wallMs.coerceAtLeast(1)
+            println(
+                "MM_SOFT_CUT COMPARE bound=$bound baselineMs=${baseline.wallMs} cutMs=${cut.wallMs} " +
+                    "baselineOverCut=${"%.3f".format(java.util.Locale.ROOT, ratio)} " +
+                    "baselineDet=${baseline.deterministicTime} cutDet=${cut.deterministicTime} " +
+                    "baselineStatus=${baseline.status ?: "NA"} cutStatus=${cut.status ?: "NA"}"
+            )
+        }
+
     private suspend fun solve(
         shape: Shape,
         config: ExperimentConfig,
@@ -134,7 +194,8 @@ class MostMasteriesPerfExperimentTest {
                 linearizationLevelOverride = 1,
                 applyDominationOverride = true,
                 mmOvershootEncoding = config.overshootEncoding,
-                mmProductEncoding = config.productEncoding
+                mmProductEncoding = config.productEncoding,
+                mmMasteryScoreUpperBound = config.masteryScoreUpperBound
             )
         val t0 = System.nanoTime()
         var last: SolverResult<BuildCombination>? = null
@@ -148,7 +209,7 @@ class MostMasteriesPerfExperimentTest {
                 runes,
                 sublimations,
                 tuning,
-                hardConstraints = true,
+                hardConstraints = config.hardLeg,
                 onTermination = { termination.set(it) }
             ).collect { result ->
                 val elapsedMs = elapsedMs(t0)

--- a/docs/MOST_MASTERIES_PERF_PLAN.md
+++ b/docs/MOST_MASTERIES_PERF_PLAN.md
@@ -315,6 +315,43 @@ near-frontier conjunction **AP16/MP8/CC100/HP12000** (~112 s production). Six pr
 outcomes recorded here as they land. Harness: `MostMasteriesPerfExperimentTest`
 (`WAKFU_MM_PERF_AB=1`, hard leg, p1/l1, 1w+interleave, same-JVM sequential arms).
 
+### 7.1–7.3 Overshoot + product encodings — ALL MEASURED-DEAD (2026-07-12)
+
+Canonical A/B (`WAKFU_MM_PERF_AB=1`, det 600, hard leg, p1/l1, 1w+interleave, seed 1, same JVM,
+sequential arms). All f5 arms prove the same optimum (raw 107 054 998 / scored 10 705).
+
+| arm | f5 det (base 35.24) | f5 branches (base 13 912) | frontier det (base 25.73) | verdict |
+|---|---|---|---|---|
+| `overshootExact` (HARD_EXACT_SIMPLIFIED) | **35.2378 — identical** | **13 912 — identical** | **25.7273 — identical** | **NULL**: literal no-op — presolve already derives the redundant `max(·,0)` elimination under the hard `actual ≥ target`. Keep CURRENT (less code). |
+| `overshootHypograph` | 42.22 (+20 %) | 16 257, 46 conflicts | 34.62 (+35 %) | **MEASURED-NO** — the objective-induced encoding *removes* propagation the exact chain gives the solver. |
+| `productTracked` | 44.54 (+26 %) | 13 662 | 36.07 (+40 %) | **MEASURED-NO** — matches the precision-mode lesson (6ecd1258), here actively harmful. |
+| `productBinary` | 46.44 (+32 %) | 13 718 | 46.01 (**+79 %**) | **MEASURED-NO** — the max-damage binary-expansion win does NOT transfer to the MM product. |
+
+The P2b pattern repeats: the shipped "naive" encodings out-propagate every hand-tightened
+alternative. The seams stay in the codebase (CURRENT default, byte-identical) as the standing
+A/B harness; do not retry these three arms.
+
+### 7.4 Frontier shape is provably INFEASIBLE — reclassifies the slow tail (2026-07-12)
+
+Every arm *proves* AP16/MP8/CC100/HP12000 **INFEASIBLE in ~23-26 det** (~23 s wall at 1w). The
+earlier E3 conclusion "joint shape feasible (112.4 s)" misread the orchestrator output: E3's
+SUMMARY line printed finalSends/objective but **not the hard leg's termination status**, and a soft-
+fallback finalSend is indistinguishable from a hard-leg success in that line.
+
+E3 re-run (2026-07-12, production path, 120 s budget) confirms:
+
+- `reachable` (F5): finalSend 14.5 s, objective 10 705, **optimal=true** — hard leg, unchanged.
+- `static` (AP 99): 11.9 s, optimal=true — static-skip fallback, unchanged.
+- `joint`: single finalSend at **t=121.8 s, objective 6 533, optimal=false** — i.e. the hard leg
+  proves INFEASIBLE quickly, then the **soft fallback burns the full remaining budget by design**
+  (it is the pre-P2a penalized problem, whose dual wall P0.5 documented) and returns best-effort.
+
+**Reclassification of the slow tail:** there is no "feasible near-frontier 112 s hard solve".
+The remaining slow workload is the **soft leg** — both as fallback for unreachable conjunctions
+and for any user who runs without required targets. That re-aims the remaining pistes: the M3
+bound as a redundant dual cut (§7.7) attacks exactly that model; the per-item filter (§7.5)
+only helps the already-fast hard leg and gets deprioritized accordingly.
+
 ### 7.5 Per-item conditional-ceiling filter — dry-run says GO (measured 2026-07-12)
 
 `MostMasteriesConditionalCeilingAnalysisTest` (`WAKFU_MM_ITEM_CEILING=1`), frontier shape, production

--- a/docs/MOST_MASTERIES_PERF_PLAN.md
+++ b/docs/MOST_MASTERIES_PERF_PLAN.md
@@ -307,3 +307,45 @@ P1a + P1b alone plausibly take F5@245 from ~138 s to **~90-110 s to a proven-wit
 the penalty-product diagnosis. P3 is the order-of-magnitude ceiling but is gated, soundness-heavy,
 and may legitimately conclude "fires never" — sequence it last, after the cheap levers have moved
 the baseline.
+
+## 7. Encoding campaign (2026-07-12) — post-P2a follow-up
+
+Workload re-anchor: F5@245 is production-solved (~14 s); the driving shape is now the hard
+near-frontier conjunction **AP16/MP8/CC100/HP12000** (~112 s production). Six proposals; measured
+outcomes recorded here as they land. Harness: `MostMasteriesPerfExperimentTest`
+(`WAKFU_MM_PERF_AB=1`, hard leg, p1/l1, 1w+interleave, same-JVM sequential arms).
+
+### 7.5 Per-item conditional-ceiling filter — dry-run says GO (measured 2026-07-12)
+
+`MostMasteriesConditionalCeilingAnalysisTest` (`WAKFU_MM_ITEM_CEILING=1`), frontier shape, production
+domination pool (6 886 items after domination, 7 884 base):
+
+- **rejected 2 277 / 6 886 = 33.07 %** of the pool — every rejection via the **AP 16** target
+  (an item occupying its slot without enough AP leaves AP16 unreachable even with best-case
+  everything else). By slot: BOOTS 694, CHEST_PLATE 488, TWO_HANDED 458, ONE_HANDED 434, CAPE 88,
+  AMULET 79, rest <10 each.
+- MP8 / CC100 / HP12000 reject **zero** items each (relaxed ceiling too loose or genuinely
+  reachable with any single item fixed).
+- The screen's relaxations only ADD reach (rune competition, sub colours/conditions, joint skill
+  budgets, condition gating all ignored; conversions into a probed stat bail) — a rejection is a
+  sound "cannot be in any hard-feasible build".
+
+Next step (not yet coded): apply as a hard-leg-only pre-solve pool filter (or fixed-to-zero
+booleans), keyed on the same `U(stat | item) < target` certificate; add an optimum-equality lock
+vs the unfiltered model and re-run the frontier timing.
+
+### 7.6 Certifier FAST-harvest coordinate index — measured, byte-identical, modest (2026-07-12)
+
+`indexedFastHarvestApCoordinates`/`indexedFastHarvestCritCoordinates` +
+`WAKFU_MAX_DAMAGE_CERT_INDEXED_HARVEST=1` seam; locks: 5 000-case coordinate fuzz + full-ledger
+byte-identity (`MaxDamageCertifierHarvestIndexTest`) + real-shape 245 ledger equality (below).
+
+245 fire ledger, threads=1, incumbent=16 909 590, same JVM protocol as the C-series:
+
+- Ledger **byte-identical** (max 17 674 020, every cell equal; identical valid-coordinate counts —
+  the index visits exactly the reference's accepted triplets).
+- FAST tier Σ per-world: **12.9 s → 10.9 s (−16 %)**; ledger total **25.1 s → 22.8 s (−9 %)**.
+- Reading: consistent with the C8 frontier verdict — the fast tier is add-call-volume-bound; the
+  index removes only the rejected-cell *scanning*, which is ~16 % of the tier. Real, exact, cheap
+  to keep behind the seam; flipping the production default is a certifier change (bump
+  `CERTIFIER_VERSION` even though values are byte-identical, per the standing rule).

--- a/docs/MOST_MASTERIES_PERF_PLAN.md
+++ b/docs/MOST_MASTERIES_PERF_PLAN.md
@@ -386,3 +386,27 @@ byte-identity (`MaxDamageCertifierHarvestIndexTest`) + real-shape 245 ledger equ
   index removes only the rejected-cell *scanning*, which is ~16 % of the tier. Real, exact, cheap
   to keep behind the seam; flipping the production default is a certifier change (bump
   `CERTIFIER_VERSION` even though values are byte-identical, per the standing rule).
+
+### 7.7 M3 bound as a redundant dual cut on the SOFT model — MEASURED-NO, 2.1× WORSE (2026-07-12)
+
+Seam `SolverTuning.mmMasteryScoreUpperBound` (redundant `masteryScore ≤ U`); harness
+`WAKFU_MM_SOFT_CUT_AB=1` (F5@245, soft leg, U = 11 909 from the M3 prototype, det 600, 1w+interleave,
+same JVM):
+
+- softBaseline: OPTIMAL, det **51.49**, 14 257 branches, wall 132.8 s.
+- softM3Cut: OPTIMAL, det **107.42 (+109 %)**, 17 035 branches, 115 conflicts, wall 232.6 s —
+  same raw/scored optimum (equality lock passed).
+
+The externally-derived tight ceiling actively *hurts* the by-exhaustion proof — the extra
+constraint feeds the LP/propagation stack without pruning the exhaustion tree. Together with §4's
+"redundant upper bound is vacuous for primal pruning", the redundant-bound idea is now dead in BOTH
+directions. **Do not retry**; the seam stays as the standing harness.
+
+### 7.8 Campaign close (2026-07-12)
+
+All six pistes measured. 1-4 dead, 5 dry-run-GO-but-deprioritized (the hard leg is already fast),
+6 real-but-modest behind its seam. The soft leg remains the only slow workload (fallback +
+no-required-target requests) and every cheap structural lever against its dual wall is now
+exhausted — the remaining ideas (Lagrangian target-aware certificate, M3-v2 multi-dimensional DP)
+are heavy, soundness-critical builds whose prize is a best-effort path where proof matters least.
+Recommendation: stop here; revisit only if user-facing soft-leg latency becomes a real complaint.


### PR DESCRIPTION
## Summary
The most-masteries perf campaign (docs/MOST_MASTERIES_PERF_PLAN.md §7) — all six proposals measured, production behavior byte-identical (every seam defaults to CURRENT/off):

- **Measured-dead** (recorded, do not retry): simplified/hypograph overshoot encodings, tracked-domain + binary-expansion MM product, M3 bound as redundant dual cut (2.1× worse).
- **Key finding:** the frontier shape AP16/MP8/CC100/HP12000 is provably INFEASIBLE — the earlier 'feasible 112.4s' reading was the soft fallback burning its budget. Slow workload reclassified to the soft leg.
- **Kept:** `SolveOutcome` now carries bestObjectiveBound/detTime/branches/conflicts; measurement seams (`MmOvershootEncoding`, `MmProductEncoding`, `mmMasteryScoreUpperBound`); certifier FAST-harvest coordinate index behind `WAKFU_MAX_DAMAGE_CERT_INDEXED_HARVEST=1` (byte-identical, −16% fast tier serial, default OFF — no CERTIFIER_VERSION bump needed while off); per-item ceiling dry-run screen (33% pool rejectable on the frontier shape, deprioritized).
- New locks: 5k-case coordinate fuzz + full-ledger byte-identity for the harvest index; optimum-equality locks in every A/B harness.

## Verification
- `:autobuilder:test` green (includes the new locks); ktlint clean.
- Full measurement log in docs/MOST_MASTERIES_PERF_PLAN.md §7.1–7.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)