### PR TITLE
fix: What's new shows every release since the last one seen

### DIFF
--- a/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/Main.kt
@@ -204,10 +204,13 @@ fun App(model: BuildSearchModel) {
                             System.getenv("WAKFU_COMPOSE_SCREENSHOT_WHATSNEW") != null
                     }
                 var showWhatsNew by remember { mutableStateOf(forceWhatsNew || (!screenshotMode && WhatsNew.shouldShow())) }
-                val notes = remember { WhatsNew.releaseNotes }
-                if (showWhatsNew && model.isReady && notes != null) {
+                // Every unseen release (a version jump shows them all); the forced screenshot knob
+                // falls back to the running version's notes since nothing is "unseen" there.
+                val releases =
+                    remember { WhatsNew.unseenReleaseNotes().ifEmpty { listOfNotNull(WhatsNew.releaseNotes) } }
+                if (showWhatsNew && model.isReady && releases.isNotEmpty()) {
                     WhatsNewDialog(
-                        notes = notes,
+                        releases = releases,
                         onDismiss = {
                             WhatsNew.markSeen()
                             showWhatsNew = false

--- a/gui-compose/src/main/kotlin/me/chosante/ui/components/WhatsNewDialog.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/components/WhatsNewDialog.kt
@@ -25,17 +25,20 @@ import me.chosante.ui.theme.WTypography
 
 /**
  * Once-per-version release-notes pop-in, shown over the shell on the first launch after an update
- * (see [me.chosante.ui.state.WhatsNew] for the gating). Bullets come from the release-please
- * CHANGELOG, so they are English-only; section titles are the few known release-please headings
- * and get translated.
+ * (see [me.chosante.ui.state.WhatsNew] for the gating). When the user skipped releases (e.g. a
+ * 1.7 → 1.10 jump), every unseen release is stacked newest-first with its own version header.
+ * Bullets come from the release-please CHANGELOG, so they are English-only; section titles are the
+ * few known release-please headings and get translated.
  */
 @Composable
 fun WhatsNewDialog(
-    notes: ReleaseNotes,
+    releases: List<ReleaseNotes>,
     onDismiss: () -> Unit,
 ) {
+    val title =
+        if (releases.size == 1) "${tr(Tr.WHATS_NEW_TITLE)} ${releases.single().version}" else tr(Tr.WHATS_NEW_TITLE)
     Scrim(onDismiss = onDismiss) {
-        ModalCard(title = "${tr(Tr.WHATS_NEW_TITLE)} ${notes.version}") {
+        ModalCard(title = title) {
             Column(
                 modifier =
                     Modifier
@@ -43,25 +46,36 @@ fun WhatsNewDialog(
                         .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(7.dp)
             ) {
-                notes.sections.forEachIndexed { sectionIndex, section ->
-                    if (sectionIndex > 0) {
-                        Spacer(modifier = Modifier.height(4.dp))
+                releases.forEachIndexed { releaseIndex, notes ->
+                    if (releases.size > 1) {
+                        if (releaseIndex > 0) {
+                            Spacer(modifier = Modifier.height(10.dp))
+                        }
+                        Text(
+                            text = notes.version,
+                            style = WTypography.titleMedium.copy(color = WColor.accent, fontWeight = FontWeight.Bold)
+                        )
                     }
-                    Text(
-                        text = sectionTitle(section.title),
-                        style = WTypography.labelMedium.copy(color = WColor.muted, fontWeight = FontWeight.SemiBold)
-                    )
-                    section.items.forEach { item ->
-                        Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                            Text(
-                                text = "•",
-                                style = WTypography.bodyMedium.copy(color = WColor.accent)
-                            )
-                            Text(
-                                text = item,
-                                style = WTypography.bodyMedium.copy(color = WColor.text, lineHeight = 19.sp),
-                                modifier = Modifier.padding(top = 1.dp)
-                            )
+                    notes.sections.forEachIndexed { sectionIndex, section ->
+                        if (sectionIndex > 0) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                        Text(
+                            text = sectionTitle(section.title),
+                            style = WTypography.labelMedium.copy(color = WColor.muted, fontWeight = FontWeight.SemiBold)
+                        )
+                        section.items.forEach { item ->
+                            Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+                                Text(
+                                    text = "•",
+                                    style = WTypography.bodyMedium.copy(color = WColor.accent)
+                                )
+                                Text(
+                                    text = item,
+                                    style = WTypography.bodyMedium.copy(color = WColor.text, lineHeight = 19.sp),
+                                    modifier = Modifier.padding(top = 1.dp)
+                                )
+                            }
                         }
                     }
                 }

--- a/gui-compose/src/main/kotlin/me/chosante/ui/state/WhatsNew.kt
+++ b/gui-compose/src/main/kotlin/me/chosante/ui/state/WhatsNew.kt
@@ -24,6 +24,13 @@ data class ReleaseNotesSection(
 object WhatsNew {
     private const val KEY = "lastSeenChangelogVersion"
 
+    /**
+     * Ceiling on the number of releases stacked into one dialog. Also the safety net when the
+     * last-seen version has no heading in the embedded changelog (corrupted pref, truncated file):
+     * rather than greeting the user with the full history, the dialog shows at most this many.
+     */
+    internal const val MAX_VERSIONS_SHOWN = 10
+
     private val prefs: Preferences? = runCatching { Preferences.userRoot().node("me/chosante/wakfu-autobuilder") }.getOrNull()
 
     /** App version baked in by the build, or null when the resource is missing (unit tests, IDE). */
@@ -38,9 +45,22 @@ object WhatsNew {
     }
 
     /**
-     * True when the running version has unseen release notes. A machine with no recorded version
-     * is a fresh install, not an update — it records the baseline silently instead of greeting a
-     * new user with a changelog.
+     * Every release the user hasn't seen yet, newest first — so a 1.7 → 1.10 jumper reads the 1.8
+     * and 1.9 notes too, not just the running version's. Empty when up to date, on a fresh install,
+     * or when the changelog is missing.
+     */
+    fun unseenReleaseNotes(): List<ReleaseNotes> {
+        val version = appVersion ?: return emptyList()
+        val lastSeen = runCatching { prefs?.get(KEY, null) }.getOrNull() ?: return emptyList()
+        if (lastSeen == version) return emptyList()
+        val changelog = runCatching { resourceText("/CHANGELOG.md") }.getOrNull() ?: return emptyList()
+        return parseReleaseNotesSince(changelog, currentVersion = version, lastSeenVersion = lastSeen, maxVersions = MAX_VERSIONS_SHOWN)
+    }
+
+    /**
+     * True when there are unseen release notes. A machine with no recorded version is a fresh
+     * install, not an update — it records the baseline silently instead of greeting a new user
+     * with a changelog.
      */
     fun shouldShow(): Boolean {
         val version = appVersion ?: return false
@@ -49,7 +69,7 @@ object WhatsNew {
             markSeen()
             return false
         }
-        return lastSeen != version && releaseNotes != null
+        return lastSeen != version && unseenReleaseNotes().isNotEmpty()
     }
 
     fun markSeen() {
@@ -81,7 +101,49 @@ internal fun parseReleaseNotes(
     val start = lines.indexOfFirst { releaseHeading.find(it)?.groupValues?.get(1) == version }
     if (start == -1) return null
     val body = lines.drop(start + 1).takeWhile { !it.startsWith("## ") }
+    val sections = parseSections(body)
+    return if (sections.isEmpty()) null else ReleaseNotes(version, sections)
+}
 
+/**
+ * Every release section from [currentVersion] down to — and excluding — [lastSeenVersion], newest
+ * first, capped at [maxVersions]. Releases without bullets are skipped. When [currentVersion] has
+ * no heading (a dev build newer than the embedded changelog), the walk starts at the newest release
+ * instead; when [lastSeenVersion] has no heading, [maxVersions] is the only stop.
+ */
+internal fun parseReleaseNotesSince(
+    changelog: String,
+    currentVersion: String,
+    lastSeenVersion: String,
+    maxVersions: Int = WhatsNew.MAX_VERSIONS_SHOWN,
+): List<ReleaseNotes> {
+    val lines = changelog.lines()
+    val headings =
+        lines
+            .withIndex()
+            .mapNotNull { (index, line) ->
+                releaseHeading
+                    .find(line)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.let { index to it }
+            }
+    if (headings.isEmpty()) return emptyList()
+
+    val startAt = headings.indexOfFirst { (_, version) -> version == currentVersion }.coerceAtLeast(0)
+    val notes = mutableListOf<ReleaseNotes>()
+    for (headingIndex in startAt until headings.size) {
+        val (lineIndex, version) = headings[headingIndex]
+        if (version == lastSeenVersion || notes.size >= maxVersions) break
+        val bodyEnd = headings.getOrNull(headingIndex + 1)?.first ?: lines.size
+        val sections = parseSections(lines.subList(lineIndex + 1, bodyEnd))
+        if (sections.isNotEmpty()) notes += ReleaseNotes(version, sections)
+    }
+    return notes
+}
+
+/** The `### title` / `* bullet` groups of one release's body lines (see [parseReleaseNotes]). */
+private fun parseSections(body: List<String>): List<ReleaseNotesSection> {
     val sections = mutableListOf<ReleaseNotesSection>()
     var title = ""
     var items = mutableListOf<String>()
@@ -107,7 +169,7 @@ internal fun parseReleaseNotes(
         }
     }
     flush()
-    return if (sections.isEmpty()) null else ReleaseNotes(version, sections)
+    return sections
 }
 
 /** `**gui:** stuff ([#140](url)) ([abc1234](url))` → `gui: stuff (#140)`. */

--- a/gui-compose/src/test/kotlin/me/chosante/ui/state/WhatsNewParserTest.kt
+++ b/gui-compose/src/test/kotlin/me/chosante/ui/state/WhatsNewParserTest.kt
@@ -60,6 +60,93 @@ class WhatsNewParserTest {
     }
 
     @Test
+    fun `a version jump collects every release down to the last seen one, exclusive`() {
+        val jump =
+            """
+            # Changelog
+
+            ## [1.10.0](https://example.com) (2026-07-12)
+
+            ### Bug Fixes
+
+            * newest fix
+
+            ## [1.9.1](https://example.com) (2026-07-11)
+
+            ### Features
+
+            * middle feature
+
+            ## [1.9.0](https://example.com) (2026-07-10)
+
+            ### Features
+
+            * older feature
+
+            ## [1.7.0](https://example.com) (2026-06-01)
+
+            ### Features
+
+            * already seen
+            """.trimIndent()
+
+        val notes = parseReleaseNotesSince(jump, currentVersion = "1.10.0", lastSeenVersion = "1.7.0")
+
+        assertThat(notes.map { it.version })
+            .describedAs("newest first, stops BEFORE the last seen version")
+            .containsExactly("1.10.0", "1.9.1", "1.9.0")
+        assertThat(
+            notes
+                .first()
+                .sections
+                .single()
+                .items
+        ).containsExactly("newest fix")
+    }
+
+    @Test
+    fun `an up-to-date user gets nothing and a bullet-less release is skipped`() {
+        val withEmptyRelease =
+            """
+            ## [1.3.0](https://example.com) (2026-08-01)
+
+            ### Features
+
+            * new stuff
+
+            ## [1.2.5](https://example.com) (2026-07-20)
+
+            ## [1.2.0](https://example.com) (2026-07-01)
+
+            ### Features
+
+            * old stuff
+            """.trimIndent()
+
+        assertThat(parseReleaseNotesSince(withEmptyRelease, "1.3.0", lastSeenVersion = "1.3.0")).isEmpty()
+        assertThat(parseReleaseNotesSince(withEmptyRelease, "1.3.0", lastSeenVersion = "1.2.0").map { it.version })
+            .describedAs("the bullet-less 1.2.5 is skipped, 1.2.0 (seen) excluded")
+            .containsExactly("1.3.0")
+    }
+
+    @Test
+    fun `an unknown last-seen version is capped instead of dumping the full history`() {
+        val many =
+            (20 downTo 1).joinToString("\n\n") { minor ->
+                "## [1.$minor.0](https://example.com) (2026-01-01)\n\n### Features\n\n* entry $minor"
+            }
+
+        val notes = parseReleaseNotesSince(many, currentVersion = "1.20.0", lastSeenVersion = "0.0.1", maxVersions = 3)
+        assertThat(notes.map { it.version }).containsExactly("1.20.0", "1.19.0", "1.18.0")
+    }
+
+    @Test
+    fun `a dev build newer than the changelog starts at the newest release`() {
+        val notes = parseReleaseNotesSince(changelog, currentVersion = "1.3.0-dev", lastSeenVersion = "1.1.0")
+        assertThat(notes.map { it.version }).containsExactly("1.2.0")
+    }
+
+    @Test
     fun `returns null when the section has no bullets`() {
         val empty =
             """


### PR DESCRIPTION
## Summary
A player updating across several versions (e.g. 1.7 → 1.10.0) only saw the newest version's notes — everything shipped in between was silently skipped (beta-tester scenario from today's Windows catch-up).

- `WhatsNew.unseenReleaseNotes()` parses **every** changelog section newer than `lastSeenChangelogVersion` (newest first, capped at 10 as a safety net for a corrupted/unknown recorded version); bullet-less releases are skipped.
- The dialog stacks the releases, each under its own accent version header; single-release updates keep the exact previous look (version in the title).
- Fresh installs still record the baseline silently; the screenshot knob falls back to the running version's notes.

## Verification
- `WhatsNewParserTest`: version-jump collection (exclusive stop at last seen), up-to-date → empty, bullet-less release skipped, unknown last-seen capped, dev-build-newer-than-changelog fallback.
- `:gui-compose:test` (incl. E2E) + ktlint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)